### PR TITLE
ILogger is no longer inheriting IDisposable because this should be up the the client of the Neo4j driver to decide

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -61,7 +61,6 @@ namespace Neo4j.Driver
                 return;
             _sessionPool?.Dispose();
             _sessionPool = null;
-            Logger?.Dispose();
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Logger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Logger.cs
@@ -36,7 +36,7 @@ namespace Neo4j.Driver
     /// <remarks>
     /// Set the logger that you want to use via <see cref="Config"/>.
     /// If no logger is explicitly set, then a default debug logger would be used <see cref="Config.DefaultConfig"/></remarks>
-    public interface ILogger : IDisposable
+    public interface ILogger 
     {
         /// <summary>Log a message at <see cref="LogLevel.Error"/> level.</summary>
         /// <param name="message">The error message.</param>


### PR DESCRIPTION
I have removed the IDisposable from the ILogger interface because I think it is the client of the Neo4j driver that owns its logger and how it wants to use it. So I think it would be wrong if the Neo4j driver disposed it and therefor IDisposable is no longer needed on the ILogger interface.

This is backwards compatible breaking, this is why I created the PR agains 1.0 :)
