### PR TITLE
Making an interface for the Driver 

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
@@ -290,7 +290,7 @@ namespace Neo4j.Driver.Examples
 
         private void ClearDatabase()
         {
-            Driver driver = GraphDatabase.Driver("bolt://localhost:7687");
+            IDriver driver = GraphDatabase.Driver("bolt://localhost:7687");
             var session = driver.Session();
             var result = session.Run("MATCH (n) DETACH DELETE n RETURN count(*)");
             result.ToList();

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TckStepsBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TckStepsBase.cs
@@ -13,7 +13,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
     public class TckStepsBase
     {
         public const string Url = "bolt://localhost:7687";
-        protected static Driver Driver;
+        protected static IDriver Driver;
         protected static INeo4jInstaller Installer;
 
         protected static object GetValue(string type, string value)

--- a/Neo4j.Driver/Neo4j.Driver/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Driver.cs
@@ -30,7 +30,7 @@ namespace Neo4j.Driver
     ///     configured by the <see cref="Config.MaxIdleSessionPoolSize" /> property on the <see cref="Config" /> when creating the
     ///     Driver.
     /// </remarks>
-    public class Driver : IDisposable
+    internal class Driver : IDriver
     {
         private SessionPool _sessionPool;
 

--- a/Neo4j.Driver/Neo4j.Driver/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/GraphDatabase.cs
@@ -39,7 +39,7 @@ namespace Neo4j.Driver
         /// <returns>A new <see cref="Neo4j.Driver.Driver" /> instance specified by the <paramref name="uri" /></returns>
         /// <remarks>Ensure you provide the protocol for the <paramref name="uri" /></remarks>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c></exception>
-        public static Driver Driver(Uri uri, Config config = null)
+        public static IDriver Driver(Uri uri, Config config = null)
         {
             return Driver(uri, AuthTokens.None, config ?? Config.DefaultConfig);
         }
@@ -59,7 +59,7 @@ namespace Neo4j.Driver
         /// <returns>A new <see cref="Neo4j.Driver.Driver" /> instance specified by the <paramref name="uri" /></returns>
         /// <remarks>Ensure you provide the protocol for the <paramref name="uri" /></remarks>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c></exception>
-        public static Driver Driver(string uri, Config config = null)
+        public static IDriver Driver(string uri, Config config = null)
         {
             return Driver(new Uri(uri), AuthTokens.None, config ?? Config.DefaultConfig);
         }
@@ -74,7 +74,7 @@ namespace Neo4j.Driver
         /// <param name="authToken">Authentication to use, <see cref="AuthTokens" /></param>
         /// <param name="config">User defined configuration</param>
         /// <returns>A new driver to the database instance specified by the URI</returns>
-        public static Driver Driver(string uri, IAuthToken authToken, Config config = null)
+        public static IDriver Driver(string uri, IAuthToken authToken, Config config = null)
         {
             return Driver(new Uri(uri), authToken, config ?? Config.DefaultConfig);
         }
@@ -89,7 +89,7 @@ namespace Neo4j.Driver
         /// <param name="authToken">Authentication to use, <see cref="AuthTokens" /></param>
         /// <param name="config">User defined configuration</param>
         /// <returns>A new driver to the database instance specified by the URI</returns>
-        public static Driver Driver(Uri uri, IAuthToken authToken, Config config = null)
+        public static IDriver Driver(Uri uri, IAuthToken authToken, Config config = null)
         {
             return new Driver(uri, authToken, config ?? Config.DefaultConfig);
         }

--- a/Neo4j.Driver/Neo4j.Driver/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IDriver.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Neo4j.Driver
+{
+    /// <summary>
+    ///     The Driver instance maintains the connections with the Neo4j database, providing an access point via the
+    ///     <see cref="Session" /> method.
+    /// </summary>
+    /// <remarks>
+    ///     The Driver maintains a session pool buffering the <see cref="ISession" />s created by the user. The size of the
+    ///     buffer can be
+    ///     configured by the <see cref="Config.MaxIdleSessionPoolSize" /> property on the <see cref="Config" /> when creating the
+    ///     Driver.
+    /// </remarks>
+    public interface IDriver : IDisposable
+    {
+        /// <summary>
+        ///     Gets the <see cref="Uri" /> of the Neo4j database.
+        /// </summary>
+        Uri Uri { get; }
+
+        /// <summary>
+        ///     Establish a session with Neo4j instance
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="ISession" /> that could be used to <see cref="IStatementRunner.Run(Statement)" /> a statement or begin a
+        ///     transaction
+        /// </returns>
+        ISession Session();
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -41,6 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IAuthToken.cs" />
+    <Compile Include="IDriver.cs" />
     <Compile Include="Internal\AuthToken.cs" />
     <Compile Include="Internal\DebugLogger.cs" />
     <Compile Include="Internal\Result\RecordSet.cs" />


### PR DESCRIPTION
Reasons for doing this:
- The code is more complete, every type used except the `GraphDatabase` is an interface
- It is easier to make code that can pass an `IDriver` instance to a class and then make unittests for this class.
- In the future, it could be possible to have different driver implementations that the `GraphDatabase` returns depending on settings etc. - without breaking existing client code.
