### PR TITLE
Bug fix for default debug logger

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedInputTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedInputTests.cs
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Tests
             {
                 var clientMock = new Mock<ITcpSocketClient>();
                 var loggerMock = new Mock<ILogger>();
-                loggerMock.Setup(x => x.Trace(It.IsAny<string>(), It.IsAny<object[]>()))
+                loggerMock.Setup(x => x.Trace(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<int>(), It.IsAny<int>()))
                     .Callback<string, object[]>((s, o) => _output.WriteLine(s +  ((byte[])o[0]).ToHexString(showX:true)));
                 TestHelper.TcpSocketClientSetup.SetupClientReadStream(clientMock, input);
 
@@ -84,7 +84,7 @@ namespace Neo4j.Driver.Tests
                 byte[] actual = new byte[3];
                 chunkedInput.ReadBytes(actual);
                 actual.Should().Equal(correctValue);
-                loggerMock.Verify(x => x.Trace("S: ", It.IsAny<byte[]>()), Times.Exactly(4));
+                loggerMock.Verify(x => x.Trace("S: ", It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Exactly(4));
             }
 
             [Theory]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/DebugLoggerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/DebugLoggerTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) 2002-2016 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Neo4j.Driver.Internal;
+using Xunit;
+
+namespace Neo4j.Driver.Tests
+{
+    public class DebugLoggerTests
+    {
+        internal class StringLogger : BaseOutLogger
+        {
+            public StringLogger(List<string> lines):base(lines.Add)
+            { }
+        }
+
+        public class TraceMethod
+        {
+            [Fact]
+            public void ShouldLogByteBufferCorrectly()
+            {
+                byte[] buffer = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+                var lines = new List<string>();
+
+                var logger = new StringLogger(lines) {Level = LogLevel.Trace};
+                logger.Trace("message ", buffer, 0, 10);
+
+                lines.Count.Should().Be(1);
+                lines[0].Should().Be("[Trace] => message 01 02 03 04 05 06 07 08 09 0A");
+            }
+
+            [Fact]
+            public void ShouldThrowExceptionIfBufferOffsetAndCountIsNotSpecified()
+            {
+                byte[] buffer = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+                var lines = new List<string>();
+
+                var logger = new StringLogger(lines) { Level = LogLevel.Trace };
+                var ex = Record.Exception(() =>logger.Trace("message ", buffer));
+
+                ex.Should().BeOfType<ArgumentOutOfRangeException>();
+            }
+        }
+
+        public class LogMethod
+        {
+            [Fact]
+            public void ShouldLogAllMessages()
+            {
+                byte[] buffer = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+                var lines = new List<string>();
+
+                var logger = new StringLogger(lines) { Level = LogLevel.Trace };
+                logger.Debug("message ", buffer, "string after buffer", 10);
+
+                lines.Count.Should().Be(1);
+                lines[0].Should().Be("[Debug] => message [01 02 03 04 05 06 07 08 09 0A, string after buffer, 10]");
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -89,6 +89,7 @@
   <ItemGroup>
     <Compile Include="Connector\ChunkedOutputTest.cs" />
     <Compile Include="Connector\MessageResponseHandlerTests.cs" />
+    <Compile Include="DebugLoggerTests.cs" />
     <Compile Include="DriverTests.cs" />
     <Compile Include="EntityTests.cs" />
     <Compile Include="Messaging\MessageTests.cs" />

--- a/Neo4j.Driver/Neo4j.Driver/ILogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ILogger.cs
@@ -57,7 +57,11 @@ namespace Neo4j.Driver
 
         /// <summary>Log a message at <see cref="LogLevel.Trace"/> level</summary>
         /// <param name="message">The message.</param>
-        /// <param name="restOfMessage">Any <paramref name="restOfMessage"/> parts of the message, including (but not limited to) bytes sent and received over the connection.</param>
+        /// <param name="restOfMessage">
+        /// Any <paramref name="restOfMessage"/> parts of the message, 
+        /// including (but not limited to) byte buffer to send/receive data over the connection, 
+        /// offset in byte buffer, the length of bytes in the buffer.
+        /// </param>
         void Trace(string message, params object[] restOfMessage);
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
@@ -133,7 +133,7 @@ namespace Neo4j.Driver.Internal.Connector
                 throw new Neo4jException($"Expect {buffer.Length}, but got {numberOfbytesRead}");
             }
 
-            _logger?.Trace("S: ", buffer);
+            _logger?.Trace("S: ", buffer, 0, buffer.Length);
         }
 
         public void ReadMessageTail()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
@@ -47,7 +47,23 @@ namespace Neo4j.Driver.Internal
                 return;
             }
 
-            LogMethod($"[{level}] => {message}{ObjectToString(restOfMessage)}");
+            if (level == LogLevel.Trace)
+            {
+                LogMethod($"[{level}] => {message}{ByteBufferToString(restOfMessage)}");
+            }
+            else
+            {
+                LogMethod($"[{level}] => {message}{ObjectToString(restOfMessage)}");
+            }
+        }
+
+        private string ByteBufferToString(object[] restOfMessage)
+        {
+            Throw.ArgumentOutOfRangeException.IfValueLessThan(restOfMessage.Length, 3, nameof(restOfMessage.Length));
+            var buffer = (byte[])restOfMessage[0];
+            var offset = (int) restOfMessage[1];
+            var count = (int) restOfMessage[2];
+            return buffer.ToHexString(offset, count);
         }
 
         private string ObjectToString(object o)

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -94,7 +94,7 @@
     <Compile Include="IRecord.cs" />
     <Compile Include="IStatementResult.cs" />
     <Compile Include="IResultSummary.cs" />
-    <Compile Include="Logger.cs" />
+    <Compile Include="ILogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Internal\Result\Record.cs" />
     <Compile Include="Internal\Result\StatementResult.cs" />


### PR DESCRIPTION
Fix the bug where the default debug logger `Trace` will print the whole input buffer out
Now after the fix, the `Trace` method prints only the byte section that will be sent
