### PR TITLE
Fx for equality in Neo4j entities (INode, IRelationship, etc) that could lead to bugs

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/EntityTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/EntityTests.cs
@@ -15,6 +15,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 using FluentAssertions;
+using Moq;
 using Neo4j.Driver.Internal;
 using Xunit;
 
@@ -28,10 +29,20 @@ namespace Neo4j.Driver.Tests
             public void ShouldEqualIfIdEquals()
             {
                 var node1 = new Node(123, new []{"buibui"}, null);
-                var node2 = new Node(123, new []{"lala"}, null);
+                var node2 = new Node(123, new []{"lala"}, null);  
                 node1.Equals(node2).Should().BeTrue();
                 Equals(node1, node2).Should().BeTrue();
                 node1.GetHashCode().Should().Be(node2.GetHashCode());
+
+                var node3Mock = new Mock<INode>();
+                node3Mock.Setup(f => f.Id).Returns(123);
+                node3Mock.Setup(f => f.Labels).Returns(new[] { "same interface, different implementation" });
+                node3Mock.Setup(f => f.GetHashCode()).Returns(123);
+                var node3 = node3Mock.Object;
+                node1.Equals(node3).Should().BeTrue();
+                Equals(node1, node3).Should().BeTrue();
+                // TODO: The following test is currently not supported by Moq
+                //node1.GetHashCode().Should().Be(node3.GetHashCode());
             }
         }
 
@@ -45,6 +56,19 @@ namespace Neo4j.Driver.Tests
                 rel1.Equals(rel2).Should().BeTrue();
                 Equals(rel1, rel2).Should().BeTrue();
                 rel1.GetHashCode().Should().Be(rel2.GetHashCode());
+
+                var rel3Mock = new Mock<IRelationship>();
+                rel3Mock.Setup(f => f.Id).Returns(123);
+                rel3Mock.Setup(f => f.StartNodeId).Returns(444);
+                rel3Mock.Setup(f => f.EndNodeId).Returns(555);
+                rel3Mock.Setup(f => f.Type).Returns("same interface, different implementation");
+                rel3Mock.Setup(f => f.GetHashCode()).Returns(123);
+                var rel3 = rel3Mock.Object;
+
+                rel1.Equals(rel3).Should().BeTrue();
+                Equals(rel1, rel3).Should().BeTrue();
+                // TODO: The following test is currently not supported by Moq
+                //rel1.GetHashCode().Should().Be(rel3.GetHashCode());
             }
         }
 
@@ -62,6 +86,16 @@ namespace Neo4j.Driver.Tests
                 path1.Equals(path2).Should().BeTrue();
                 Equals(path1, path2).Should().BeTrue();
                 path1.GetHashCode().Should().Be(path2.GetHashCode());
+
+                var path3Mock = new Mock<IPath>();
+                path3Mock.Setup(f => f.Start).Returns(new Node(123, new[] { "same interface, different implementation" }, null));
+                path3Mock.Setup(f => f.Relationships).Returns(new[] { new Relationship(1, 222, 333, "same interface --- different implementation", null) });
+                var path3 = path3Mock.Object;
+                path1.Equals(path3).Should().BeTrue();
+                Equals(path1, path3).Should().BeTrue();
+
+                // TODO: The following test is currently not supported by Moq
+                //path1.GetHashCode().Should().Be(path2.GetHashCode());
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/IEntity.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IEntity.cs
@@ -14,6 +14,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+using System;
 using System.Collections.Generic;
 
 namespace Neo4j.Driver
@@ -42,7 +43,7 @@ namespace Neo4j.Driver
     /// <summary>
     /// Represents a <c>Node</c> in the Neo4j graph database 
     /// </summary>
-    public interface INode: IEntity
+    public interface INode: IEntity, IEquatable<INode>
     {
         /// <summary>
         /// Gets the lables of the node.
@@ -53,7 +54,7 @@ namespace Neo4j.Driver
     /// <summary>
     /// Represents a <c>Relationship</c> in the Neo4j graph database
     /// </summary>
-    public interface IRelationship:IEntity
+    public interface IRelationship : IEntity, IEquatable<IRelationship>
     {
         /// <summary>
         /// Gets the type of the relationship
@@ -77,7 +78,7 @@ namespace Neo4j.Driver
     ///     It is allowed to be of size 0, meaning there are no relationships in it.In this case,
     ///     it contains only a single node which is both the start and the end of the path.
     /// </summary>
-    public interface IPath
+    public interface IPath : IEquatable<IPath>
     {
         /// <summary>
         /// Gets the start <see cref="INode"/> in the path.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
@@ -73,8 +73,8 @@ namespace Neo4j.Driver.Internal
 
         public bool Equals(IRelationship other)
         {
-            if (other == null)
-                if (ReferenceEquals(this, other)) return true;
+            if (other == null) return false;
+            if (ReferenceEquals(this, other)) return true;
             return Equals(Id, other.Id);
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Neo4j.Driver.Internal
 {
-    public class Node : INode, IEquatable<INode>
+    public class Node : INode
     {
         public long Id { get; }
         public IReadOnlyList<string> Labels { get; }
@@ -52,7 +52,7 @@ namespace Neo4j.Driver.Internal
         }
     }
 
-    public class Relationship : IRelationship, IEquatable<IRelationship>
+    public class Relationship : IRelationship
     {
         public long Id { get; }
         public string Type { get; }
@@ -101,7 +101,7 @@ namespace Neo4j.Driver.Internal
     /// for that relationship.This exists because the relationship has a direction between the two nodes that is
     /// separate and potentially different from the direction of the path.
     /// </summary>
-    public interface ISegment
+    public interface ISegment : IEquatable<ISegment>
     {
         /// <summary>
         /// Gets the start node underlying this path segment.
@@ -117,7 +117,7 @@ namespace Neo4j.Driver.Internal
         IRelationship Relationship { get; }
     }
 
-    public class Segment : ISegment, IEquatable<ISegment>
+    public class Segment : ISegment
     {
         public Segment(INode start, IRelationship rel, INode end)
         {
@@ -154,7 +154,7 @@ namespace Neo4j.Driver.Internal
         }
     }
 
-    public class Path : IPath, IEquatable<IPath>
+    public class Path : IPath
     {
         private readonly IReadOnlyList<ISegment> _segments;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
@@ -36,15 +36,14 @@ namespace Neo4j.Driver.Internal
 
         public bool Equals(INode other)
         {
+            if (other == null) return false;
+            if (ReferenceEquals(this, other)) return true;
             return Equals(Id, other.Id);
         }
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((Node) obj);
+            return Equals(obj as INode);
         }
 
         public override int GetHashCode()
@@ -74,15 +73,14 @@ namespace Neo4j.Driver.Internal
 
         public bool Equals(IRelationship other)
         {
+            if (other == null)
+                if (ReferenceEquals(this, other)) return true;
             return Equals(Id, other.Id);
         }
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((Relationship) obj);
+            return Equals(obj as IRelationship);
         }
 
         public override int GetHashCode()
@@ -134,15 +132,14 @@ namespace Neo4j.Driver.Internal
 
         public bool Equals(ISegment other)
         {
+            if (other == null) return false;
+            if (ReferenceEquals(this, other)) return true;
             return Equals(Start, other.Start) && Equals(End, other.End) && Equals(Relationship, other.Relationship);
         }
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((ISegment)obj);
+            return Equals(obj as ISegment);
         }
 
         public override int GetHashCode()
@@ -176,15 +173,14 @@ namespace Neo4j.Driver.Internal
 
         public bool Equals(IPath other)
         {
+            if (other == null) return false;
+            if (ReferenceEquals(this, other)) return true;
             return Equals(Start, other.Start) && Relationships.SequenceEqual(other.Relationships);
         }
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((IPath)obj);
+            return Equals(obj as IPath);
         }
 
         public override int GetHashCode()
@@ -192,11 +188,9 @@ namespace Neo4j.Driver.Internal
             unchecked
             {
                 var hashCode = Start?.GetHashCode() ?? 0;
-                hashCode = Relationships?.Aggregate(hashCode, (current, relationship) => (current*397) ^ relationship.GetHashCode()) ?? hashCode;
+                hashCode = Relationships?.Aggregate(hashCode, (current, relationship) => (current * 397) ^ relationship.GetHashCode()) ?? hashCode;
                 return hashCode;
             }
         }
-
-        
     }
 }


### PR DESCRIPTION
I have changed the code for equality in all entities because the current implementation required that the two instances that one wanted to compare has the same type. Example:

```
class Node : INode {} 
class MyNode : INode {}
var node = new Node(1); // Id = 1
var myNode = new MyNode(1); // Id = 1
var isEqual = node.Equals(myNode); // isEqual would now be false.
```

I have also moved the IEquatable to the entity interfaces because the interfaces are the public part of the driver and it make sense to compare to entities of the same interface. 
