### PR TITLE
Making official nonpublic types internal

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
@@ -19,7 +19,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal;
 using Xunit;
 using Xunit.Abstractions;

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Linq;
 //tag::minimal-example-import[]
 using Neo4j.Driver;
-using Neo4j.Driver.Exceptions;
 //end::minimal-example-import[]
 using Neo4j.Driver.IntegrationTests;
 using Neo4j.Driver.Internal;

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/WindowsNeo4jInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/WindowsNeo4jInstaller.cs
@@ -21,7 +21,6 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading.Tasks;
-using Neo4j.Driver.Exceptions;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverAuthSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverAuthSteps.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal;
 using TechTalk.SpecFlow;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Extensions;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
@@ -51,7 +51,7 @@ namespace Neo4j.Driver.Tests.Messaging
             };
 
             [Theory, MemberData("MessageData")]
-            public void ShouldPrintTheMessageAsExpected(IMessage message, string expected)
+            internal void ShouldPrintTheMessageAsExpected(IMessage message, string expected)
             {
                 message.ToString().Should().Be(expected);
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/UnpackerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/UnpackerTests.cs
@@ -654,7 +654,7 @@ namespace Neo4j.Driver.Tests
                 [InlineData(PackStream.INT_16, PackStream.PackType.Integer)]
                 [InlineData(PackStream.INT_32, PackStream.PackType.Integer)]
                 [InlineData(PackStream.INT_64, PackStream.PackType.Integer)]
-                public void ShouldPeekTypeCorrectly(byte marker, PackStream.PackType expected)
+                internal void ShouldPeekTypeCorrectly(byte marker, PackStream.PackType expected)
                 {
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.PeekByte()).Returns(marker);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Result;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -16,7 +16,6 @@
 // limitations under the License.
 using FluentAssertions;
 using Moq;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/StatementRunnerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/StatementRunnerTests.cs
@@ -8,7 +8,7 @@ namespace Neo4j.Driver.Tests
 {
     public class StatementRunnerTests
     {
-        public class MyStatementRunner : StatementRunner
+        internal class MyStatementRunner : StatementRunner
         {
             public string Statement { private set; get; }
             public IDictionary<string, object> Parameters { private set; get; } 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
@@ -25,7 +25,7 @@ using Xunit;
 
 namespace Neo4j.Driver.Tests
 {
-    public class SocketClientTestHarness : IDisposable
+    internal class SocketClientTestHarness : IDisposable
     {
         public SocketClient Client { get; }
         public Mock<Stream> MockWriteStream { get; }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -21,7 +21,6 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/ByteExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/ByteExtensions.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Neo4j.Driver.Extensions
 {
-    public static class ByteExtensions
+    internal static class ByteExtensions
     {
         public static byte[] PadRight(this byte[] bytes, int totalSize)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/CollectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/CollectionExtensions.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Neo4j.Driver.Extensions
 {
-    public static class CollectionExtensions
+    internal static class CollectionExtensions
     {
         public static string ValueToString(this object o)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/Extensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/Extensions.cs
@@ -20,7 +20,7 @@ using Neo4j.Driver.Exceptions;
 
 namespace Neo4j.Driver.Extensions
 {
-    public static class Extensions
+    internal static class Extensions
     {
         public static T[] DequeueToArray<T>(this Queue<T> queue, int length)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/Extensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/Extensions.cs
@@ -16,7 +16,6 @@
 //  limitations under the License.
 using System.Collections.Generic;
 using System.Linq;
-using Neo4j.Driver.Exceptions;
 
 namespace Neo4j.Driver.Extensions
 {

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/Throw.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace Neo4j.Driver.Extensions
 {
-    public static class Throw
+    internal static class Throw
     {
         public static class ArgumentNullException
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
@@ -22,7 +22,7 @@ namespace Neo4j.Driver.Internal
     /// <summary>
     ///     A simple common token for authentication schemes that easily convert to an auth token map
     /// </summary>
-    public class AuthToken : IAuthToken
+    internal class AuthToken : IAuthToken
     {
         public AuthToken(IDictionary<string, object> content)
         {
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.Internal
         public IDictionary<string, object> Content { get; }
     }
 
-    public static class AuthTokenExtensions
+    internal static class AuthTokenExtensions
     {
         public static IDictionary<string, object> AsDictionary(this IAuthToken authToken)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System.Collections.Generic;
-using Neo4j.Driver.Exceptions;
 
 namespace Neo4j.Driver.Internal
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
@@ -23,7 +23,7 @@ using Sockets.Plugin.Abstractions;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    public class ChunkedInputStream : IInputStream
+    internal class ChunkedInputStream : IInputStream
     {
         private const int ChunkSize = 1024*8; 
         public static byte[] Tail = {0x00, 0x00};

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
@@ -16,7 +16,6 @@
 //  limitations under the License.
 
 using System.Collections.Generic;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Extensions;
 using Neo4j.Driver.Internal.Packstream;
 using Sockets.Plugin.Abstractions;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
@@ -22,7 +22,7 @@ using Sockets.Plugin.Abstractions;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    public class ChunkedOutputStream : IOutputStream
+    internal class ChunkedOutputStream : IOutputStream
     {
         internal const int BufferSize = 1024*8;
         private readonly int _chunkSize;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -21,7 +21,7 @@ using Neo4j.Driver.Internal.Result;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    public interface IConnection : IDisposable
+    internal interface IConnection : IDisposable
     {
         void Sync();
         void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> parameters=null);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IInputStream.cs
@@ -16,7 +16,7 @@
 //  limitations under the License.
 namespace Neo4j.Driver.Internal.Connector
 {
-    public interface IInputStream
+    internal interface IInputStream
     {
         sbyte ReadSByte();
         byte ReadByte();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IOutputStream.cs
@@ -16,7 +16,7 @@
 //  limitations under the License.
 namespace Neo4j.Driver.Internal.Connector
 {
-    public interface IOutputStream
+    internal interface IOutputStream
     {
         IOutputStream Write(byte b, params byte[] bytes);
         IOutputStream Write(byte[] bytes);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -21,7 +21,7 @@ using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    public interface ISocketClient
+    internal interface ISocketClient
     {
         Task Start();
         Task Stop();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/MessageResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/MessageResponseHandler.cs
@@ -16,7 +16,6 @@
 //  limitations under the License.
 
 using System.Collections.Generic;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Result;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -25,7 +25,7 @@ using Sockets.Plugin.Abstractions;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    public class SocketClient :  ISocketClient, IDisposable
+    internal class SocketClient :  ISocketClient, IDisposable
     {
         private readonly Config _config;
         private readonly ITcpSocketClient _tcpSocketClient;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Extensions;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketExtensions.cs
@@ -19,7 +19,7 @@ using System.IO;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    public static class SocketExtensions
+    internal static class SocketExtensions
     {
         public static void Write(this Stream stream, byte[] bytes)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
@@ -6,14 +6,14 @@ using Neo4j.Driver.Extensions;
 namespace Neo4j.Driver.Internal
 {
 
-    public class DebugLogger : BaseOutLogger
+    internal class DebugLogger : BaseOutLogger
     {
         public DebugLogger() :
             base(s => System.Diagnostics.Debug.WriteLine(s))
         { }
     }
 
-    public abstract class BaseOutLogger : ILogger
+    internal abstract class BaseOutLogger : ILogger
     {
         protected Action<string> LogMethod { get; set; }
         public LogLevel Level { get; set; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Entity.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Neo4j.Driver.Internal
 {
-    public class Node : INode
+    internal class Node : INode
     {
         public long Id { get; }
         public IReadOnlyList<string> Labels { get; }
@@ -52,7 +52,7 @@ namespace Neo4j.Driver.Internal
         }
     }
 
-    public class Relationship : IRelationship
+    internal class Relationship : IRelationship
     {
         public long Id { get; }
         public string Type { get; }
@@ -101,7 +101,7 @@ namespace Neo4j.Driver.Internal
     /// for that relationship.This exists because the relationship has a direction between the two nodes that is
     /// separate and potentially different from the direction of the path.
     /// </summary>
-    public interface ISegment : IEquatable<ISegment>
+    internal interface ISegment : IEquatable<ISegment>
     {
         /// <summary>
         /// Gets the start node underlying this path segment.
@@ -117,7 +117,7 @@ namespace Neo4j.Driver.Internal
         IRelationship Relationship { get; }
     }
 
-    public class Segment : ISegment
+    internal class Segment : ISegment
     {
         public Segment(INode start, IRelationship rel, INode end)
         {
@@ -154,7 +154,7 @@ namespace Neo4j.Driver.Internal
         }
     }
 
-    public class Path : IPath
+    internal class Path : IPath
     {
         private readonly IReadOnlyList<ISegment> _segments;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/DiscardAllMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/DiscardAllMessage.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    class DiscardAllMessage:IRequestMessage
+    internal class DiscardAllMessage:IRequestMessage
     {
         public void Dispatch(IMessageRequestHandler messageRequestHandler)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    class FailureMessage : IMessage
+    internal class FailureMessage : IMessage
     {
         private readonly string _code;
         private readonly string _message;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessage.cs
@@ -16,12 +16,12 @@
 //  limitations under the License.
 namespace Neo4j.Driver.Internal.Messaging
 {
-    public interface IRequestMessage :IMessage
+    internal interface IRequestMessage :IMessage
     {
         void Dispatch(IMessageRequestHandler messageRequestHandler);
     }
 
-    public interface IMessage
+    internal interface IMessage
     {
         
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -20,7 +20,7 @@ using Neo4j.Driver.Internal.Result;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    public interface IMessageRequestHandler
+    internal interface IMessageRequestHandler
     {
         void HandleInitMessage(string clientNameAndVersion, IDictionary<string, object> authToken);
         void HandleRunMessage(string statement, IDictionary<string, object> parameters);
@@ -29,7 +29,7 @@ namespace Neo4j.Driver.Internal.Messaging
         void HandleResetMessage();
     }
 
-    public interface IMessageResponseHandler
+    internal interface IMessageResponseHandler
     {
         bool HasError { get; }
         Neo4jException Error { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System.Collections.Generic;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Result;
 
 namespace Neo4j.Driver.Internal.Messaging

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IgnoredMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IgnoredMessage.cs
@@ -16,7 +16,7 @@
 //  limitations under the License.
 namespace Neo4j.Driver.Internal.Messaging
 {
-    public class IgnoredMessage : IMessage
+    internal class IgnoredMessage : IMessage
     {
         public override string ToString()
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/InitMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/InitMessage.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    public class InitMessage : IRequestMessage
+    internal class InitMessage : IRequestMessage
     {
         private readonly IDictionary<string, object> _authToken;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/PullAllMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/PullAllMessage.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    class PullAllMessage : IRequestMessage
+    internal class PullAllMessage : IRequestMessage
     {
         public void Dispatch(IMessageRequestHandler messageRequestHandler)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/RecordMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/RecordMessage.cs
@@ -23,7 +23,7 @@ using Neo4j.Driver.Extensions;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    class RecordMessage : IMessage
+    internal class RecordMessage : IMessage
     {
         private object[] fields;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/ResetMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/ResetMessage.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
-    class ResetMessage:IRequestMessage
+    internal class ResetMessage:IRequestMessage
     {
         public void Dispatch(IMessageRequestHandler messageRequestHandler)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/BigEndianTargetBitConverter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/BigEndianTargetBitConverter.cs
@@ -23,7 +23,7 @@ namespace Neo4j.Driver.Internal.Packstream
     /// <summary>
     ///     Converts from/to big endian (target) to platform endian.
     /// </summary>
-    public class BigEndianTargetBitConverter : BitConverterBase
+    internal class BigEndianTargetBitConverter : BitConverterBase
     {
         /// <summary>
         ///     Converts the bytes to big endian.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/BitConverterBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/BitConverterBase.cs
@@ -20,7 +20,7 @@ using System.Text;
 
 namespace Neo4j.Driver.Internal.Packstream
 {
-    public abstract class BitConverterBase
+    internal abstract class BitConverterBase
     {
         /// <summary>
         ///     Converts a byte to bytes.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
@@ -23,7 +23,7 @@ using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.Packstream
 {
-    public class PackStream
+    internal class PackStream
     {
         public enum PackType
         {
@@ -653,13 +653,13 @@ namespace Neo4j.Driver.Internal.Packstream
         }
     }
 
-    public interface IWriter
+    internal interface IWriter
     {
         void Write(IRequestMessage requestMessage);
         void Flush();
     }
 
-    public interface IReader
+    internal interface IReader
     {
 //        bool HasNext();
         void Read(IMessageResponseHandler responseHandler);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
@@ -26,7 +26,7 @@ using Sockets.Plugin.Abstractions;
 
 namespace Neo4j.Driver.Internal.Packstream
 {
-    public class PackStreamMessageFormatV1
+    internal class PackStreamMessageFormatV1
     {
         private static BitConverterBase _bitConverter;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace Neo4j.Driver.Internal.Result
 {
-    public interface IResultBuilder
+    internal interface IResultBuilder
     {
         void Record(object[] fields);
         StatementResult Build();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/PeekingEnumerator.cs
@@ -21,14 +21,14 @@ using System.Collections.Generic;
 
 namespace Neo4j.Driver.Internal.Result
 {
-    public interface IPeekingEnumerator<T> : IEnumerator<T> where T : class
+    internal interface IPeekingEnumerator<T> : IEnumerator<T> where T : class
     {
         T Peek();
         void Consume();
         long Position { get; }
     }
 
-    public class PeekingEnumerator<T> : IPeekingEnumerator<T> where T:class
+    internal class PeekingEnumerator<T> : IPeekingEnumerator<T> where T:class
     {
         private IEnumerator<T> _enumerator;
         private T _cached;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
@@ -21,7 +21,7 @@ using Neo4j.Driver.Extensions;
 
 namespace Neo4j.Driver.Internal.Result
 {
-    public class Record : IRecord
+    internal class Record : IRecord
     {
         public object this[int index] => Values[Values.Keys.ToList()[index]];
         public object this[string key] => Values[key];

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -23,7 +23,7 @@ using static Neo4j.Driver.StatementType;
 
 namespace Neo4j.Driver.Internal.Result
 {
-    public class ResultBuilder : IResultBuilder
+    internal class ResultBuilder : IResultBuilder
     {
         private string[] _keys = new string[0];
         private readonly IList<Record> _records = new List<Record>();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -17,7 +17,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Extensions;
 using static Neo4j.Driver.StatementType;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.Internal.Result
     /// <summary>
     /// The result returned from the Neo4j instance
     /// </summary>
-    public class StatementResult : IStatementResult
+    internal class StatementResult : IStatementResult
     {
         private IResultSummary _summary;
         private readonly IPeekingEnumerator<Record> _enumerator;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/SummaryBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/SummaryBuilder.cs
@@ -74,7 +74,7 @@ namespace Neo4j.Driver.Internal.Result
         }
     }
 
-    public class Plan : IPlan
+    internal class Plan : IPlan
     {
         public Plan(string operationType, IDictionary<string, object> args, IList<string> identifiers, IList<IPlan> childPlans)
         {
@@ -98,7 +98,7 @@ namespace Neo4j.Driver.Internal.Result
         }
     }
 
-    public class ProfiledPlan : IProfiledPlan
+    internal class ProfiledPlan : IProfiledPlan
     {
         public ProfiledPlan(string operatorType, IDictionary<string, object> arguments, IList<string> identifiers, IList<IProfiledPlan> children, long dbHits, long records)
         {
@@ -135,7 +135,7 @@ namespace Neo4j.Driver.Internal.Result
         }
     }
 
-    public class Counters : ICounters
+    internal class Counters : ICounters
     {
 
         public bool ContainsUpdates => (
@@ -204,7 +204,7 @@ namespace Neo4j.Driver.Internal.Result
     /// <summary>
     /// This is a notifcation
     /// </summary>
-    public class Notification : INotification
+    internal class Notification : INotification
     {
         public string Code { get; }
         public string Title { get; }
@@ -232,7 +232,7 @@ namespace Neo4j.Driver.Internal.Result
 
     }
 
-    public class InputPosition : IInputPosition
+    internal class InputPosition : IInputPosition
     {
         public int Offset { get; }
         public int Line { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Result;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -23,7 +23,7 @@ using Neo4j.Driver.Internal.Result;
 
 namespace Neo4j.Driver.Internal
 {
-    public class Session : StatementRunner, IPooledSession
+    internal class Session : StatementRunner, IPooledSession
     {
         private readonly IConnection _connection;
         private Transaction _transaction;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/SessionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/SessionPool.cs
@@ -159,7 +159,7 @@ namespace Neo4j.Driver.Internal
     }
 
 
-    public interface IPooledSession : ISession
+    internal interface IPooledSession : ISession
     {
         Guid Id { get; }
         bool IsHealthy { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace Neo4j.Driver.Internal
 {
-    public abstract class StatementRunner : LoggerBase
+    internal abstract class StatementRunner : LoggerBase
     {
         protected StatementRunner(ILogger logger) : base(logger)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using Neo4j.Driver.Exceptions;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Result;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -23,7 +23,7 @@ using Neo4j.Driver.Internal.Result;
 
 namespace Neo4j.Driver.Internal
 {
-    public class Transaction : StatementRunner, ITransaction
+    internal class Transaction : StatementRunner, ITransaction
     {
         private State _state = State.Active;
         private readonly IConnection _connection;

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -43,7 +43,7 @@
     <Compile Include="IAuthToken.cs" />
     <Compile Include="Internal\AuthToken.cs" />
     <Compile Include="Internal\DebugLogger.cs" />
-    <Compile Include="Exceptions\Neo4jException.cs" />
+    <Compile Include="Neo4jException.cs" />
     <Compile Include="Extensions\Throw.cs" />
     <Compile Include="Extensions\ByteExtensions.cs" />
     <Compile Include="Extensions\Extensions.cs" />

--- a/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace Neo4j.Driver.Exceptions
+namespace Neo4j.Driver
 {
     /// <summary>
     /// The base class for all Neo4j exceptions.

--- a/Neo4j.Driver/Neo4j.Driver/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Properties/AssemblyInfo.cs
@@ -44,4 +44,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: InternalsVisibleTo("Neo4j.Driver.Tests"), InternalsVisibleTo("Neo4j.Driver.Tck.Tests")]
+[assembly: InternalsVisibleTo("Neo4j.Driver.Tests"), InternalsVisibleTo("Neo4j.Driver.IntegrationTests"), InternalsVisibleTo("Neo4j.Driver.Tck.Tests"), InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
All types that are not listed here: http://alpha.neohq.net/docs/dotnet-driver/html/f7d9eea1-5357-f1de-8a54-336a77141b6d.htm
was made internal with the internal keyword. 

I also moved the Neo4j exceptions to root namespace because it makes the Neo4jDriver easier to use by clients because they do not have to include two namespaces. I see the exceptions as common types and therefor they should be en root namespace. This is the norm for the standard C#/.NET framework. 

This is a "fix" for issue #40 
