### PR TITLE
Bug fix for streaming records

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="DriverTests.cs" />
     <Compile Include="EntityTests.cs" />
     <Compile Include="Messaging\MessageTests.cs" />
+    <Compile Include="Result\RecordSetTests.cs" />
     <Compile Include="Result\ResultBuilderTests.cs" />
     <Compile Include="SessionPoolTests.cs" />
     <Compile Include="SessionTests.cs" />

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Neo4j.Driver.Internal.Result;
+using Xunit;
+using Record = Neo4j.Driver.Internal.Result.Record;
+
+namespace Neo4j.Driver.Tests.Result
+{
+    internal class ListBasedRecordSet : IRecordSet
+    {
+        private readonly IList<IRecord> _records;
+        private readonly RecordSet _recordSet;
+
+        public int Position => _recordSet.Position;
+
+        public ListBasedRecordSet(IList<IRecord> records)
+        {
+            _records = records;
+            _recordSet = new RecordSet(_records, ()=>AtEnd);
+        }
+
+        public bool AtEnd => _recordSet.Position >= _records.Count;
+        public IRecord Peek()
+        {
+            return _recordSet.Peek();
+        }
+
+        public IEnumerable<IRecord> Records()
+        {
+            return _recordSet.Records();
+        }
+    }
+
+    internal static class RecordCreator
+    {
+        public static IList<string> CreateKeys(int keySize=1)
+        {
+            var keys = new List<string>(keySize);
+            for (int i = 0; i < keySize; i++)
+            {
+                keys.Add($"key{i}");
+            }
+            return keys;
+        }
+
+        public static IList<IRecord> CreateRecords(int recordSize, int keySize=1)
+        {
+            var keys = CreateKeys(keySize);
+            return CreateRecords(recordSize, keys);
+        }
+
+        public static IList<IRecord> CreateRecords(int recordSize, IList<string> keys)
+        {
+            var records = new List<IRecord>(recordSize);
+
+
+            for (int j = 0; j < recordSize; j++)
+            {
+                var values = new List<object>();
+                for (int i = 0; i < keys.Count; i++)
+                {
+                    values.Add($"record{j}:key{i}");
+                }
+                records.Add(new Record(keys.ToArray(), values.ToArray()));
+            }
+            return records;
+        } 
+    }
+
+    public class RecordSetTests
+    {
+        public class RecordMethod
+        {
+            [Fact]
+            public void ShouldReturnRecordsInOrder()
+            {
+                var records = RecordCreator.CreateRecords(5);
+                var recordSet = new ListBasedRecordSet(records);
+
+                int i = 0;
+                foreach (var record in recordSet.Records())
+                {
+                    record[0].As<string>().Should().Be($"record{i++}:key0");
+                }
+                i.Should().Be(5);
+            }
+
+            [Fact]
+            public void ShouldReturnRecordsAddedLatter()
+            {
+                var keys = RecordCreator.CreateKeys();
+                var records = RecordCreator.CreateRecords(5, keys);
+                var recordSet = new ListBasedRecordSet(records);
+
+                // I add a new record after RecordSet is created
+                var newRecord = new Record(keys.ToArray(), new object[] {"record5:key0"});
+                records.Add(newRecord);
+
+                int i = 0;
+                foreach (var record in recordSet.Records())
+                {
+                    record[0].As<string>().Should().Be($"record{i++}:key0");
+                }
+                i.Should().Be(6);
+            }
+        }
+
+        public class PeekMethod
+        {
+            [Fact]
+            public void ShouldReturnNextRecordWithoutMovingCurrentRecord()
+            {
+                var records = RecordCreator.CreateRecords(5);
+                var recordSet = new ListBasedRecordSet(records);
+
+                var record = recordSet.Peek();
+                record.Should().NotBeNull();
+                record[0].As<string>().Should().Be("record0:key0");
+
+                // not moving further no matter how many times are called
+                record = recordSet.Peek();
+                record.Should().NotBeNull();
+                record[0].As<string>().Should().Be("record0:key0");
+            }
+
+            [Fact]
+            public void ShouldReturnNextRecordAfterNextWithoutMovingCurrentRecord()
+            {
+                var records = RecordCreator.CreateRecords(5);
+                var recordSet = new ListBasedRecordSet(records);
+
+                recordSet.Records().Take(1).ToList();
+                var record = recordSet.Peek();
+                record.Should().NotBeNull();
+                record[0].As<string>().Should().Be("record1:key0");
+
+                // not moving further no matter how many times are called
+                record = recordSet.Peek();
+                record.Should().NotBeNull();
+                record[0].As<string>().Should().Be("record1:key0");
+            }
+
+            [Fact]
+            public void ShouldReturnNullIfAtEnd()
+            {
+                var records = RecordCreator.CreateRecords(5);
+                var recordSet = new ListBasedRecordSet(records);
+                recordSet.Records().Take(4).ToList(); // [0, 1, 2, 3]
+
+                var record = recordSet.Peek();
+                record.Should().NotBeNull();
+                record[0].As<string>().Should().Be("record4:key0");
+
+                var moveNext = recordSet.Records().GetEnumerator().MoveNext();
+                moveNext.Should().BeTrue();
+
+                record.Should().NotBeNull();
+                record[0].As<string>().Should().Be("record4:key0");
+
+                record = recordSet.Peek();
+                record.Should().BeNull();
+            }
+
+            [Fact]
+            public void ShouldBeTheSameWithEnumeratorMoveNextCurrent()
+            {
+                var records = RecordCreator.CreateRecords(2);
+                var recordSet = new ListBasedRecordSet(records);
+
+                IRecord record;
+                IEnumerator<IRecord> enumerator;
+                for (int i = 0; i < 2; i++)
+                {
+                    record = recordSet.Peek();
+                    record.Should().NotBeNull();
+                    record[0].As<string>().Should().Be($"record{i}:key0");
+
+                    enumerator = recordSet.Records().GetEnumerator();
+                    enumerator.MoveNext().Should().BeTrue();
+
+                    // peeked record = current
+                    enumerator.Current[0].As<string>().Should().Be($"record{i}:key0");
+                }
+
+                record = recordSet.Peek();
+                record.Should().BeNull();
+
+                enumerator = recordSet.Records().GetEnumerator();
+                enumerator.MoveNext().Should().BeFalse();
+                enumerator.Current.Should().BeNull();
+            }
+            
+        }
+
+        public class RecordNavigation
+        {
+            [Fact]
+            public void EnumeratorResetShouldDoNothing()
+            {
+                var records = RecordCreator.CreateRecords(5);
+                var recordSet = new ListBasedRecordSet(records);
+
+                var ex = Xunit.Record.Exception(()=>recordSet.Records().GetEnumerator().Reset());
+                ex.Should().BeOfType<NotSupportedException>();
+            }
+
+            [Fact]
+            public void ShouldGetTheFirstRecordAndMoveToNextPosition()
+            {
+                var records = RecordCreator.CreateRecords(5);
+                var recordSet = new ListBasedRecordSet(records);
+                var recordStream = recordSet.Records();
+
+                var record = recordStream.First();
+                record[0].As<string>().Should().Be("record0:key0");
+
+                record = recordStream.First();
+                record[0].As<string>().Should().Be("record1:key0");
+            }
+
+            [Fact]
+            public void ShouldAlwaysAdvanceRecordPosition()
+            {
+                var recordSet = new ListBasedRecordSet(RecordCreator.CreateRecords(5));
+                var recordStream = recordSet.Records();
+
+                var enumerable = recordStream.Take(1);
+                var records = recordStream.Take(2).ToList();
+
+                records[0][0].As<string>().Should().Be("record0:key0");
+                records[1][0].As<string>().Should().Be("record1:key0");
+
+                records = enumerable.ToList();
+                records[0][0].As<string>().Should().Be("record2:key0");
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Result;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IRecordSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IRecordSet.cs
@@ -18,11 +18,11 @@ namespace Neo4j.Driver.Internal.Result
         /// Peeks a record without consuming. 
         /// If all records has been consumed, this is null
         /// </summary>
-        IRecord Peek { get; }
+        IRecord Peek();
 
         /// <summary>
         /// Returns an IEnumerable of records.
         /// </summary>
-        IEnumerable<IRecord> Records { get; }
+        IEnumerable<IRecord> Records();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/RecordSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/RecordSet.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Neo4j.Driver.Internal.Result
+{
+    internal class RecordSet : IRecordSet
+    {
+        private readonly Func<bool> _atEnd;
+        internal int Position = 0;
+        private readonly IList<IRecord> _records;
+
+        public RecordSet(IList<IRecord> records, Func<bool> atEnd)
+        {
+            _records = records;
+            _atEnd = atEnd;
+        }
+
+        public bool AtEnd => _atEnd();
+
+        public IEnumerable<IRecord> Records()
+        {
+            while (!AtEnd || Position <= _records.Count)
+            {
+                while (Position == _records.Count)
+                {
+                    Task.Delay(50).Wait();
+                    if (AtEnd && Position == _records.Count)
+                        yield break;
+                }
+
+                yield return _records[Position++];
+//                Position++;
+            }
+        }
+
+        public IRecord Peek()
+        {
+            while (Position >= _records.Count) // Peeking record not received
+            {
+                if (AtEnd && Position >= _records.Count)
+                {
+                    return null;
+                }
+
+                Task.Delay(50).Wait();
+            }
+
+            return _records[Position];
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -66,12 +66,12 @@ namespace Neo4j.Driver.Internal.Result
 
         public IRecord Peek()
         {
-            return _recordSet.Peek;
+            return _recordSet.Peek();
         }
 
         public IResultSummary Consume()
         {
-            foreach (var record in _recordSet.Records)
+            foreach (var record in _recordSet.Records())
             {
                 // Do nothing, just consume the records
             }
@@ -80,7 +80,7 @@ namespace Neo4j.Driver.Internal.Result
 
         public IEnumerator<IRecord> GetEnumerator()
         {
-            return _recordSet.Records.GetEnumerator();
+            return _recordSet.Records().GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -43,6 +43,7 @@
     <Compile Include="IAuthToken.cs" />
     <Compile Include="Internal\AuthToken.cs" />
     <Compile Include="Internal\DebugLogger.cs" />
+    <Compile Include="Internal\Result\RecordSet.cs" />
     <Compile Include="Neo4jException.cs" />
     <Compile Include="Extensions\Throw.cs" />
     <Compile Include="Extensions\ByteExtensions.cs" />


### PR DESCRIPTION
Fix the bug where the pos/index in record stream is not moving forward correctly.
Fix the bug where the peek method starts from record 1 rather than 0.

Before the fix, some Linq methods will not consume the record when the record has been visited.
This is very wrong as it enables the user to buffer the pos in the stream and revisit it latter.
The bug is caused by not forwarding the current pos/index in the stream before yielding the record back.

The peek method now would peek the record that will be returned by calling Enumerator.MoveNext()
which means it will return record in pos 0 before Enumerator.MoveNext() is called the first time.
