### PR TITLE
Changing the way Async tasks are run Synchronously

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -103,14 +103,14 @@ namespace Neo4j.Driver.Internal.Connector
                 catch (Exception ex)
                 {
                     _config.Logger.Error("Unable to unpack message from server, connection has been terminated.", ex);
-                    Stop().Wait();
+                    Task.Run(() => Stop()).Wait();
                     throw;
                 }
                 if (responseHandler.HasError)
                 {
                     if (responseHandler.Error.Code.ToLowerInvariant().Contains("clienterror.request"))
                     {
-                        Stop().Wait();
+                        Task.Run(() => Stop()).Wait();
                         throw responseHandler.Error;
                     }
                 }
@@ -164,7 +164,7 @@ namespace Neo4j.Driver.Internal.Connector
             if (!isDisposing)
                 return;
 
-            Stop().Wait();
+            Task.Run(() => Stop()).Wait();
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Result;
@@ -38,8 +39,7 @@ namespace Neo4j.Driver.Internal.Connector
             _messageHandler = messageResponseHandler ?? new MessageResponseHandler(logger);
 
             _client = socketClient;
-            var t = _client.Start();
-            t.Wait();
+            Task.Run(() => _client.Start()).Wait();
 
             // add init requestMessage by default
             Enqueue(new InitMessage("neo4j-dotnet/1.0.0"));
@@ -109,8 +109,7 @@ namespace Neo4j.Driver.Internal.Connector
             if (!isDisposing)
                 return;
 
-            var t = _client.Stop();
-            t.Wait();
+            Task.Run(() => _client.Stop()).Wait();
         }
 
         private void ClearQueue()


### PR DESCRIPTION
Using `Task.Run` instead of just relying on `Wait` - this is required
for MVC style apps.

There is no way I am aware of to test that you call `Task.Run` over relying on the default `Wait` to work, I found this whilst writing the canonical example (movies website) for Michael - without this change the code won't work in MVC apps.
