### PR TITLE
Fixing compiler warnings

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
@@ -694,11 +694,11 @@ namespace Neo4j.Driver.Tests
                     {
                         public static INode Alice = new Node(1001L,
                             new List<string> {"Person", "Employee"},
-                            new Dictionary<string, object> {{"name", "Alice"}, {"age", 33l}});
+                            new Dictionary<string, object> {{"name", "Alice"}, {"age", 33L}});
 
                         public static INode Bob = new Node(1002L,
                             new List<string> {"Person", "Employee"},
-                            new Dictionary<string, object> {{"name", "Bob"}, {"age", 44l}});
+                            new Dictionary<string, object> {{"name", "Bob"}, {"age", 44L}});
 
                         public static INode Carol = new Node(
                             1003L,

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/PeekingEnumeratorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/PeekingEnumeratorTests.cs
@@ -115,15 +115,32 @@ namespace Neo4j.Driver.Tests
         public class DisposeMethod
         {
             [Fact]
-            public void ShouldNotDiscardAfterDispose()
+            public void ShouldDiscardAfterDispose()
             {
                 var list = new List<string> { "1", "2", "3" }.GetEnumerator();
                 var enumerator = new PeekingEnumerator<string>(list);
-                enumerator.MoveNext().Should().BeTrue();
-                enumerator.Consume();
+                enumerator.Dispose();
                 enumerator.MoveNext().Should().BeFalse();
                 enumerator.Peek().Should().BeNull();
-                enumerator.Position.Should().Be(3);
+                enumerator.Position.Should().Be(-1);
+            }
+
+            [Fact]
+            public void PeakShouldReturnDefaultAfterDispose()
+            {
+                var list = new List<string> { "1", "2", "3" }.GetEnumerator();
+                var enumerator = new PeekingEnumerator<string>(list);
+                enumerator.Dispose();
+                enumerator.Peek().Should().Be(null); // null is default(string)
+            }
+
+            [Fact]
+            public void ConsumeShouldThrowAfterDispose()
+            {
+                var list = new List<string> { "1", "2", "3" }.GetEnumerator();
+                var enumerator = new PeekingEnumerator<string>(list);
+                enumerator.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => enumerator.Consume());
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -385,26 +385,53 @@ namespace Neo4j.Driver.Tests
         public class DisposeMethod
         {
             [Fact]
-            public void ShouldConsumeRecordStream()
+            public void ShouldNotConsumeRecordStream()
             {
                 var result = ResultCreator.CreateResult(1, 2);
 
                 result.Dispose();
 
                 result.AtEnd.Should().BeTrue();
-                result.Position.Should().Be(2);
+                result.Position.Should().Be(-1);
                 result.GetEnumerator().MoveNext().Should().BeFalse();
                 result.GetEnumerator().Current.Should().BeNull();
             }
 
             [Fact]
-            public void ShouldPullSummary()
+            public void ShouldNotPullSummary()
             {
                 int getSummaryCalled = 0;
                 var result = ResultCreator.CreateResult(1, 0, () => { getSummaryCalled++; return new FakeSummary(); });
 
                 result.Dispose();
-                getSummaryCalled.Should().Be(1);
+                getSummaryCalled.Should().Be(0);
+            }
+
+            [Fact]
+            public void PeakShouldThrowAfterDispose()
+            {
+                var result = ResultCreator.CreateResult(1, 2);
+                result.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => result.Peek());
+            }
+
+            [Fact]
+            public void ConsumeShouldThrowAfterDispose()
+            {
+                var result = ResultCreator.CreateResult(1, 2);
+                result.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => result.Consume());
+            }
+
+            [Fact]
+            public void SingleShouldThrowAfterDispose()
+            {
+                var result = ResultCreator.CreateResult(1, 2);
+                result.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => result.Single());
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -73,7 +73,7 @@ namespace Neo4j.Driver
         ///     Establish a session with Neo4j instance
         /// </summary>
         /// <returns>
-        ///     An <see cref="ISession" /> that could be used to <see cref="ISession.Run" /> a statement or begin a
+        ///     An <see cref="ISession" /> that could be used to <see cref="IStatementRunner.Run(Statement)" /> a statement or begin a
         ///     transaction
         /// </returns>
         public ISession Session()

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -59,8 +59,13 @@ namespace Neo4j.Driver
         {
             if (!isDisposing)
                 return;
-            _sessionPool?.Dispose();
-            _sessionPool = null;
+
+            if (_sessionPool != null)
+            {
+                _sessionPool.Dispose();
+                _sessionPool = null;
+            }
+
             Logger?.Dispose();
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/INotification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/INotification.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver
         /// </summary>
         string Description { get; }
 
-        ///
+        /// <summary>
         ///The position in the statement where this notification points to.
         ///Not all notifications have a unique position to point to and in that case the position would be set to null.
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ISession.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver
         /// Begin a new transaction in this session. A session can have at most one transaction running at a time, if you
         /// want to run multiple concurrent transactions, you should use multiple concurrent sessions.
         /// 
-        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run"/>
+        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run(Statement)"/>
         /// method directly on this session interface as well. When you use that method, your statement automatically gets
         /// wrapped in a transaction.
         ///

--- a/Neo4j.Driver/Neo4j.Driver/IStatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IStatementResult.cs
@@ -26,7 +26,7 @@ namespace Neo4j.Driver
     /// The records in the result is lazily retrived and could only be visited once.
     /// </summary>
     /// <remarks> Calling <see cref="Enumerable.ToList{TSource}"/> will enumerate the entire stream.</remarks>
-    public interface IStatementResult : IEnumerable<IRecord>
+    public interface IStatementResult : IEnumerable<IRecord>, IDisposable
     {
         /// <summary>
         /// Gets the keys in the result

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
@@ -35,6 +35,7 @@ namespace Neo4j.Driver.Internal.Result
         private T _current;
         private bool _hasConsumed = false;
         private int _position = -1;
+        private bool _disposed = false;
         public long Position => _position;
 
         public PeekingEnumerator(IEnumerator<T> enumerator)
@@ -48,6 +49,8 @@ namespace Neo4j.Driver.Internal.Result
 
         public bool MoveNext()
         {
+            if (_disposed) return false;
+
             if (CacheNext())
             {
                 _current = _cached;
@@ -90,11 +93,13 @@ namespace Neo4j.Driver.Internal.Result
 
         public T Peek()
         {
+            if (_disposed) return default(T);
             return CacheNext() ? _cached : null;
         }
 
         public void Consume()
         {
+            if (_disposed) throw new ObjectDisposedException(nameof(PeekingEnumerator<T>));
             if (_hasConsumed)
             {
                 return;
@@ -113,6 +118,7 @@ namespace Neo4j.Driver.Internal.Result
 
         protected virtual void Dispose(bool isDisposing)
         {
+            _disposed = true;
         }
 
         public void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -28,7 +28,7 @@ namespace Neo4j.Driver.Internal.Result
     public class StatementResult : IStatementResult
     {
         private IResultSummary _summary;
-        private readonly IPeekingEnumerator<Record> _enumerator;
+        private IPeekingEnumerator<Record> _enumerator;
         private List<string> _keys;
         private Func<IResultSummary> _getSummary;
         internal long Position => _enumerator.Position;
@@ -105,7 +105,12 @@ namespace Neo4j.Driver.Internal.Result
             {
                 return;
             }
-            Consume();
+            
+            if (_enumerator != null)
+            {
+                _enumerator.Dispose();
+                _enumerator = null;
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
I have fixed all compiler warnings in all projects because it leave a better impression when cloning and compiling the code :)

Take special note to the commit: https://github.com/neo4j/neo4j-dotnet-driver/commit/e968381c75f1248fe7e00787a7cbca52f1a7b3b2

I think this change is for the better, because the changed classes now behaves like you would expect. Eg: Dispose does not have any side effects other than the object being disposed. And calling most of the methods on a disposed object throws `ObjectDisposedException` because the state of an disposed is undefined.
