### PR TITLE
Remove the warnning about the Dispose method in StatementResult

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
@@ -694,11 +694,11 @@ namespace Neo4j.Driver.Tests
                     {
                         public static INode Alice = new Node(1001L,
                             new List<string> {"Person", "Employee"},
-                            new Dictionary<string, object> {{"name", "Alice"}, {"age", 33l}});
+                            new Dictionary<string, object> {{"name", "Alice"}, {"age", 33L}});
 
                         public static INode Bob = new Node(1002L,
                             new List<string> {"Person", "Employee"},
-                            new Dictionary<string, object> {{"name", "Bob"}, {"age", 44l}});
+                            new Dictionary<string, object> {{"name", "Bob"}, {"age", 44L}});
 
                         public static INode Carol = new Node(
                             1003L,

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -354,7 +354,7 @@ namespace Neo4j.Driver.Tests.Result
                 actual.Summary.Notifications.Should().BeEmpty();
                 actual.Summary.Plan.Should().BeNull();
                 actual.Summary.Profile.Should().BeNull();
-                actual.Summary.Statement.Template.Should().BeNull();
+                actual.Summary.Statement.Text.Should().BeNull();
                 actual.Summary.StatementType.Should().Be(StatementType.Unknown);
                 actual.Summary.Counters.ShouldBeEquivalentTo(DefaultCounters);
             }

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -59,8 +59,12 @@ namespace Neo4j.Driver
         {
             if (!isDisposing)
                 return;
-            _sessionPool?.Dispose();
-            _sessionPool = null;
+
+            if (_sessionPool != null)
+            {
+                _sessionPool.Dispose();
+                _sessionPool = null;
+            }
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -71,7 +71,7 @@ namespace Neo4j.Driver
         ///     Establish a session with Neo4j instance
         /// </summary>
         /// <returns>
-        ///     An <see cref="ISession" /> that could be used to <see cref="ISession.Run" /> a statement or begin a
+        ///     An <see cref="ISession" /> that could be used to <see cref="IStatementRunner.Run(Statement)" /> a statement or begin a
         ///     transaction
         /// </returns>
         public ISession Session()

--- a/Neo4j.Driver/Neo4j.Driver/INotification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/INotification.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver
         /// </summary>
         string Description { get; }
 
-        ///
+        /// <summary>
         ///The position in the statement where this notification points to.
         ///Not all notifications have a unique position to point to and in that case the position would be set to null.
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ISession.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver
         /// Begin a new transaction in this session. A session can have at most one transaction running at a time, if you
         /// want to run multiple concurrent transactions, you should use multiple concurrent sessions.
         /// 
-        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run"/>
+        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run(Statement)"/>
         /// method directly on this session interface as well. When you use that method, your statement automatically gets
         /// wrapped in a transaction.
         ///

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
@@ -107,6 +107,7 @@ namespace Neo4j.Driver.Internal.Result
             _position ++;
             _cached = null;
             _current = null;
+            _enumerator.Dispose();
             _enumerator = null;
             _hasConsumed = true;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -25,10 +25,10 @@ namespace Neo4j.Driver.Internal.Result
     /// <summary>
     /// The result returned from the Neo4j instance
     /// </summary>
-    public class StatementResult : IStatementResult
+    public class StatementResult : IStatementResult, IDisposable
     {
         private IResultSummary _summary;
-        private readonly IPeekingEnumerator<Record> _enumerator;
+        private IPeekingEnumerator<Record> _enumerator;
         private List<string> _keys;
         private Func<IResultSummary> _getSummary;
         internal long Position => _enumerator.Position;
@@ -106,6 +106,11 @@ namespace Neo4j.Driver.Internal.Result
                 return;
             }
             Consume();
+            if (_enumerator != null)
+            {
+                _enumerator.Dispose();
+            }
+            _enumerator = null;
         }
 
         public void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
@@ -14,7 +14,7 @@ namespace Neo4j.Driver.Internal
 
         public IStatementResult Run(Statement statement)
         {
-            return Run(statement.Template, statement.Parameters);
+            return Run(statement.Text, statement.Parameters);
         }
 
         public IStatementResult Run(string statement, object parameters)

--- a/Neo4j.Driver/Neo4j.Driver/Statement.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Statement.cs
@@ -32,9 +32,9 @@ namespace Neo4j.Driver
         }
          
         /// <summary>
-        /// Gets the statement's template.
+        /// Gets the statement's text.
         /// </summary>
-        public string Template { get; }
+        public string Text { get; }
         /// <summary>
         /// Gets the statement's parameters.
         /// </summary>
@@ -43,17 +43,17 @@ namespace Neo4j.Driver
         /// <summary>
         /// Create a statemete
         /// </summary>
-        /// <param name="template">The statement's template</param>
+        /// <param name="text">The statement's text</param>
         /// <param name="parameters">The statement's parameters, whoes values should not be changed while the statement is used in a session/transaction.</param>
-        public Statement(string template, IDictionary<string, object> parameters = null)
+        public Statement(string text, IDictionary<string, object> parameters = null)
         {
-            Template = template;
+            Text = text;
             Parameters = parameters ?? NoParameter;
         }
 
         public override string ToString()
         {
-            return $"`{Template}`, {Parameters.ToContentString()}";
+            return $"`{Text}`, {Parameters.ToContentString()}";
         }
     }
 


### PR DESCRIPTION
This is a follow-up of PR #46 
The IDisposible is added on the impl StatementResult
The user should not do

```
using(Driver driver = GraphDatabase.Driver(url))
using(ISession session = driver.Session())
using(IStatementResult result = session.Run("A Cypher statement"))
{
    //do sth with the result
}
```

Instead, the correct way of use this result API should be

```
using(Driver driver = GraphDatabase.Driver(url))
using(ISession session = driver.Session())
{
    IStatementResult result = session.Run("A Cypher statement");
    //do sth with the result
    result.Consume(); // explicitly dispose all resources in result.
}
```
