### PR TITLE
Fix wrongly read a incoming chunk that is greater than 0x7FFF (32767)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedOutputTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedOutputTest.cs
@@ -69,7 +69,6 @@ namespace Neo4j.Driver.Tests
                 mockWriteStream.Verify(x => x.Flush(), Times.Exactly(3));
 
             }
-            // new byte[0];
         }
     } 
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
@@ -108,7 +108,7 @@ namespace Neo4j.Driver.Internal.Connector
                 // head
                 ReadSpecifiedSize(_headTailBuffer);
 
-                var chunkSize = _bitConverter.ToInt16(_headTailBuffer);
+                var chunkSize = _bitConverter.ToUInt16(_headTailBuffer);
 
                 // chunk
                 var chunk = new byte[chunkSize];

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/BitConverterBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/BitConverterBase.cs
@@ -126,6 +126,17 @@ namespace Neo4j.Driver.Internal.Packstream
         }
 
         /// <summary>
+        ///     Converts an byte array to a unsigned short.
+        /// </summary>
+        /// <param name="bytes">The byte array to convert.</param>
+        /// <returns>A unsigned short converted from the byte array.</returns>
+        public ushort ToUInt16(byte[] bytes)
+        {
+            bytes = ToPlatformEndian(bytes);
+            return BitConverter.ToUInt16(bytes, 0);
+        }
+
+        /// <summary>
         ///     Converts an byte array to a int (Int32).
         /// </summary>
         /// <param name="bytes">The byte array to convert.</param>


### PR DESCRIPTION
Fix the bug that the driver would wrongly read a incoming chunk that is greater than 0x7FFF (32767)

The bug would rarely happen as the default size of the chunking buffer in server is 8192
