### PR TITLE
Fix warning and rename `IStatement.Text`

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverResultApiSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverResultApiSteps.cs
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tck.Tests
         public void ThenRequestingTheStatementAsTextShouldGive(string statement)
         {
             var summary = ScenarioContext.Current.Get<IResultSummary>();
-            summary.Statement.Template.Should().Be(statement);
+            summary.Statement.Text.Should().Be(statement);
         }
 
         [Then(@"requesting the `Statement` parameter should give: \{}")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
@@ -694,11 +694,11 @@ namespace Neo4j.Driver.Tests
                     {
                         public static INode Alice = new Node(1001L,
                             new List<string> {"Person", "Employee"},
-                            new Dictionary<string, object> {{"name", "Alice"}, {"age", 33l}});
+                            new Dictionary<string, object> {{"name", "Alice"}, {"age", 33L}});
 
                         public static INode Bob = new Node(1002L,
                             new List<string> {"Person", "Employee"},
-                            new Dictionary<string, object> {{"name", "Bob"}, {"age", 44l}});
+                            new Dictionary<string, object> {{"name", "Bob"}, {"age", 44L}});
 
                         public static INode Carol = new Node(
                             1003L,

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -354,7 +354,7 @@ namespace Neo4j.Driver.Tests.Result
                 actual.Summary.Notifications.Should().BeEmpty();
                 actual.Summary.Plan.Should().BeNull();
                 actual.Summary.Profile.Should().BeNull();
-                actual.Summary.Statement.Template.Should().BeNull();
+                actual.Summary.Statement.Text.Should().BeNull();
                 actual.Summary.StatementType.Should().Be(StatementType.Unknown);
                 actual.Summary.Counters.ShouldBeEquivalentTo(DefaultCounters);
             }

--- a/Neo4j.Driver/Neo4j.Driver.nuspec
+++ b/Neo4j.Driver/Neo4j.Driver.nuspec
@@ -27,6 +27,7 @@
         <dependency id="rda.SocketsForPCL" version="1.2.2" />
         <dependency id="System.Collections" version="4.0.0" />
         <dependency id="System.Diagnostics.Debug" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.0" />
         <dependency id="System.IO" version="4.0.0" />
         <dependency id="System.Linq" version="4.0.0" />
         <dependency id="System.Reflection" version="4.0.0" />

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -59,8 +59,12 @@ namespace Neo4j.Driver
         {
             if (!isDisposing)
                 return;
-            _sessionPool?.Dispose();
-            _sessionPool = null;
+
+            if (_sessionPool != null)
+            {
+                _sessionPool.Dispose();
+                _sessionPool = null;
+            }
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -71,7 +71,7 @@ namespace Neo4j.Driver
         ///     Establish a session with Neo4j instance
         /// </summary>
         /// <returns>
-        ///     An <see cref="ISession" /> that could be used to <see cref="ISession.Run" /> a statement or begin a
+        ///     An <see cref="ISession" /> that could be used to <see cref="IStatementRunner.Run(Statement)" /> a statement or begin a
         ///     transaction
         /// </returns>
         public ISession Session()

--- a/Neo4j.Driver/Neo4j.Driver/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ISession.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver
         /// Begin a new transaction in this session. A session can have at most one transaction running at a time, if you
         /// want to run multiple concurrent transactions, you should use multiple concurrent sessions.
         /// 
-        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run"/>
+        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run(Statement)"/>
         /// method directly on this session interface as well. When you use that method, your statement automatically gets
         /// wrapped in a transaction.
         ///

--- a/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
@@ -14,7 +14,7 @@ namespace Neo4j.Driver.Internal
 
         public IStatementResult Run(Statement statement)
         {
-            return Run(statement.Template, statement.Parameters);
+            return Run(statement.Text, statement.Parameters);
         }
 
         public IStatementResult Run(string statement, object parameters)

--- a/Neo4j.Driver/Neo4j.Driver/Statement.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Statement.cs
@@ -32,9 +32,9 @@ namespace Neo4j.Driver
         }
          
         /// <summary>
-        /// Gets the statement's template.
+        /// Gets the statement's text.
         /// </summary>
-        public string Template { get; }
+        public string Text { get; }
         /// <summary>
         /// Gets the statement's parameters.
         /// </summary>
@@ -43,17 +43,17 @@ namespace Neo4j.Driver
         /// <summary>
         /// Create a statemete
         /// </summary>
-        /// <param name="template">The statement's template</param>
+        /// <param name="text">The statement's text</param>
         /// <param name="parameters">The statement's parameters, whoes values should not be changed while the statement is used in a session/transaction.</param>
-        public Statement(string template, IDictionary<string, object> parameters = null)
+        public Statement(string text, IDictionary<string, object> parameters = null)
         {
-            Template = template;
+            Text = text;
             Parameters = parameters ?? NoParameter;
         }
 
         public override string ToString()
         {
-            return $"`{Template}`, {Parameters.ToContentString()}";
+            return $"`{Text}`, {Parameters.ToContentString()}";
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/ValueExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ValueExtensions.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using Neo4j.Driver.Exceptions;
 
 namespace Neo4j.Driver
 {


### PR DESCRIPTION
I moved the non-controversial part of PR #42 into here so that we could merge first.
- Fixed most of the warnings (Only `StatementResult.Dispose` is left)
- Renamed `IStatement.Template` to `IStatement.Text`
