### PR TITLE
Adding Error extension method to the ILogger interface

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Neo4j.Driver.IntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Neo4j.Driver.Tck.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Neo4j.Driver.Tck.Tests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Neo4j.Driver.Tck.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/CypherRecordParser.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/CypherRecordParser.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Neo4j.Driver.Extensions;
 using Neo4j.Driver.Internal;
+using System.Globalization;
 
 namespace Neo4j.Driver.Tck.Tests.TCK
 {
@@ -79,7 +80,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
             match = _floatPattern.Match(input);
             if (match.Success)
             {
-                return Convert.ToDouble(match.Groups[1].Value);
+                return Convert.ToDouble(match.Groups[1].Value, CultureInfo.InvariantCulture);
             }
             throw new NotSupportedException($"Failed to parse to {nameof(Null)}/{nameof(Boolean)}/{nameof(String)}/{nameof(Integer)}/{nameof(Float)} from input: {input}");
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
@@ -22,6 +22,7 @@ using FluentAssertions;
 using Neo4j.Driver.IntegrationTests;
 using TechTalk.SpecFlow;
 using Xunit;
+using System.Globalization;
 
 namespace Neo4j.Driver.Tck.Tests.TCK
 {
@@ -45,7 +46,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
                 case "Integer":
                     return Convert.ToInt64(value);
                 case "Float":
-                    return Convert.ToDouble(value);
+                    return Convert.ToDouble(value, CultureInfo.InvariantCulture);
                 case "String":
                     return value;
                 default:

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Neo4j.Driver.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -1,23 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{5642BD95-BF3C-4DFE-B5E5-1456EC9119BB}</ProjectGuid>
+    <ProjectGuid>{A8B4B2FB-6E40-440A-BD2B-7EF93F2934B6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Neo4j.Driver.Tests</RootNamespace>
     <AssemblyName>Neo4j.Driver.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -77,37 +70,29 @@
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-  </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise />
-  </Choose>
+  </ItemGroup>  
   <ItemGroup>
+    <Compile Include="Connector\ChunkedInputTests.cs" />
     <Compile Include="Connector\ChunkedOutputTest.cs" />
     <Compile Include="Connector\MessageResponseHandlerTests.cs" />
+    <Compile Include="Connector\SocketClientTests.cs" />
+    <Compile Include="Connector\SocketConnectionTests.cs" />
     <Compile Include="DriverTests.cs" />
     <Compile Include="EntityTests.cs" />
     <Compile Include="Messaging\MessageTests.cs" />
-    <Compile Include="Result\ResultBuilderTests.cs" />
-    <Compile Include="SessionPoolTests.cs" />
-    <Compile Include="SessionTests.cs" />
+    <Compile Include="PackStream\PackerTests.cs" />
+    <Compile Include="PackStream\PackStreamMessageFormatV1Tests.cs" />
     <Compile Include="PackStream\PackStreamTests.cs" />
     <Compile Include="PackStream\UnpackerTests.cs" />
-    <Compile Include="PackStream\PackerTests.cs" />
-    <Compile Include="Result\PeekingEnumeratorTests.cs" />
-    <Compile Include="Result\StatementResultTests.cs" />
-    <Compile Include="Connector\ChunkedInputTests.cs" />
-    <Compile Include="PackStream\PackStreamMessageFormatV1Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Result\PeekingEnumeratorTests.cs" />
+    <Compile Include="Result\ResultBuilderTests.cs" />
+    <Compile Include="Result\StatementResultTests.cs" />
+    <Compile Include="SessionPoolTests.cs" />
+    <Compile Include="SessionTests.cs" />
     <Compile Include="StatementRunnerTests.cs" />
     <Compile Include="TestUtil\ExtensionsTests.cs" />
     <Compile Include="TestUtil\SocketClientTestHarness.cs" />
-    <Compile Include="Connector\SocketClientTests.cs" />
-    <Compile Include="Connector\SocketConnectionTests.cs" />
     <Compile Include="TestUtil\TestHelper.cs" />
     <Compile Include="TransactionTests.cs" />
     <Compile Include="ValueExtensionsTests.cs" />
@@ -121,26 +106,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
@@ -49,7 +49,6 @@ namespace Neo4j.Driver.Tests
                 object value = null;
                 var ex = Record.Exception(() => value.As<bool>());
                 ex.Should().BeOfType<InvalidCastException>();
-                ex.Message.Should().Be("Unable to cast `null` to `System.Boolean`.");
             }
 
             [Theory]
@@ -180,7 +179,6 @@ namespace Neo4j.Driver.Tests
                 object value = 10;
                 var ex = Record.Exception(() => value.As<List<int>>());
                 ex.Should().BeOfType<InvalidCastException>();
-                ex.Message.Should().Be("Unable to cast object of type `System.Int32` to type `System.Collections.Generic.List`1[System.Int32]`.");
             }
             [Fact]
             public void ShouldThrowExceptionWhenCastFromListToInt()
@@ -188,7 +186,6 @@ namespace Neo4j.Driver.Tests
                 object value = new List<object> { "string", 2, true, "lala" };
                 var ex = Record.Exception(() => value.As<int>());
                 ex.Should().BeOfType<InvalidCastException>();
-                ex.Message.Should().Be("Unable to cast object of type 'System.Collections.Generic.List`1[System.Object]' to type 'System.IConvertible'.");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Logger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Logger.cs
@@ -64,4 +64,21 @@ namespace Neo4j.Driver
         /// </summary>
         LogLevel Level { get; set; }
     }
+
+    /// <summary>
+    /// Extension methods for the <see cref="ILogger"/> interface.
+    /// </summary>
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Log a message at <see cref="LogLevel.Error"/> level.
+        /// </summary>
+        /// <param name="logger">An <see cref="ILogger"/> instance or null.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="restOfMessage">Any restOfMessage parts of the message.</param>
+        public static void Error(this ILogger logger, string message, params object[] restOfMessage)
+        {
+            logger?.Error(message, (Exception)null, restOfMessage);
+        }
+    }
 }


### PR DESCRIPTION
Adding Error extension method to the ILogger interface to make it easier to create error log entries when there is no exception instance.
