### PR TITLE
Fixed the null exception bug of bitConverter in concurrent executions

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedInputTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedInputTests.cs
@@ -43,7 +43,7 @@ namespace Neo4j.Driver.Tests
                 var clientMock = new Mock<ITcpSocketClient>();
                 TestHelper.TcpSocketClientSetup.SetupClientReadStream(clientMock, response);
 
-                var chunkedInput = new ChunkedInputStream(clientMock.Object, new BigEndianTargetBitConverter(), null);
+                var chunkedInput = new ChunkedInputStream(clientMock.Object, null);
                 var actual = chunkedInput.ReadSByte();
                 actual.Should().Be(correctValue); //, $"Got: {actual}, expected: {correctValue}");
             }
@@ -66,7 +66,7 @@ namespace Neo4j.Driver.Tests
                 var clientMock = new Mock<ITcpSocketClient>();
                 TestHelper.TcpSocketClientSetup.SetupClientReadStream(clientMock, input);
 
-                var chunkedInput = new ChunkedInputStream(clientMock.Object, new BigEndianTargetBitConverter(), null);
+                var chunkedInput = new ChunkedInputStream(clientMock.Object, null);
                 byte[] actual = new byte[3];
                 chunkedInput.ReadBytes( actual );
                 actual.Should().Equal(correctValue);
@@ -82,7 +82,7 @@ namespace Neo4j.Driver.Tests
                     .Callback<string, object[]>((s, o) => _output.WriteLine(s +  ((byte[])o[0]).ToHexString(showX:true)));
                 TestHelper.TcpSocketClientSetup.SetupClientReadStream(clientMock, input);
 
-                var chunkedInput = new ChunkedInputStream(clientMock.Object, new BigEndianTargetBitConverter(), loggerMock.Object);
+                var chunkedInput = new ChunkedInputStream(clientMock.Object, loggerMock.Object);
                 byte[] actual = new byte[3];
                 chunkedInput.ReadBytes(actual);
                 actual.Should().Equal(correctValue);
@@ -97,7 +97,7 @@ namespace Neo4j.Driver.Tests
                 var clientMock = new Mock<ITcpSocketClient>();
                 TestHelper.TcpSocketClientSetup.SetupClientReadStream(clientMock, input);
 
-                var chunkedInput = new ChunkedInputStream(clientMock.Object, new BigEndianTargetBitConverter(), null, 1);
+                var chunkedInput = new ChunkedInputStream(clientMock.Object, null, 1);
                 byte[] actual = new byte[3];
                 chunkedInput.ReadBytes(actual);
                 actual.Should().Equal(correctValue);
@@ -132,7 +132,7 @@ namespace Neo4j.Driver.Tests
                     var clientMock = new Mock<ITcpSocketClient>();
                     TestHelper.TcpSocketClientSetup.SetupClientReadStream(clientMock, input);
 
-                    var chunkedInput = new ChunkedInputStream(clientMock.Object, new BigEndianTargetBitConverter(), null);
+                    var chunkedInput = new ChunkedInputStream(clientMock.Object, null);
                     byte[] actual = new byte[chunkHeaderSize];
                     chunkedInput.ReadBytes(actual);
                     for (int j = 0; j < actual.Length; j++)

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedOutputTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/ChunkedOutputTest.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Tests
             [Fact]
             public void ShouldThrowExceptionIfChunkSizeLessThan8()
             {
-                var ex = Xunit.Record.Exception(() => new ChunkedOutputStream(null, null, null, 7));
+                var ex = Xunit.Record.Exception(() => new ChunkedOutputStream(null, null, 7));
                 ex.Should().BeOfType<ArgumentOutOfRangeException>();
             }
 
@@ -49,7 +49,7 @@ namespace Neo4j.Driver.Tests
                 mockClient.Setup(x => x.WriteStream).Returns(mockWriteStream.Object);
                 var mockLogger = new Mock<ILogger>();
 
-                var chunker = new ChunkedOutputStream(mockClient.Object, new BigEndianTargetBitConverter(), mockLogger.Object, 8);
+                var chunker = new ChunkedOutputStream(mockClient.Object, mockLogger.Object, 8);
 
                 byte[] bytes = new byte[10];
                 for (int i = 0; i < bytes.Length; i++)

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
@@ -72,7 +72,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 writer.Write(new InitMessage("a", new Dictionary<string, object>()));
                 writer.Flush();
 
@@ -85,7 +85,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 writer.Write(new RunMessage("RETURN 1 AS num"));
                 writer.Flush();
                 mocks.VerifyWrite(
@@ -117,7 +117,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"integer", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -133,7 +133,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -150,7 +150,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -167,7 +167,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -187,7 +187,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -203,7 +203,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -219,7 +219,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -235,7 +235,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -252,7 +252,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -269,7 +269,7 @@ namespace Neo4j.Driver.Tests
                 var mocks = new Mocks();
 
                 var writer =
-                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, new BigEndianTargetBitConverter(), null).Writer;
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> {{"value", value}};
 
                 writer.Write(new RunMessage("", values));
@@ -335,9 +335,7 @@ namespace Neo4j.Driver.Tests
                     TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes.ToArray());
 
                     PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                        new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                            null)
-                            .Reader;
+                        new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                     var real = reader.UnpackValue();
                     Assert.Equal(expected, real);
                 }
@@ -352,9 +350,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var real = reader.UnpackValue();
                         IRelationship rel = real as IRelationship;
                         rel.Should().NotBeNull();
@@ -374,9 +370,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var node = reader.UnpackValue();
                         INode n = node as INode;
                         n.Should().NotBeNull();
@@ -394,9 +388,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -421,9 +413,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -448,9 +438,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -477,9 +465,8 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null)
+.Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -515,9 +502,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -560,9 +545,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -609,9 +592,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();
@@ -658,9 +639,7 @@ namespace Neo4j.Driver.Tests
                         TestHelper.TcpSocketClientSetup.SetupClientReadStream(mockTcpSocketClient, bytes);
 
                         PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
-                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, new BigEndianTargetBitConverter(),
-                                null)
-                                .Reader;
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
                         var path = reader.UnpackValue();
                         IPath p = path as IPath;
                         p.Should().NotBeNull();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackerTests.cs
@@ -75,7 +75,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackNullSuccessfully()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.PackNull();
                     mocks.VerifyWrite(PackStream.NULL);
@@ -90,7 +90,7 @@ namespace Neo4j.Driver.Tests
 //                public void ShouldUnpacPawBytesSuccessfully()
 //                {
 //                    var mocks = new Mocks();
-//                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+//                    var u = new PackStream.Packer(mocks.OutputStream);
 //
 //                    var bytes = new byte[] { 1, 2, 3 };
 //                    u.PackRaw(bytes);
@@ -114,7 +114,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackLongSuccessfully(long input, byte marker, string expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack(input);
                     mocks.VerifyWrite(marker);
@@ -132,7 +132,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackDoubleSuccessfully(double input, string expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack(input);
                     mocks.VerifyWrite(PackStream.FLOAT_64);
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackBoolSuccessfully(bool input)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack(input);
                     if (input)
@@ -169,7 +169,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackNullStringSuccessfully()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack((string) null);
                     mocks.VerifyWrite(PackStream.NULL);
@@ -180,7 +180,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackEmptyStringSuccessfully()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack(string.Empty);
                     mocks.VerifyWrite(PackStream.TINY_STRING | 0);
@@ -194,7 +194,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackStringSuccessfully(int size, byte marker, byte[] sizeByte)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     var input = new string('a', size);
                     var expected = new byte[size];
@@ -215,7 +215,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackUnicodeStringSuccessfully(int size, byte marker, byte[] sizeByte)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     var input = new string('å', size);
                     var expected = new byte[size*2];
@@ -238,7 +238,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackNullBytesSuccessfully()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack((byte[]) null);
                     mocks.VerifyWrite(PackStream.NULL);
@@ -249,7 +249,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackEmptyByteSuccessfully()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     u.Pack(new byte[] {});
                     mocks.VerifyWrite(PackStream.BYTES_8, new byte[] {0});
@@ -263,7 +263,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackStringSuccessfully(int size, byte marker, byte[] sizeByte)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     var expected = new byte[size];
                     for (int i = 0; i < size; i++)
@@ -284,7 +284,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsNull()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack((object) null);
 
                     mocks.VerifyWrite(PackStream.NULL);
@@ -296,7 +296,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackNullableBool(bool? input, byte expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack(input);
                     mocks.VerifyWrite(expected);
                 }
@@ -307,7 +307,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackNullableAsNull(sbyte? input, byte expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack(input);
                     mocks.VerifyWrite(expected);
                 }
@@ -324,7 +324,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackNumbersAsLong(object input, byte expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack(input);
                     mocks.VerifyWrite(expected);
                 }
@@ -336,7 +336,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackFloatNumbersAsDouble(object input, byte expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack(input);
                     mocks.VerifyWrite(expected);
                 }
@@ -345,7 +345,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackDecimalNumbersAsDouble()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     decimal input = 1.34m;
                     u.Pack((object) input);
                     mocks.VerifyWrite(PackStream.FLOAT_64);
@@ -356,7 +356,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsByteArray()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     var input = new byte[] {1, 2, 3};
                     u.Pack((object) input);
                     mocks.VerifyWrite(PackStream.BYTES_8, 3);
@@ -366,7 +366,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackCharAsString()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     char input = 'a';
                     u.Pack((object) input);
                     mocks.VerifyWrite(PackStream.TINY_STRING | 1);
@@ -376,7 +376,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsString()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     string input = "abc";
                     u.Pack((object) input);
                     mocks.VerifyWrite(PackStream.TINY_STRING | 3);
@@ -386,7 +386,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsList()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     IList<object> list = new List<object>();
                     list.Add(1);
@@ -405,7 +405,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackArrayAsList()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     int[] list = new int[2];
                     list[0]=1;
@@ -422,7 +422,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsDictionary()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     IDictionary<object, object> dic = new Dictionary<object, object>();
                     dic.Add(true, "a");
@@ -438,7 +438,7 @@ namespace Neo4j.Driver.Tests
                 [Fact]
                 public void ShouldThrowExceptionIfTypeUnknown()
                 {
-                    var packer = new PackStream.Packer(null, null);
+                    var packer = new PackStream.Packer(null);
                     var ex = Xunit.Record.Exception(() => packer.Pack(new {Name = "Test"}));
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
                 }
@@ -450,7 +450,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsNullIfListIsNull()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack((IList) null);
 
                     mocks.VerifyWrite(PackStream.NULL);
@@ -464,7 +464,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackListHeaderCorrectly(int size, byte marker, byte[] expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.PackListHeader(size);
 
                     mocks.VerifyWrite(marker, expected);
@@ -474,7 +474,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackListOfDifferentTypeCorrectly()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     var list = new List<object>();
                     list.Add(1);
@@ -496,7 +496,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackAsNullIfDictionaryIsNull()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.Pack((IDictionary) null);
 
                     mocks.VerifyWrite(PackStream.NULL);
@@ -510,7 +510,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackListHeaderCorrectly(int size, byte marker, byte[] expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.PackMapHeader(size);
 
                     mocks.VerifyWrite(marker, expected);
@@ -520,7 +520,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackMapOfDifferentTypeCorrectly()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
 
                     IDictionary<object, object> dic = new Dictionary<object, object>();
                     dic.Add(true, "a");
@@ -542,7 +542,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackStructHeaderCorrectly(int size, byte marker, byte[] expected)
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.PackStructHeader(size, 0x77);
 
                     mocks.VerifyWrite(marker, expected);
@@ -552,7 +552,7 @@ namespace Neo4j.Driver.Tests
                 public void ShouldPackStructHeaderStruct16Correctly()
                 {
                     var mocks = new Mocks();
-                    var u = new PackStream.Packer(mocks.OutputStream, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Packer(mocks.OutputStream);
                     u.PackStructHeader(short.MaxValue, 0x77);
 
                     mocks.VerifyWrite(PackStream.STRUCT_16, new byte[] { 0x7F, 0xFF });
@@ -562,7 +562,7 @@ namespace Neo4j.Driver.Tests
                 [Fact]
                 public void ShouldThrowExceptionIfSizeIsGreaterThanShortMax()
                 {
-                    var packer = new PackStream.Packer(null, null);
+                    var packer = new PackStream.Packer(null);
                     var ex = Xunit.Record.Exception(() => packer.PackStructHeader(short.MaxValue +1, 0x1));
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
                 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/UnpackerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/UnpackerTests.cs
@@ -36,7 +36,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.NULL);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackNull().Should().BeNull();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -49,7 +49,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.BYTES_16);
 
-                    var unpacker = new PackStream.Unpacker(mockInput.Object, null);
+                    var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackNull());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -64,7 +64,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.TRUE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackBoolean().Should().BeTrue();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.FALSE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackBoolean().Should().BeFalse();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -89,7 +89,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.BYTES_16);
 
-                    var unpacker = new PackStream.Unpacker(mockInput.Object, null);
+                    var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackBoolean());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -107,7 +107,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(data);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     sbyte real = (sbyte)u.UnpackLong();
                     real.Should().Be(expected);
@@ -124,7 +124,7 @@ namespace Neo4j.Driver.Tests
                     sbyte expected = 1;
                     mockInput.Setup(x => x.ReadSByte()).Returns(expected);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     sbyte real = (sbyte) u.UnpackLong();
                     Assert.Equal(expected, real);
@@ -140,7 +140,7 @@ namespace Neo4j.Driver.Tests
                     short expected = 124;
                     mockInput.Setup(x => x.ReadShort()).Returns(expected);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     Assert.Equal(expected, u.UnpackLong());
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -155,7 +155,7 @@ namespace Neo4j.Driver.Tests
                     int expected = 1024;
                     mockInput.Setup(x => x.ReadInt()).Returns(expected);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     Assert.Equal(expected, u.UnpackLong());
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -170,7 +170,7 @@ namespace Neo4j.Driver.Tests
                     long expected = 1024;
                     mockInput.Setup(x => x.ReadLong()).Returns(expected);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     Assert.Equal(expected, u.UnpackLong());
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -183,7 +183,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.BYTES_16);
 
-                    var unpacker = new PackStream.Unpacker(mockInput.Object, null);
+                    var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackLong());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -200,7 +200,7 @@ namespace Neo4j.Driver.Tests
                     double expected = 1.12;
                     mockInput.Setup(x => x.ReadDouble()).Returns(expected);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     Assert.Equal(expected, u.UnpackDouble());
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -213,7 +213,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.BYTES_16);
 
-                    var unpacker = new PackStream.Unpacker(mockInput.Object, null);
+                    var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackDouble());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -228,7 +228,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.TINY_STRING);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackString().Should().BeEmpty(); //.Equals(String.Empty);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -242,7 +242,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackString().Should().Be("a");
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -258,7 +258,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackString().Should().Be("a");
                     mockInput.Verify(x => x.ReadByte(), Times.Exactly(2));
@@ -274,7 +274,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackString().Should().Be("a");
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -291,7 +291,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackString().Should().Be("a");
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -306,7 +306,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.STRING_32);
                     mockInput.Setup(x => x.ReadInt()).Returns(-1);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackString());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -320,7 +320,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.FALSE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackString());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -340,7 +340,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var actual = u.UnpackBytes();
                     actual.Length.Should().Be(1);
@@ -358,7 +358,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var actual = u.UnpackBytes();
                     actual.Length.Should().Be(1);
@@ -377,7 +377,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadBytes(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int?>()))
                         .Callback<byte[], int, int?>((buffer, offset, size) => { buffer[0] = 0x61; });
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var actual = u.UnpackBytes();
                     actual.Length.Should().Be(1);
@@ -394,7 +394,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.BYTES_32);
                     mockInput.Setup(x => x.ReadInt()).Returns(-1);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackBytes());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -408,7 +408,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.FALSE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackBytes());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -424,7 +424,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(0xA2);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackMapHeader().Should().Be(2);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -437,7 +437,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte())
                         .Returns(new Queue<byte>(new[] {PackStream.MAP_8, (byte) 1}).Dequeue);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackMapHeader().Should().Be(1);
                     mockInput.Verify(x => x.ReadByte(), Times.Exactly(2));
@@ -450,7 +450,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.MAP_16);
                     mockInput.Setup(x => x.ReadShort()).Returns(1);
                    
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackMapHeader().Should().Be(1);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -464,7 +464,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.MAP_32);
                     mockInput.Setup(x => x.ReadInt()).Returns(-1);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackMapHeader().Should().Be(uint.MaxValue);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -477,7 +477,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.FALSE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackMapHeader());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -493,7 +493,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(0x92);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackListHeader().Should().Be(2);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -506,7 +506,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte())
                         .Returns(new Queue<byte>(new[] { PackStream.LIST_8, (byte)1 }).Dequeue);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackListHeader().Should().Be(1);
                     mockInput.Verify(x => x.ReadByte(), Times.Exactly(2));
@@ -519,7 +519,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.LIST_16);
                     mockInput.Setup(x => x.ReadShort()).Returns(1);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackListHeader().Should().Be(1);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -533,7 +533,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.LIST_32);
                     mockInput.Setup(x => x.ReadInt()).Returns(-1);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackListHeader().Should().Be(uint.MaxValue);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -546,7 +546,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.FALSE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackListHeader());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -562,7 +562,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(0xFF);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackStructSignature().Should().Be(0xFF);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -578,7 +578,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(0xB2);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackStructHeader().Should().Be(2);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -591,7 +591,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte())
                         .Returns(new Queue<byte>(new[] { PackStream.STRUCT_8, (byte)1 }).Dequeue);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackStructHeader().Should().Be(1);
                     mockInput.Verify(x => x.ReadByte(), Times.Exactly(2));
@@ -604,7 +604,7 @@ namespace Neo4j.Driver.Tests
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.STRUCT_16);
                     mockInput.Setup(x => x.ReadShort()).Returns(1);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.UnpackStructHeader().Should().Be(1);
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
@@ -617,7 +617,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.ReadByte()).Returns(PackStream.FALSE);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackStructHeader());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();
@@ -659,7 +659,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.PeekByte()).Returns(marker);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, null);
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     u.PeekNextType().Should().Be(expected);
                     mockInput.Verify(x => x.PeekByte(), Times.Once);
@@ -671,7 +671,7 @@ namespace Neo4j.Driver.Tests
                     var mockInput = new Mock<IInputStream>();
                     mockInput.Setup(x => x.PeekByte()).Returns(PackStream.RESERVED_C4);
 
-                    var u = new PackStream.Unpacker(mockInput.Object, new BigEndianTargetBitConverter());
+                    var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.PeekNextType());
                     ex.Should().BeOfType<ArgumentOutOfRangeException>();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/TestHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/TestHelper.cs
@@ -19,14 +19,13 @@ using System.IO;
 using System.Linq;
 using Moq;
 using Neo4j.Driver.Internal.Connector;
+using Neo4j.Driver.Internal.Packstream;
 using Sockets.Plugin.Abstractions;
 
 namespace Neo4j.Driver.Tests
 {
     public static class TestHelper
     {
-
-
         public static class TcpSocketClientSetup
         {
             public static void SetupClientReadStream(Mock<ITcpSocketClient> mock, byte[] response)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.Internal.Connector
     {
         internal const int BufferSize = 1024*8;
         private readonly int _chunkSize;
-        private readonly BitConverterBase _bitConverter;
+        private static readonly BitConverterBase BitConverter = SocketClient.BitConverter;
         private readonly ITcpSocketClient _tcpSocketClient;
         private byte[] _buffer; //new byte[1024*8];
         private int _pos = -1;
@@ -34,10 +34,9 @@ namespace Neo4j.Driver.Internal.Connector
         private bool _isInChunk = false;
         private readonly ILogger _logger;
 
-        public ChunkedOutputStream(ITcpSocketClient tcpSocketClient, BitConverterBase bitConverter, ILogger logger, int? chunkSize = BufferSize)
+        public ChunkedOutputStream(ITcpSocketClient tcpSocketClient, ILogger logger, int? chunkSize = BufferSize)
         {
             _tcpSocketClient = tcpSocketClient;
-            _bitConverter = bitConverter;
             _logger = logger;
             Throw.ArgumentOutOfRangeException.IfValueLessThan(chunkSize.Value, 8, nameof(chunkSize));
 
@@ -139,7 +138,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         private void WriteShort(short num, byte[] buffer, int pos)
         {
-            _bitConverter.GetBytes(num).CopyTo(buffer, pos);
+            BitConverter.GetBytes(num).CopyTo(buffer, pos);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -33,14 +33,14 @@ namespace Neo4j.Driver.Internal.Connector
         private IReader _reader;
         private IWriter _writer;
 
+        public static readonly BigEndianTargetBitConverter BitConverter = new BigEndianTargetBitConverter();
+
         public SocketClient(Uri url, Config config, ITcpSocketClient socketClient = null)
         {
             _url = url;
             _config = config;
             _tcpSocketClient = socketClient ?? new TcpSocketClient();
         }
-
-        private static BigEndianTargetBitConverter BitConverter => new BigEndianTargetBitConverter();
 
         public void Dispose()
         {
@@ -62,7 +62,7 @@ namespace Neo4j.Driver.Internal.Connector
             }
            _config.Logger?.Debug("S: [HANDSHAKE] 1");
 
-            var formatV1 = new PackStreamMessageFormatV1(_tcpSocketClient, BitConverter, _config.Logger);
+            var formatV1 = new PackStreamMessageFormatV1(_tcpSocketClient, _config.Logger);
             _writer = formatV1.Writer;
             _reader = formatV1.Reader;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
@@ -104,12 +104,11 @@ namespace Neo4j.Driver.Internal.Packstream
         {
 
             private readonly IOutputStream _out;
-            private static BitConverterBase _bitConverter;
+            private static readonly BitConverterBase BitConverter = SocketClient.BitConverter;
 
-            public Packer(IOutputStream outputStream, BitConverterBase converter)
+            public Packer(IOutputStream outputStream)
             {
                 _out = outputStream;
-                _bitConverter = converter;
             }
 
             public void PackNull()
@@ -130,25 +129,25 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else if (value >= MINUS_2_TO_THE_7 && value < MINUS_2_TO_THE_4)
                 {
-                    _out.Write(INT_8).Write(_bitConverter.GetBytes((byte)value));// (byte) value;
+                    _out.Write(INT_8).Write(BitConverter.GetBytes((byte)value));// (byte) value;
                 }
                 else if (value >= MINUS_2_TO_THE_15 && value < PLUS_2_TO_THE_15)
                 {
-                    _out.Write(INT_16).Write(_bitConverter.GetBytes((short) value));
+                    _out.Write(INT_16).Write(BitConverter.GetBytes((short) value));
                 }
                 else if (value >= MINUS_2_TO_THE_31 && value < PLUS_2_TO_THE_31)
                 {
-                    _out.Write(INT_32).Write(_bitConverter.GetBytes((int) value));
+                    _out.Write(INT_32).Write(BitConverter.GetBytes((int) value));
                 }
                 else
                 {
-                    _out.Write(INT_64).Write(_bitConverter.GetBytes(value));
+                    _out.Write(INT_64).Write(BitConverter.GetBytes(value));
                 }
             }
 
             public void Pack(double value)
             {
-                _out.Write(FLOAT_64).Write(_bitConverter.GetBytes(value));
+                _out.Write(FLOAT_64).Write(BitConverter.GetBytes(value));
             }
 
             public void Pack(bool value)
@@ -164,7 +163,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     return;
                 }
 
-                var bytes = _bitConverter.GetBytes(value);
+                var bytes = BitConverter.GetBytes(value);
                 PackStringHeader(bytes.Length);
                 _out.Write(bytes);
             }
@@ -263,11 +262,11 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else if (size <= short.MaxValue)
                 {
-                    _out.Write(BYTES_16,_bitConverter.GetBytes((short) size));
+                    _out.Write(BYTES_16,BitConverter.GetBytes((short) size));
                 }
                 else
                 {
-                    _out.Write(BYTES_32, _bitConverter.GetBytes(size));
+                    _out.Write(BYTES_32, BitConverter.GetBytes(size));
                 }
             }
 
@@ -283,11 +282,11 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else if (size <= short.MaxValue)
                 {
-                    _out.Write(LIST_16, _bitConverter.GetBytes((short) size));
+                    _out.Write(LIST_16, BitConverter.GetBytes((short) size));
                 }
                 else
                 {
-                    _out.Write(LIST_32, _bitConverter.GetBytes(size));
+                    _out.Write(LIST_32, BitConverter.GetBytes(size));
                 }
             }
 
@@ -303,11 +302,11 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else if (size <= short.MaxValue)
                 {
-                    _out.Write(MAP_16, _bitConverter.GetBytes((short) size));
+                    _out.Write(MAP_16, BitConverter.GetBytes((short) size));
                 }
                 else
                 {
-                    _out.Write(MAP_32, _bitConverter.GetBytes(size));
+                    _out.Write(MAP_32, BitConverter.GetBytes(size));
                 }
             }
 
@@ -323,11 +322,11 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else if (size <= short.MaxValue)
                 {
-                    _out.Write(STRING_16, _bitConverter.GetBytes((short) size));
+                    _out.Write(STRING_16, BitConverter.GetBytes((short) size));
                 }
                 else
                 {
-                    _out.Write(STRING_32, _bitConverter.GetBytes(size));
+                    _out.Write(STRING_32, BitConverter.GetBytes(size));
                 }
             }
 
@@ -343,7 +342,7 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else if (size <= short.MaxValue)
                 {
-                    _out.Write(STRUCT_16, _bitConverter.GetBytes((short) size)).Write(signature);
+                    _out.Write(STRUCT_16, BitConverter.GetBytes((short) size)).Write(signature);
                 }
                 else
                     throw new ArgumentOutOfRangeException(nameof(size), size,
@@ -354,12 +353,11 @@ namespace Neo4j.Driver.Internal.Packstream
         public class Unpacker
         {
             private readonly IInputStream _in;
-            private static BitConverterBase _bitConverter;
+            private static readonly BitConverterBase BitConverter = SocketClient.BitConverter;
 
-            public Unpacker(IInputStream inputStream, BitConverterBase converter)
+            public Unpacker(IInputStream inputStream)
             {
                 _in = inputStream;
-                _bitConverter = converter;
             }
 
             public object UnpackNull()
@@ -430,7 +428,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     return string.Empty;
                 }
 
-                return _bitConverter.ToString(UnpackUtf8(markerByte));
+                return BitConverter.ToString(UnpackUtf8(markerByte));
             }
 
             public byte[] UnpackBytes()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
@@ -27,13 +27,10 @@ namespace Neo4j.Driver.Internal.Packstream
 {
     internal class PackStreamMessageFormatV1
     {
-        private static BitConverterBase _bitConverter;
-
-        public PackStreamMessageFormatV1(ITcpSocketClient tcpSocketClient, BitConverterBase bitConverter, ILogger logger)
+        public PackStreamMessageFormatV1(ITcpSocketClient tcpSocketClient, ILogger logger)
         {
-            _bitConverter = bitConverter;
-            Writer = new WriterV1(new ChunkedOutputStream(tcpSocketClient, bitConverter, logger));
-            Reader = new ReaderV1(new ChunkedInputStream(tcpSocketClient, bitConverter, logger));
+            Writer = new WriterV1(new ChunkedOutputStream(tcpSocketClient, logger));
+            Reader = new ReaderV1(new ChunkedInputStream(tcpSocketClient, logger));
         }
 
         public IWriter Writer { get; }
@@ -48,7 +45,7 @@ namespace Neo4j.Driver.Internal.Packstream
             public ReaderV1(ChunkedInputStream inputStream)
             {
                 _inputStream = inputStream;
-                _unpacker = new PackStream.Unpacker(_inputStream, _bitConverter);
+                _unpacker = new PackStream.Unpacker(_inputStream);
             }
 
             public void Read(IMessageResponseHandler responseHandler)
@@ -280,7 +277,7 @@ namespace Neo4j.Driver.Internal.Packstream
             public WriterV1(ChunkedOutputStream outputStream)
             {
                 _outputStream = outputStream;
-                _packer = new PackStream.Packer(_outputStream, _bitConverter);
+                _packer = new PackStream.Packer(_outputStream);
             }
 
             public void HandleInitMessage(string clientNameAndVersion, IDictionary<string, object> authToken)


### PR DESCRIPTION
In the fix, we still keep the static field as only one bitConverter is needed for a driver.
However the code is changed to use eager initialization for the singleton instance bitConverter to make sure it is always initialized correctly.
