### PR TITLE
Internal Position property removed from StatementResult because it is no longer needed after Single was removed

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -57,14 +57,6 @@ namespace Neo4j.Driver.Tests
             }
         }
 
-        public int Position
-        {
-            get
-            {
-                return _recordIndex - 1;
-            }
-        }
-
         public IEnumerable<IRecord> Records
         {
             get
@@ -145,7 +137,6 @@ namespace Neo4j.Driver.Tests
                 result.Consume();
                 result.Count().Should().Be(0);
                 result.Peek().Should().BeNull();
-                result.Position.Should().Be(3);
             }
 
             [Fact]
@@ -182,7 +173,6 @@ namespace Neo4j.Driver.Tests
 
                 result.Consume();
                 result.Count().Should().Be(0); // the records left after consume
-                result.Position.Should().Be(3);
 
                 result.GetEnumerator().Current.Should().BeNull();
                 result.GetEnumerator().MoveNext().Should().BeFalse();
@@ -274,8 +264,6 @@ namespace Neo4j.Driver.Tests
                 public bool AtEnd { get { throw new NotImplementedException(); } }
 
                 public IRecord Peek { get { throw new NotImplementedException(); } }
-
-                public int Position { get { throw new NotImplementedException(); } }
 
                 public IEnumerable<IRecord> Records
                 {
@@ -389,11 +377,9 @@ namespace Neo4j.Driver.Tests
             public void ShouldReturnNextRecordWithoutMovingCurrentRecord()
             {
                 var result = ResultCreator.CreateResult(1);
-                result.Position.Should().Be(-1);
                 var record = result.Peek();
                 record.Should().NotBeNull();
 
-                result.Position.Should().Be(-1);
                 result.GetEnumerator().Current.Should().BeNull();
             }
 
@@ -402,7 +388,6 @@ namespace Neo4j.Driver.Tests
             {
                 var result = ResultCreator.CreateResult(1);
                 result.Take(1).ToList();
-                result.Position.Should().Be(0);
                 var record = result.Peek();
                 record.Should().BeNull();
             }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IRecordSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IRecordSet.cs
@@ -15,14 +15,6 @@ namespace Neo4j.Driver.Internal.Result
         bool AtEnd { get; }
 
         /// <summary>
-        /// The position in the forward stream of records.
-        /// This is -1 before any records has been consumed.
-        /// This is the 0-indexed position of the just consumed record.
-        /// When there is no more records, this has the value of number of records (count).
-        /// </summary>
-        int Position { get; }
-
-        /// <summary>
         /// Peeks a record without consuming. 
         /// If all records has been consumed, this is null
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -87,8 +87,7 @@ namespace Neo4j.Driver.Internal.Result
         {
             return new StatementResult(
                 _keys, 
-                new RecordSet(RecordsStream, Peek, () => _recordIteratorIndex - 1, () => !HasMoreRecords),
-                () => _summaryBuilder.Build());
+                new RecordSet(RecordsStream, Peek, () => !HasMoreRecords), () => _summaryBuilder.Build());
         }
 
         public void CollectFields(IDictionary<string, object> meta)
@@ -275,27 +274,13 @@ namespace Neo4j.Driver.Internal.Result
         {
             private readonly Func<IEnumerable<Record>> _getRecords;
             private readonly Func<Record> _peekRecord;
-            private readonly Func<int> _getPosition;
             private readonly Func<bool> _atEnd;
 
-            public RecordSet(Func<IEnumerable<Record>> getRecords, Func<Record> peekRecord, Func<int> getPosition, Func<bool> atEnd)
+            public RecordSet(Func<IEnumerable<Record>> getRecords, Func<Record> peekRecord, Func<bool> atEnd)
             {
                 _getRecords = getRecords;
                 _peekRecord = peekRecord;
-                _getPosition = getPosition;
                 _atEnd = atEnd;
-            }
-
-            /// <summary>
-            /// Returns the current position of the last read record.
-            /// If no records have been read, this returns -1
-            /// </summary>
-            public int Position
-            {
-                get
-                {
-                    return _getPosition();
-                }
             }
 
             public bool AtEnd

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -34,11 +34,6 @@ namespace Neo4j.Driver.Internal.Result
 
         private IResultSummary _summary = null;
         
-        /// <summary>
-        /// This is only used in unittest => either the unittest is bad (testing implementation not interface) or the OOP design is bad.
-        /// </summary>
-        internal long Position => _recordSet.Position;
-
         public StatementResult(string[] keys, IRecordSet recordSet, Func<IResultSummary> getSummary = null)
         {
             Throw.ArgumentNullException.IfNull(keys, nameof(keys));


### PR DESCRIPTION
`Position` was only used for unittests (after `Single` was removed) and in those tests it did not contribute with anything new. So I think it is both safe and good to remove it :)

And nice that you are removing the `Single` method :)
