### PR TITLE
Xamarin and Mono support for integration tests

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/IntegrationTestFixture.cs
@@ -23,7 +23,7 @@ namespace Neo4j.Driver.IntegrationTests
 {
     public class IntegrationTestFixture : IDisposable
     {
-        private readonly INeo4jInstaller _installer = new WindowsNeo4jInstaller();
+        private readonly INeo4jInstaller _installer = Neo4jInstallerFactory.Create();
         public int Port { get; private set; }
         public string Neo4jHome { get; private set; }
         public IntegrationTestFixture()

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jInstallerFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jInstallerFactory.cs
@@ -14,7 +14,7 @@
         /// </returns>
         public static INeo4jInstaller Create()
         {
-#if __MonoCs__
+#if __MonoCS__
             return new UnixProcessBasedNeo4jInstaller();
 #else
             return new WindowsNeo4jInstaller();

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jInstallerFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jInstallerFactory.cs
@@ -1,0 +1,24 @@
+﻿namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    /// <summary>
+    ///     Factory for creating <see cref="INeo4jInstaller"/> instances
+    ///     based on which OS platform the tests are run on.
+    /// </summary>
+    public static class Neo4jInstallerFactory
+    {
+        /// <summary>
+        ///     Returns an <see cref="INeo4jInstaller"/> instance.
+        /// </summary>
+        /// <returns>
+        ///     Returns an <see cref="INeo4jInstaller"/> instance.
+        /// </returns>
+        public static INeo4jInstaller Create()
+        {
+#if __MonoCs__
+            return new UnixProcessBasedNeo4jInstaller();
+#else
+            return new WindowsNeo4jInstaller();
+#endif
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jServerFilesDownloader.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jServerFilesDownloader.cs
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.IntegrationTests.Internals
     {
       EnsureDirectoriesExist();
 
-      var downloadFileInfo = new FileInfo($"../target/{Version}.zip");
+      var downloadFileInfo = new FileInfo(string.Format("../target/{0}.{1}", Version, GetPlatformFileExtension(platform)));
       if (downloadFileInfo.Directory != null)
       {
         if (!downloadFileInfo.Directory.Exists)

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jServerFilesDownloader.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Neo4jServerFilesDownloader.cs
@@ -21,23 +21,23 @@ using System.Net;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
-  internal enum Neo4jServerEdition
-  {
-    Community,
-    Enterprise
-  }
+    internal enum Neo4jServerEdition
+    {
+        Community,
+        Enterprise
+    }
 
-  internal enum Neo4jServerPlatform
-  {
-    Windows,
-    Unix
-  }
+    internal enum Neo4jServerPlatform
+    {
+        Windows,
+        Unix
+    }
 
-  /// <summary>
+    /// <summary>
     ///     Helper class for downloading Neo4j server files.
-  /// </summary>
-  internal static class Neo4jServerFilesDownloadHelper
-  {
+    /// </summary>
+    internal static class Neo4jServerFilesDownloadHelper
+    {
         /// <summary>
         ///     {0}: Edition
         ///     {1}: Version
@@ -46,85 +46,85 @@ namespace Neo4j.Driver.IntegrationTests.Internals
         /// </summary>
         private static readonly string PackageUrlFormat = "http://alpha.neohq.net/dist/neo4j-{0}-{1}-{2}.{3}";
 
-    private static DirectoryInfo Neo4jDir => new DirectoryInfo("../target/neo4j");
+        private static DirectoryInfo Neo4jDir => new DirectoryInfo("../target/neo4j");
 
-    private static string Version => Environment.GetEnvironmentVariable("version") ?? "3.0.0-NIGHTLY";
+        private static string Version => Environment.GetEnvironmentVariable("version") ?? "3.0.0-NIGHTLY";
 
 
-    /// <summary>
+        /// <summary>
         ///     Downloads the Neo4j server as a compressed file and saves it to the HDD
-    /// </summary>
-    /// <param name="edition">The edition to download</param>
-    /// <param name="platform">The platform to download</param>
-    /// <returns></returns>
+        /// </summary>
+        /// <param name="edition">The edition to download</param>
+        /// <param name="platform">The platform to download</param>
+        /// <returns></returns>
         public static DirectoryInfo DownloadNeo4j(Neo4jServerEdition edition, Neo4jServerPlatform platform,
             INeo4jServerFileExtractor fileExtractor)
-    {
-      EnsureDirectoriesExist();
+        {
+            EnsureDirectoriesExist();
 
             var platformFileExtension = GetPlatformFileExtension(platform);
             var downloadFileInfo = new FileInfo($"../target/{Version}.{platformFileExtension}");
-      if (downloadFileInfo.Directory != null)
-      {
-        if (!downloadFileInfo.Directory.Exists)
-          downloadFileInfo.Directory.Create();
-      }
+            if (downloadFileInfo.Directory != null)
+            {
+                if (!downloadFileInfo.Directory.Exists)
+                    downloadFileInfo.Directory.Create();
+            }
 
             var packageUrl = string.Format(
-        PackageUrlFormat, 
-        edition.ToString().ToLower(), 
-        Version, 
-        platform.ToString().ToLower(),         
+                PackageUrlFormat,
+                edition.ToString().ToLower(),
+                Version,
+                platform.ToString().ToLower(),
                 platformFileExtension
-                );
+            );
 
             var downloadedNew = false;
-      long expectedSize;
-      using (var client = new WebClient())
-      {
-        client.OpenRead(packageUrl);
-        expectedSize = Convert.ToInt64(client.ResponseHeaders["Content-Length"]);
-        if (!downloadFileInfo.Exists || downloadFileInfo.Length != expectedSize)
-        {
-          client.DownloadProgressChanged += (s, e) => { Console.Write("."); };
-          client.DownloadFile(packageUrl, downloadFileInfo.FullName);
-          downloadedNew = true;
-        }
-      }
+            long expectedSize;
+            using (var client = new WebClient())
+            {
+                client.OpenRead(packageUrl);
+                expectedSize = Convert.ToInt64(client.ResponseHeaders["Content-Length"]);
+                if (!downloadFileInfo.Exists || downloadFileInfo.Length != expectedSize)
+                {
+                    client.DownloadProgressChanged += (s, e) => { Console.Write("."); };
+                    client.DownloadFile(packageUrl, downloadFileInfo.FullName);
+                    downloadedNew = true;
+                }
+            }
 
-      downloadFileInfo.Refresh();
-      if (!downloadFileInfo.Exists)
-        throw new IOException($"Unable to download the server from {packageUrl}");
-      if (downloadFileInfo.Length != expectedSize)
+            downloadFileInfo.Refresh();
+            if (!downloadFileInfo.Exists)
+                throw new IOException($"Unable to download the server from {packageUrl}");
+            if (downloadFileInfo.Length != expectedSize)
                 throw new IOException(
                     $"File at {packageUrl} was downloaded, but it's size {expectedSize.BytesToMegabytes()}Mb doesn't match the size expected {expectedSize.BytesToMegabytes()}Mb");
 
-      Neo4jDir.Refresh();
+            Neo4jDir.Refresh();
 
             var extractedFolder = fileExtractor.ExtractFile(downloadFileInfo.FullName, Neo4jDir.FullName, downloadedNew);
 
-      return new DirectoryInfo(Path.Combine(Neo4jDir.FullName, extractedFolder));
+            return new DirectoryInfo(Path.Combine(Neo4jDir.FullName, extractedFolder));
+        }
+
+        private static object GetPlatformFileExtension(Neo4jServerPlatform platform)
+        {
+            switch (platform)
+            {
+                case Neo4jServerPlatform.Windows:
+                    return "zip";
+
+                case Neo4jServerPlatform.Unix:
+                    return "tar.gz";
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private static void EnsureDirectoriesExist()
+        {
+            if (!Neo4jDir.Exists)
+                Neo4jDir.Create();
+        }
     }
-
-    private static object GetPlatformFileExtension(Neo4jServerPlatform platform)
-    {
-      switch (platform)
-      {
-        case Neo4jServerPlatform.Windows:
-          return "zip";
-
-        case Neo4jServerPlatform.Unix:
-          return "tar.gz";
-
-        default:
-          throw new NotImplementedException();
-      }
-    }
-
-    private static void EnsureDirectoriesExist()
-    {
-      if (!Neo4jDir.Exists)
-        Neo4jDir.Create();
-    }    
-  }
 }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/TgzNeo4jServerFileExtractor.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/TgzNeo4jServerFileExtractor.cs
@@ -1,81 +1,83 @@
-﻿using System;
-using System.Linq;
-using Lucene.Net.Support;
-using System.IO;
-using ICSharpCode.SharpZipLib.GZip;
+﻿using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
+using System;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
-  internal class TgzNeo4jServerFileExtractor : INeo4jServerFileExtractor
-  {
-    public string ExtractFile(string fileToExtractPath, string targetFolder, bool fileWasNewlyDownloaded)
+    /// <summary>
+    ///     Tgz (tar.gz) implementation of the <see cref="INeo4jServerFileExtractor"/>.
+    /// </summary>
+    internal class TgzNeo4jServerFileExtractor : INeo4jServerFileExtractor
     {
-      var destFolderName = GetDestFolderName(fileToExtractPath);
-      var destinationFolderPath = Path.Combine(targetFolder, destFolderName);
-
-      if (Directory.Exists(destinationFolderPath))
-      {
-        if (fileWasNewlyDownloaded)
+        public string ExtractFile(string fileToExtractPath, string targetFolder, bool fileWasNewlyDownloaded)
         {
-          var extractedDir = new DirectoryInfo(destinationFolderPath);
-          extractedDir.Delete(true);
-          ExtractZip(fileToExtractPath, targetFolder);
-        }
-      }
-      else
-      {
-        ExtractZip(fileToExtractPath, targetFolder);
-      }
+            var destFolderName = GetDestFolderName(fileToExtractPath);
+            var destinationFolderPath = Path.Combine(targetFolder, destFolderName);
 
-      FixPermissions(Path.Combine(targetFolder, destFolderName, "bin/neo4j"));
+            if (Directory.Exists(destinationFolderPath))
+            {
+                if (fileWasNewlyDownloaded)
+                {
+                    var extractedDir = new DirectoryInfo(destinationFolderPath);
+                    extractedDir.Delete(true);
+                    ExtractZip(fileToExtractPath, targetFolder);
+                }
+            }
+            else
+            {
+                ExtractZip(fileToExtractPath, targetFolder);
+            }
 
-      return destFolderName;
-    }
+            FixPermissions(Path.Combine(targetFolder, destFolderName, "bin/neo4j"));
 
-    private static string GetDestFolderName(string filename)
-    {
-      using (Stream inStream = File.OpenRead(filename))
-      using (Stream gzipStream = new GZipInputStream(inStream))
-      using (TarInputStream tarIn = new TarInputStream(gzipStream))
-      {
-        TarEntry tarEntry;
-        while ((tarEntry = tarIn.GetNextEntry()) != null) 
-        {
-          if (tarEntry.IsDirectory && tarEntry.Name.Count(f => f == '/') == 1) 
-          {
-            return tarEntry.Name.Substring(0, tarEntry.Name.Length - 1);
-          }
+            return destFolderName;
         }
 
-        throw new InvalidOperationException("Root folder in tar not found");
-      }
+        private static string GetDestFolderName(string filename)
+        {
+            using (Stream inStream = File.OpenRead(filename))
+            using (Stream gzipStream = new GZipInputStream(inStream))
+            using (TarInputStream tarIn = new TarInputStream(gzipStream))
+            {
+                TarEntry tarEntry;
+                while ((tarEntry = tarIn.GetNextEntry()) != null)
+                {
+                    if (tarEntry.IsDirectory && tarEntry.Name.Count(f => f == '/') == 1)
+                    {
+                        return tarEntry.Name.Substring(0, tarEntry.Name.Length - 1);
+                    }
+                }
+
+                throw new InvalidOperationException("Root folder in tar not found");
+            }
+        }
+
+        private static void ExtractZip(string filename, string destinationFolder)
+        {
+            using (Stream inStream = File.OpenRead(filename))
+            using (Stream gzipStream = new GZipInputStream(inStream))
+            using (TarArchive tarArchive = TarArchive.CreateInputTarArchive(gzipStream))
+            {
+                tarArchive.ExtractContents(destinationFolder);
+            }
+        }
+
+        private static void FixPermissions(string filename)
+        {
+            File.AppendAllLines("log.txt", new[] { filename });
+
+            ProcessStartInfo processInfo = new ProcessStartInfo();
+            processInfo.FileName = "chmod";
+            processInfo.Arguments = "+x " + filename;
+
+            Process process = Process.Start(processInfo);
+            process.WaitForExit();
+
+            File.AppendAllLines("log.txt", new[] { "chmod done!" });
+        }
     }
-
-    private static void ExtractZip(string filename, string destinationFolder)
-    {
-      using (Stream inStream = File.OpenRead(filename))
-      using (Stream gzipStream = new GZipInputStream(inStream))
-      using (TarArchive tarArchive = TarArchive.CreateInputTarArchive(gzipStream))
-      {
-        tarArchive.ExtractContents(destinationFolder);
-      }
-    }
-
-    private static void FixPermissions(string filename)
-    {
-      File.AppendAllLines("log.txt", new [] { filename });
-      
-      ProcessStartInfo processInfo = new ProcessStartInfo();
-      processInfo.FileName = "chmod";
-      processInfo.Arguments = "+x " + filename;
-
-      Process process = Process.Start(processInfo);
-      process.WaitForExit();
-
-      File.AppendAllLines("log.txt", new [] { "chmod done!" });
-    }
-  }
 }
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/TgzNeo4jServerFileExtractor.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/TgzNeo4jServerFileExtractor.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using Lucene.Net.Support;
+using System.IO;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
+using System.Diagnostics;
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+  internal class TgzNeo4jServerFileExtractor : INeo4jServerFileExtractor
+  {
+    public string ExtractFile(string fileToExtractPath, string targetFolder, bool fileWasNewlyDownloaded)
+    {
+      var destFolderName = GetDestFolderName(fileToExtractPath);
+      var destinationFolderPath = Path.Combine(targetFolder, destFolderName);
+
+      if (Directory.Exists(destinationFolderPath))
+      {
+        if (fileWasNewlyDownloaded)
+        {
+          var extractedDir = new DirectoryInfo(destinationFolderPath);
+          extractedDir.Delete(true);
+          ExtractZip(fileToExtractPath, targetFolder);
+        }
+      }
+      else
+      {
+        ExtractZip(fileToExtractPath, targetFolder);
+      }
+
+      FixPermissions(Path.Combine(targetFolder, destFolderName, "bin/neo4j"));
+
+      return destFolderName;
+    }
+
+    private static string GetDestFolderName(string filename)
+    {
+      using (Stream inStream = File.OpenRead(filename))
+      using (Stream gzipStream = new GZipInputStream(inStream))
+      using (TarInputStream tarIn = new TarInputStream(gzipStream))
+      {
+        TarEntry tarEntry;
+        while ((tarEntry = tarIn.GetNextEntry()) != null) 
+        {
+          if (tarEntry.IsDirectory && tarEntry.Name.Count(f => f == '/') == 1) 
+          {
+            return tarEntry.Name.Substring(0, tarEntry.Name.Length - 1);
+          }
+        }
+
+        throw new InvalidOperationException("Root folder in tar not found");
+      }
+    }
+
+    private static void ExtractZip(string filename, string destinationFolder)
+    {
+      using (Stream inStream = File.OpenRead(filename))
+      using (Stream gzipStream = new GZipInputStream(inStream))
+      using (TarArchive tarArchive = TarArchive.CreateInputTarArchive(gzipStream))
+      {
+        tarArchive.ExtractContents(destinationFolder);
+      }
+    }
+
+    private static void FixPermissions(string filename)
+    {
+      File.AppendAllLines("log.txt", new [] { filename });
+      
+      ProcessStartInfo processInfo = new ProcessStartInfo();
+      processInfo.FileName = "chmod";
+      processInfo.Arguments = "+x " + filename;
+
+      Process process = Process.Start(processInfo);
+      process.WaitForExit();
+
+      File.AppendAllLines("log.txt", new [] { "chmod done!" });
+    }
+  }
+}
+

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/UnixProcessBasedNeo4jInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/UnixProcessBasedNeo4jInstaller.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    public class UnixProcessBasedNeo4jInstaller : INeo4jInstaller
+    {
+        private Process startedProcess = null;
+
+        public DirectoryInfo Neo4jHome { get; private set; }
+ 
+        public void DownloadNeo4j()
+        {
+            Neo4jHome = Neo4jServerFilesDownloadHelper.DownloadNeo4j(
+                Neo4jServerEdition.Enterprise, 
+                Neo4jServerPlatform.Unix, 
+                new TgzNeo4jServerFileExtractor());
+
+            UpdateSettings(new Dictionary<string, string> { { "dbms.security.auth_enabled", "false" } });// disable auth
+        }
+
+        public void InstallServer()
+        {
+            // Not needed
+        }
+
+        public void StartServer()
+        {
+            ProcessStartInfo processInfo = new ProcessStartInfo();
+            processInfo.FileName = Path.Combine(Neo4jHome.FullName, @"bin/neo4j");
+            processInfo.WorkingDirectory = Neo4jHome.FullName;
+            processInfo.Arguments = "console";
+            processInfo.UseShellExecute = true;
+            processInfo.CreateNoWindow = false;
+
+      File.AppendAllLines("log.txt", new [] { processInfo.WorkingDirectory });
+      File.AppendAllLines("log.txt", new [] { processInfo.FileName });
+
+            startedProcess = Process.Start(processInfo);
+
+            Task.Delay(15000).Wait();
+        }
+
+        public void StopServer()
+        {
+            if (startedProcess == null) return;
+            startedProcess.CloseMainWindow();
+            if (!startedProcess.WaitForExit(10000))
+            {
+                startedProcess.Kill();
+                startedProcess.WaitForExit();
+            }
+            startedProcess = null;
+        }
+
+        public void UninstallServer()
+        {
+          // Not needed
+        }
+
+        public void UpdateSettings(IDictionary<string, string> keyValuePair)
+        {
+            Neo4jSettingsHelper.UpdateSettings(Neo4jHome.FullName, keyValuePair);
+        }
+    }
+}
+

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/UnixProcessBasedNeo4jInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/UnixProcessBasedNeo4jInstaller.cs
@@ -1,23 +1,25 @@
-﻿using System;
-using System.IO;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
-    public class UnixProcessBasedNeo4jInstaller : INeo4jInstaller
+    /// <summary>
+    ///     Unix implementation of the <see cref="INeo4jInstaller"/>.
+    /// </summary>
+    internal class UnixProcessBasedNeo4jInstaller : INeo4jInstaller
     {
         private Process startedProcess = null;
 
         public DirectoryInfo Neo4jHome { get; private set; }
- 
+
         public void DownloadNeo4j()
         {
             Neo4jHome = Neo4jServerFilesDownloadHelper.DownloadNeo4j(
-                Neo4jServerEdition.Enterprise, 
-                Neo4jServerPlatform.Unix, 
+                Neo4jServerEdition.Enterprise,
+                Neo4jServerPlatform.Unix,
                 new TgzNeo4jServerFileExtractor());
 
             UpdateSettings(new Dictionary<string, string> { { "dbms.security.auth_enabled", "false" } });// disable auth
@@ -37,8 +39,8 @@ namespace Neo4j.Driver.IntegrationTests.Internals
             processInfo.UseShellExecute = true;
             processInfo.CreateNoWindow = false;
 
-      File.AppendAllLines("log.txt", new [] { processInfo.WorkingDirectory });
-      File.AppendAllLines("log.txt", new [] { processInfo.FileName });
+            File.AppendAllLines("log.txt", new[] { processInfo.WorkingDirectory });
+            File.AppendAllLines("log.txt", new[] { processInfo.FileName });
 
             startedProcess = Process.Start(processInfo);
 
@@ -59,7 +61,7 @@ namespace Neo4j.Driver.IntegrationTests.Internals
 
         public void UninstallServer()
         {
-          // Not needed
+            // Not needed
         }
 
         public void UpdateSettings(IDictionary<string, string> keyValuePair)

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/WindowsNeo4jInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/WindowsNeo4jInstaller.cs
@@ -25,7 +25,7 @@ using Neo4j.Driver.Exceptions;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
-    public class WindowsNeo4jInstaller : INeo4jInstaller
+    internal class WindowsNeo4jInstaller : INeo4jInstaller
     {
         public DirectoryInfo Neo4jHome { get; private set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,9 +8,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Neo4j.Driver.IntegrationTests</RootNamespace>
     <AssemblyName>Neo4j.Driver.IntegrationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -37,51 +36,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
+    </Reference>
+    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Internals\INeo4jInstaller.cs" />
     <Compile Include="IntegrationTestFixture.cs" />
     <Compile Include="Internals\INeo4jServerFileExtractor.cs" />
+    <Compile Include="Internals\Neo4jInstallerFactory.cs" />
     <Compile Include="Internals\Neo4jServerFilesDownloader.cs" />
     <Compile Include="Internals\Neo4jSettingsHelper.cs" />
     <Compile Include="Internals\ZipNeo4jServerFileExtractor.cs" />

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -72,6 +72,10 @@
     <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
     </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -93,6 +97,8 @@
     <Compile Include="Internals\WindowsServiceBasedNeo4jInstaller.cs" />
     <Compile Include="Internals\WindowsProcessBasedNeo4jInstaller.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Internals\UnixProcessBasedNeo4jInstaller.cs" />
+    <Compile Include="Internals\TgzNeo4jServerFileExtractor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -75,7 +75,6 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="monodoc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/packages.config
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/packages.config
@@ -3,6 +3,7 @@
   <package id="FluentAssertions" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net452" />
   <package id="rda.SocketsForPCL" version="1.2.2" targetFramework="net452" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net451" />
   <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Neo4j.Driver.Tck.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Neo4j.Driver.Tck.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,9 +8,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Neo4j.Driver.Tck.Tests</RootNamespace>
     <AssemblyName>Neo4j.Driver.Tck.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -35,27 +34,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -63,21 +42,32 @@
       <HintPath>..\packages\SpecFlow.2.0.0\lib\net45\TechTalk.SpecFlow.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
+    </Reference>
+    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -129,11 +119,11 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Neo4j.Driver.IntegrationTests\Neo4j.Driver.IntegrationTests.csproj">
-      <Project>{02f68df2-0047-4b04-93b6-521bd12b5d45}</Project>
+      <Project>{02F68DF2-0047-4B04-93B6-521BD12B5D45}</Project>
       <Name>Neo4j.Driver.IntegrationTests</Name>
     </ProjectReference>
     <ProjectReference Include="..\Neo4j.Driver\Neo4j.Driver.csproj">
-      <Project>{f5e54582-c024-4b99-afeb-ca9638617ba0}</Project>
+      <Project>{F5E54582-C024-4B99-AFEB-CA9638617BA0}</Project>
       <Name>Neo4j.Driver</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
@@ -90,7 +90,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [BeforeTestRun]
         public static void GlobalBeforeScenario()
         {
-            _installer = new WindowsNeo4jInstaller();
+            _installer = Neo4jInstallerFactory.Create();
             _installer.DownloadNeo4j();
             try
             {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,9 +8,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Neo4j.Driver.Tests</RootNamespace>
     <AssemblyName>Neo4j.Driver.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -37,45 +36,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
+    </Reference>
+    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -114,7 +104,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Neo4j.Driver\Neo4j.Driver.csproj">
-      <Project>{f5e54582-c024-4b99-afeb-ca9638617ba0}</Project>
+      <Project>{F5E54582-C024-4B99-AFEB-CA9638617BA0}</Project>
       <Name>Neo4j.Driver</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
@@ -104,13 +104,11 @@
     <Compile Include="ValueExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Sockets.Plugin.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Sockets.Plugin.Abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Neo4j.Driver/RunUnitTests.bat
+++ b/Neo4j.Driver/RunUnitTests.bat
@@ -1,1 +1,0 @@
-packages\xunit.runner.console.2.1.0\tools\xunit.console.exe Neo4j.Driver.Tests\bin\Debug\Neo4j.Driver.Tests.dll Neo4j.Driver.IntegrationTests\bin\Debug\Neo4j.Driver.IntegrationTests.dll Neo4j.Driver.Tck.Tests\bin\Debug\Neo4j.Driver.Tck.Tests.dll -parallel none

--- a/Neo4j.Driver/RunUnitTests.bat
+++ b/Neo4j.Driver/RunUnitTests.bat
@@ -1,0 +1,1 @@
+packages\xunit.runner.console.2.1.0\tools\xunit.console.exe Neo4j.Driver.Tests\bin\Debug\Neo4j.Driver.Tests.dll Neo4j.Driver.IntegrationTests\bin\Debug\Neo4j.Driver.IntegrationTests.dll Neo4j.Driver.Tck.Tests\bin\Debug\Neo4j.Driver.Tck.Tests.dll -parallel none


### PR DESCRIPTION
Unix based Neo4jInstaller implemented and the used conditional depending on which platform the code in the intergration test is compiled (Mono vs MSbuild/VS). 

I have run all unit tests with success for both community and enterprise editions on OSX after I compiled the soluion in Xamarin. 

Please disragard the Windows script for running all unittest. I have removed it from the branch and this PR.

Enjoy :)
