### PR TITLE
Remove the controversial method `Single`

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -383,51 +383,6 @@ namespace Neo4j.Driver.Tests
             }
         }
 
-        public class SingleMethod
-        {
-            [Fact]
-            public void ShouldThrowInvalidOperationExceptionIfNoRecordFound()
-            {
-                var result = new StatementResult(new [] { "test" }, new ListBasedRecordSet(new List<IRecord>()));
-                var ex = Xunit.Record.Exception(() => result.Single());
-                ex.Should().BeOfType<InvalidOperationException>();
-                // INFO: Changed message because use of Enumerable.Single for simpler implementation 
-                ex.Message.Should().Be("Sequence contains no elements");
-            }
-
-            [Fact]
-            public void ShouldThrowInvalidOperationExceptionIfMoreThanOneRecordFound()
-            {
-                var result = ResultCreator.CreateResult(1, 2);
-                var ex = Xunit.Record.Exception(() => result.Single());
-                ex.Should().BeOfType<InvalidOperationException>();
-                // INFO: Changed message because use of Enumerable.Single for simpler implementation 
-                ex.Message.Should().Be("Sequence contains more than one element");
-            }
-
-            [Fact]
-            public void ShouldThrowInvalidOperationExceptionIfNotTheFistRecord()
-            {
-                var result = ResultCreator.CreateResult(1, 2);
-                var enumerator = result.GetEnumerator();
-                enumerator.MoveNext().Should().BeTrue();
-                enumerator.Current.Should().NotBeNull();
-
-                var ex = Xunit.Record.Exception(() => result.Single());
-                ex.Should().BeOfType<InvalidOperationException>();
-                ex.Message.Should().Be("The first record is already consumed.");
-            }
-
-            [Fact]
-            public void ShouldReturnRecordIfSingle()
-            {
-                var result = ResultCreator.CreateResult(1);
-                var record = result.Single();
-                record.Should().NotBeNull();
-                record.Keys.Count.Should().Be(1);
-            }
-        }
-
         public class PeekMethod
         {
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver/IStatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IStatementResult.cs
@@ -38,12 +38,6 @@ namespace Neo4j.Driver
         /// <exception cref="InvalidOperationException">Thrown if this is called before all the records have been visited.</exception>
         IResultSummary Summary { get; }
         /// <summary>
-        /// Return the first record in the result, failing if there is not exactly one record, or if this result has already been used to move past the first record.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if not exactly one result have been found, or if this result has already been used to move past the first record.</exception>
-        /// <returns>The single record in the result.</returns>
-        IRecord Single();
-        /// <summary>
         /// Investigate the next upcoming record without changing the current position in the result.
         /// </summary>
         /// <returns>The next record, or null if there is no next record</returns>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -69,16 +69,6 @@ namespace Neo4j.Driver.Internal.Result
 
         internal bool AtEnd => _recordSet.AtEnd;
 
-        public IRecord Single()
-        {
-            if (_recordSet.Position >= 0)
-            {
-                throw new InvalidOperationException("The first record is already consumed.");
-            }
-
-            return _recordSet.Records.Single();
-        }
-
         public IRecord Peek()
         {
             return _recordSet.Peek;


### PR DESCRIPTION
This is mainly because Linq already provides a [`Single`](https://msdn.microsoft.com/en-us/library/bb155325%28v=vs.100%29.aspx)method on Enumerable 
