### PR TITLE
1.0 fix warning for statement result dispose

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
@@ -107,6 +107,7 @@ namespace Neo4j.Driver.Internal.Result
             _position ++;
             _cached = null;
             _current = null;
+            _enumerator.Dispose();
             _enumerator = null;
             _hasConsumed = true;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -25,10 +25,10 @@ namespace Neo4j.Driver.Internal.Result
     /// <summary>
     /// The result returned from the Neo4j instance
     /// </summary>
-    public class StatementResult : IStatementResult
+    public class StatementResult : IStatementResult, IDisposable
     {
         private IResultSummary _summary;
-        private readonly IPeekingEnumerator<Record> _enumerator;
+        private IPeekingEnumerator<Record> _enumerator;
         private List<string> _keys;
         private Func<IResultSummary> _getSummary;
         internal long Position => _enumerator.Position;
@@ -106,6 +106,10 @@ namespace Neo4j.Driver.Internal.Result
                 return;
             }
             Consume();
+            if (_enumerator != null)
+            {
+                _enumerator.Dispose();
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
The IDisposible is added on the impl StatementResult
The user should not do

```
using(Driver driver = GraphDatabase.Driver(url))
using(ISession session = driver.Session())
using(IStatementResult result = session.Run("A Cypher statement"))
{
    //do sth with the result
}
```

Instead, the correct way of use this result API should be

```
using(Driver driver = GraphDatabase.Driver(url))
using(ISession session = driver.Session())
{
    IStatementResult result = session.Run("A Cypher statement");
    //do sth with the result
    result.Consume(); // explicitly dispose all resources in result.
}
```
