### PR TITLE
1.0 streaming

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
@@ -63,7 +63,7 @@ namespace Neo4j.Driver.IntegrationTests
             using (var session = driver.Session())
             {
                 var result = session.Run("PROFILE CREATE (p:Person { Name: 'Test'})");
-                var stats = result.Summary.Counters;
+                var stats = result.Consume().Counters;
                 _output.WriteLine(stats.ToString());
             }
         }
@@ -102,7 +102,7 @@ namespace Neo4j.Driver.IntegrationTests
                 var result1All = result1.ToList();
 
                 result2All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(4, 5, 6);
-                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(1, 2, 3);
+                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder();
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverAuthSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverAuthSteps.cs
@@ -58,9 +58,8 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             var driver = ScenarioContext.Current.Get<IDriver>();
             using (driver)
-            using (var session = driver.Session())
             {
-                var exception = Record.Exception(() => session.Run("CREATE () RETURN 2 as Number"));
+                var exception = Record.Exception(() => driver.Session());
                 exception.Should().BeOfType<ClientException>();
                 exception.Message.Should().StartWith("The client is unauthorized due to authentication failure");
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverEqualsFeatureSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverEqualsFeatureSteps.cs
@@ -29,7 +29,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [Given(@"`(.*)` is single value result of: (.*)")]
         public void GivenValue1IsSingleValueResultOf(string key, string statement)
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 var statementResult = session.Run(statement);
                 var value = statementResult.Single()[0];

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/ErrorReportingSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/ErrorReportingSteps.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [When(@"`run` a query with that same session without closing the transaction first")]
         public void WhenRunAQueryWithThatSameSessionWithoutClosingTheTransactionFirst()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             using (var tx = session.BeginTransaction())
             {
                 var ex = Xunit.Record.Exception(() => session.Run("RETURN 1"));
@@ -50,7 +50,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [When(@"I start a new `Transaction` with the same session before closing the previous")]
         public void WhenIStartANewTransactionWithTheSameSessionBeforeClosingThePrevious()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             using (var tx = session.BeginTransaction())
             {
                 var ex = Xunit.Record.Exception(() => session.BeginTransaction());
@@ -62,7 +62,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [When(@"I run a non valid cypher statement")]
         public void WhenIRunANonValidCypherStatement()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 var ex = Xunit.Record.Exception(() => session.Run("Invalid Cypher"));
                 ex.Should().BeOfType<ClientException>();

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/MatchAcceptanceTestSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/MatchAcceptanceTestSteps.cs
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [Given(@"init: (.*)$")]
         public void GivenInit(string statement)
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 session.Run(statement);
             }
@@ -43,15 +43,13 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             ScenarioContext.Current.Pending();
         }
-        
+
         [When(@"running: (.*)$")]
         public void WhenRunning(string statement)
         {
-            using (var session = TckHooks.Driver.Session())
-            {
-                var result = session.Run(statement);
-                ScenarioContext.Current.Set(result);
-            }
+            var session = TckHooks.CreateSession();
+            var result = session.Run(statement);
+            ScenarioContext.Current.Set(result);
         }
 
         [Given(@"running: (.*)$")]
@@ -70,13 +68,13 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         public void WhenRunningParameterized(string statement, Table table)
         {
             table.RowCount.Should().Be(1);
-            var dict = table.Rows[0].Keys.ToDictionary<string, string, object>(key => key, key => _parser.Parse(table.Rows[0][key]));
+            var dict = table.Rows[0].Keys.ToDictionary<string, string, object>(key => key,
+                key => _parser.Parse(table.Rows[0][key]));
 
-            using (var session = TckHooks.Driver.Session())
-            {
-                var resultCursor = session.Run(statement, dict);
-                ScenarioContext.Current.Set(resultCursor);
-            }
+            var session = TckHooks.CreateSession();
+            var result = session.Run(statement, dict);
+            ScenarioContext.Current.Set(result);
+
         }
 
         [Given(@"running parametrized: (.*)$")]
@@ -88,7 +86,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [BeforeScenario("@reset_database")]
         public void ResetDatabase()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 session.Run("MATCH (n) DETACH DELETE n");
             }
@@ -102,8 +100,8 @@ namespace Neo4j.Driver.Tck.Tests.TCK
             {
                 records.Add( new Record(row.Keys.ToArray(), row.Values.Select(value => _parser.Parse(value)).ToArray()));
             }
-            var resultCursor = ScenarioContext.Current.Get<IStatementResult>();
-            TckUtil.AssertRecordsAreTheSame(resultCursor.ToList(), records);
+            var result = ScenarioContext.Current.Get<IStatementResult>();
+            TckUtil.AssertRecordsAreTheSame(result.ToList(), records);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
@@ -112,11 +112,8 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         public void WhenTheDriverAsksTheServerToEchoThisValueBack()
         {
             var expected = ScenarioContext.Current.Get<object>(KeyExpected);
-            using (var session = TckHooks.Driver.Session())
-            {
-                _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", expected } });
-            }
-            
+            var session = TckHooks.CreateSession();
+            _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", expected } });
         }
 
         [When(@"the driver asks the server to echo this list back")]
@@ -124,11 +121,9 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             var list = ScenarioContext.Current.Get<IList<object>>(KeyList);
             ScenarioContext.Current.Set((object)list, KeyExpected);
-            using (var session = TckHooks.Driver.Session())
-            {
-                _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", list } });
-            }
-            
+
+            var session = TckHooks.CreateSession();
+            _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", list } });
         }
 
         [When(@"the driver asks the server to echo this map back")]
@@ -136,10 +131,9 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             var map = ScenarioContext.Current.Get<IDictionary<string, object>>(Keymap);
             ScenarioContext.Current.Set((object)map, KeyExpected);
-            using (var session = TckHooks.Driver.Session())
-            {
-                _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", map } });
-            }
+
+            var session = TckHooks.CreateSession();
+            _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", map } });
         }
 
         [When(@"the value given in the result should be the same as what was sent")]

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/TckHooks.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/TckHooks.cs
@@ -15,6 +15,7 @@
 // limitations under the License.
 using System;
 using Neo4j.Driver.IntegrationTests.Internals;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
 using TechTalk.SpecFlow;
 
@@ -23,10 +24,25 @@ namespace Neo4j.Driver.Tck.Tests.TCK
     [Binding]
     public static class TckHooks
     {
-        public static IDriver Driver;
+        private static IDriver _driver;
         public static INeo4jInstaller Installer;
         public const string Uri = "bolt://localhost";
         public static IAuthToken AuthToken;
+
+        public static ISession CreateSession()
+        {
+            var session = _driver.Session();
+            ScenarioContext.Current.Set(session);
+            return session;
+        }
+
+        [AfterScenario]
+        public static void DisposeSession()
+        {
+            ISession session;
+            ScenarioContext.Current.TryGetValue(out session);
+            session?.Dispose();
+        }
 
         [BeforeTestRun]
         public static void GlobalBeforeTestRun()
@@ -88,12 +104,12 @@ namespace Neo4j.Driver.Tck.Tests.TCK
 
         private static void DisposeDriver()
         {
-            Driver?.Dispose();
+            _driver?.Dispose();
         }
 
         private static void CreateNewDriver()
         {
-            Driver = GraphDatabase.Driver(Uri, AuthToken);
+            _driver = GraphDatabase.Driver(Uri, AuthToken);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) 2002-2016 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Neo4j.Driver.Internal;
+using Neo4j.Driver.V1;
+using Xunit;
+
+namespace Neo4j.Driver.Tests
+{
+    public class ConfigTests
+    {
+        public class DefaultConfigTests
+        {
+            [Fact]
+            public void DefaultConfigShouldGiveCorrectValueBack()
+            {
+                var config = Config.DefaultConfig;
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+        }
+
+        public class ConfigBuilderTests
+        {
+            [Fact]
+            public void WithLoggingShouldModifyTheSingleValue()
+            {
+                var config = Config.Builder.WithLogger(null).ToConfig();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeNull();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+
+            [Fact]
+            public void WithPoolSizeShouldModifyTheSingleValue()
+            {
+                var config = Config.Builder.WithMaxIdleSessionPoolSize(3).ToConfig();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(3);
+            }
+
+            [Fact]
+            public void WithEncryptionLevelShouldModifyTheSingleValue()
+            {
+                var config = Config.Builder.WithEncryptionLevel(EncryptionLevel.Encrypted).ToConfig();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.Encrypted);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+
+            [Fact]
+            public void ChangingNewConfigShouldNotAffectOtherConfig()
+            {
+                var config = Config.DefaultConfig;
+                var config1 = Config.Builder.WithMaxIdleSessionPoolSize(3).ToConfig();
+                var config2 = Config.Builder.WithLogger(null).ToConfig();
+                
+
+                config2.Logger.Should().BeNull();
+                config2.MaxIdleSessionPoolSize.Should().Be(10);
+
+                config1.MaxIdleSessionPoolSize.Should().Be(3);
+                config1.Logger.Should().BeOfType<DebugLogger>();
+
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
@@ -41,7 +41,7 @@ namespace Neo4j.Driver.Tests
                 mrh.HandleSuccessMessage(new Dictionary<string, object> {{"fields", new List<object> {"x"}}});
                 mrh.HandleRecordMessage(new object[] {"x"});
 
-                mockResultBuilder.Verify(x => x.Record(It.IsAny<object[]>()), Times.Once);
+                mockResultBuilder.Verify(x => x.CollectRecord(It.IsAny<object[]>()), Times.Once);
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -96,7 +96,8 @@ namespace Neo4j.Driver.Tests
                     harness.ResetCalls();
 
                     // When
-                    harness.Client.Send(messages, messageHandler);
+                    harness.Client.Send(messages);
+                    harness.Client.Receive(messageHandler);
 
                     // Then
                     harness.VerifyWriteStreamUsages(2 /*write + flush*/);
@@ -125,16 +126,16 @@ namespace Neo4j.Driver.Tests
                     harness.ResetCalls();
 
                     // When
-                    harness.Client.Send(messages, messageHandler);
+                    harness.Client.Send(messages);
+                    Record.Exception(() => harness.Client.Receive(messageHandler));
 
                     // Then
                     harness.VerifyWriteStreamUsages(2 /*write + flush*/);
 
                     messageHandler.HasError.Should().BeTrue();
                     messageHandler.Error.Code.Should().Be("Neo.ClientError.Statement.InvalidSyntax");
-                    messageHandler.Error.Message.Should()
-                        .Be(
-                            "Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))\n\"This will cause a syntax error\"\n ^");
+                    messageHandler.Error.Message.Should().Be(
+                        "Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))\n\"This will cause a syntax error\"\n ^");
                 }
             }
 
@@ -167,16 +168,17 @@ namespace Neo4j.Driver.Tests
 
 
                     // When
-                    harness.Client.Send(messages, messageHandler);
+                    harness.Client.Send(messages);
+                    Record.Exception(() => harness.Client.Receive(messageHandler));
 
                     // Then
                     harness.VerifyWriteStreamUsages(2 /*write + flush*/);
 
                     messageHandler.HasError.Should().BeTrue();
                     messageHandler.Error.Code.Should().Be("Neo.ClientError.Statement.InvalidSyntax");
-                    messageHandler.Error.Message.Should()
-                        .Be("Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))\n\"This will cause a syntax error\"\n ^");
-                    messageHandler.QueueIsEmpty().Should().BeTrue();
+                    messageHandler.Error.Message.Should().Be(
+                        "Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))\n\"This will cause a syntax error\"\n ^");
+                    messageHandler.UnhandledMessageSize.Should().Be(0);
                     messageHandler.FailureMessageCalled.Should().Be(1);
                     messageHandler.IgnoreMessageCalled.Should().Be(1);
                 }
@@ -209,7 +211,8 @@ namespace Neo4j.Driver.Tests
                     messageHandler.Error = new ClientException("Neo.ClientError.Request.Invalid", "Test Message");
 
                     // When
-                    var ex = Record.Exception(() => harness.Client.Send(messages, messageHandler));
+                    harness.Client.Send(messages);
+                    var ex = Record.Exception(() => harness.Client.Receive(messageHandler));
                     ex.Should().BeOfType<ClientException>();
 
                     harness.MockTcpSocketClient.Verify(x => x.DisconnectAsync(), Times.Once);
@@ -262,10 +265,8 @@ namespace Neo4j.Driver.Tests
                     throw new NotImplementedException();
                 }
 
-                public bool QueueIsEmpty()
-                {
-                    return _messageHandler.QueueIsEmpty();
-                }
+                public int UnhandledMessageSize => _messageHandler.UnhandledMessageSize;
+                public bool IsRecordMessageReceived => _messageHandler.IsRecordMessageReceived;
 
                 public bool HasError => _messageHandler.HasError;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -30,10 +30,7 @@ namespace Neo4j.Driver.Tests
 {
     public class SocketConnectionTests
     {
-        private static ILogger Logger
-        {
-            get { return new Mock<ILogger>().Object; }
-        }
+        private static ILogger Logger => new Mock<ILogger>().Object;
 
         private static Mock<ISocketClient> MockSocketClient => new Mock<ISocketClient>();
 
@@ -50,15 +47,16 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void ShouldEnqueuesInitMessage()
+            public void ShouldSyncInitMessageImmediately()
             {
                 var mockClient = new Mock<ISocketClient>();
-                var socketConnection = new SocketConnection(mockClient.Object, AuthTokens.None, Logger, null);
+                var mockHandler = new Mock<IMessageResponseHandler>();
+                new SocketConnection(mockClient.Object, AuthTokens.None, Logger, mockHandler.Object);
 
-                //socketConnection.Init("testclient");
-                socketConnection.Messages.Should().HaveCount(1);
-                var msg = socketConnection.Messages.First();
-                msg.Should().BeAssignableTo<InitMessage>();
+                mockHandler.Verify(h => h.Register(It.IsAny<InitMessage>(), null));
+
+                mockClient.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>()), Times.Once);
+                mockClient.Verify(c => c.Receive(mockHandler.Object, 0), Times.Once);
             }
 
             [Fact]
@@ -124,8 +122,8 @@ namespace Neo4j.Driver.Tests
                 con.Run(new ResultBuilder(), "a statement");
 
                 // Then
-                con.Messages.Count.Should().Be(2); // Init + Run
-                con.Messages[1].Should().BeAssignableTo<RunMessage>();
+                con.Messages.Count.Should().Be(1); // Run
+                con.Messages[0].Should().BeAssignableTo<RunMessage>();
             }
 
             [Fact]
@@ -155,8 +153,8 @@ namespace Neo4j.Driver.Tests
                 con.PullAll(new ResultBuilder());
 
                 // Then
-                con.Messages.Count.Should().Be(2); // Init + PullAll
-                con.Messages[1].Should().BeAssignableTo<PullAllMessage>();
+                con.Messages.Count.Should().Be(1); // PullAll
+                con.Messages[0].Should().BeAssignableTo<PullAllMessage>();
             }
 
             [Fact]
@@ -176,17 +174,20 @@ namespace Neo4j.Driver.Tests
         public class ResetMethod
         {
             [Fact]
-            public void ShouldClearSendingMessagesMessageHandlerAndEnqueueResetMessage()
+            public void ShouldNotClearMessagesResponseHandlerAndEnqueueResetMessage()
             {
                 var mock = MockSocketClient;
                 var mockResponseHandler = new Mock<IMessageResponseHandler>();
                 var con = new SocketConnection(mock.Object, AuthTokens.None, Logger, mockResponseHandler.Object);
 
+                con.Run(null, "bula");
                 con.Reset();
                 var messages = con.Messages;
-                messages.Count.Should().Be(1);
-                messages[0].Should().BeOfType<ResetMessage>();
-                mockResponseHandler.Verify(x => x.Clear());
+                messages.Count.Should().Be(2);
+                messages[0].Should().BeOfType<RunMessage>();
+                messages[1].Should().BeOfType<ResetMessage>();
+                mockResponseHandler.Verify(x => x.Register(It.IsAny<RunMessage>(), null), Times.Once);
+                mockResponseHandler.Verify(x => x.Register(It.IsAny<ResetMessage>(), null), Times.Once);
             }
         }
 
@@ -200,7 +201,7 @@ namespace Neo4j.Driver.Tests
                 var con = new SocketConnection(mock.Object, AuthTokens.None, Logger, mockResponseHandler.Object);
 
                 mockResponseHandler.Setup(x => x.Error).Returns(new TransientException("BLAH", "lalala"));
-                con.HasUnrecoverableError.Should().BeTrue();
+                con.HasUnrecoverableError.Should().BeFalse();
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -94,7 +94,7 @@ namespace Neo4j.Driver.Tests
                 con.Sync();
                 mock.Reset();
                 con.Sync();
-                mock.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>(), It.IsAny<IMessageResponseHandler>()),
+                mock.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>()),
                     Times.Never);
             }
 
@@ -105,7 +105,7 @@ namespace Neo4j.Driver.Tests
                 var con = new SocketConnection(mock.Object, AuthTokens.None, Logger, null);
 
                 con.Sync();
-                mock.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>(), It.IsAny<IMessageResponseHandler>()),
+                mock.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>()),
                     Times.Once);
                 con.Messages.Count.Should().Be(0);
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -87,6 +87,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ConfigTests.cs" />
     <Compile Include="Connector\ChunkedOutputTest.cs" />
     <Compile Include="Connector\MessageResponseHandlerTests.cs" />
     <Compile Include="Connector\SocketExtensionTests.cs" />

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
@@ -28,17 +28,17 @@ namespace Neo4j.Driver.Tests
     internal class ListBasedRecordSet : IRecordSet
     {
         private readonly IList<IRecord> _records;
+        private int _count = 0;
         private readonly RecordSet _recordSet;
-
-        public int Position => _recordSet.Position;
 
         public ListBasedRecordSet(IList<IRecord> records)
         {
             _records = records;
-            _recordSet = new RecordSet(_records, ()=>AtEnd);
+            _recordSet = new RecordSet(() => _records[_count++], () => !AtEnd);
         }
 
-        public bool AtEnd => _recordSet.Position >= _records.Count;
+        public bool AtEnd => _count >= _records.Count;
+        
         public IRecord Peek()
         {
             return _recordSet.Peek();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -292,9 +292,9 @@ namespace Neo4j.Driver.Tests
                 var cursor = builder.Build();
 
                 var t = AssertGetExpectResults(cursor, 3);
-                builder.Record(new object[] {123});
-                builder.Record(new object[] {123});
-                builder.Record(new object[] {123});
+                builder.CollectRecord(new object[] {123});
+                builder.CollectRecord(new object[] {123});
+                builder.CollectRecord(new object[] {123});
                 builder.CollectSummaryMeta(null);
                 t.Wait();
             }
@@ -318,9 +318,9 @@ namespace Neo4j.Driver.Tests
                 var builder = GenerateBuilder();
                 var cursor = builder.Build();
 
-                builder.Record(new object[] { 123 });
-                builder.Record(new object[] { 123 });
-                builder.Record(new object[] { 123 });
+                builder.CollectRecord(new object[] { 123 });
+                builder.CollectRecord(new object[] { 123 });
+                builder.CollectRecord(new object[] { 123 });
                 builder.CollectSummaryMeta(null);
 
                 var t = AssertGetExpectResults(cursor, 3);
@@ -343,7 +343,7 @@ namespace Neo4j.Driver.Tests
 
                 foreach (var recordValue in recordValues)
                 { 
-                    builder.Record(new object[] { recordValue });
+                    builder.CollectRecord(new object[] { recordValue });
                 }
                 builder.CollectSummaryMeta(null);
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -46,7 +46,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectType()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () => false;
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 { {"type", "r" } };
                 builder.CollectSummaryMeta(meta);
@@ -60,7 +60,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectStattistics()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () => false;
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 { {"type", "r" }, {"stats", new Dictionary<string, object> { {"nodes-created", 10L}, {"nodes-deleted", 5L} } } };
                 builder.CollectSummaryMeta(meta);
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectNotifications()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () => false;
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r" },
@@ -125,7 +125,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectSimplePlan()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () => false;
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {   {"type", "r" },
                     { "plan", new Dictionary<string, object>
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectPlanThatContainsPlans()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () => false;
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r"},
@@ -205,7 +205,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectProfiledPlanThatContainsProfiledPlans()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () => false;
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r"},
@@ -304,7 +304,7 @@ namespace Neo4j.Driver.Tests
             {
                 var builder = GenerateBuilder();
                 var i = 0;
-                builder.ReceiveOneMessageRecordFunc = () =>
+                builder.ReceiveOneRecordMessageFunc = () =>
                 {
                     if (i++ >= 3)
                     {
@@ -324,7 +324,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldReturnNoResultsWhenNoneRecieved()
             {
                 var builder = GenerateBuilder();
-                builder.ReceiveOneMessageRecordFunc = () =>
+                builder.ReceiveOneRecordMessageFunc = () =>
                 {
                     builder.CollectSummaryMeta(null);
                     return false;
@@ -348,7 +348,7 @@ namespace Neo4j.Driver.Tests
                     10
                 };
                 var i = 0;
-                builder.ReceiveOneMessageRecordFunc = () =>
+                builder.ReceiveOneRecordMessageFunc = () =>
                 {
                     if (i < recordValues.Count)
                     {
@@ -373,7 +373,7 @@ namespace Neo4j.Driver.Tests
             public void DoesNothingWhenMetaIsNull()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneMessageRecordFunc = () =>
+                builder.ReceiveOneRecordMessageFunc = () =>
                 {
                     builder.CollectSummaryMeta(null);
                     return false;
@@ -406,7 +406,7 @@ namespace Neo4j.Driver.Tests
                         {"type", typeValue}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -426,7 +426,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -461,7 +461,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -493,7 +493,7 @@ namespace Neo4j.Driver.Tests
                         } }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -525,7 +525,7 @@ namespace Neo4j.Driver.Tests
                     {
                         {"something", "unknown"}
                     };
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -546,7 +546,7 @@ namespace Neo4j.Driver.Tests
                         {"plan", new Dictionary<string,object>()}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -567,7 +567,7 @@ namespace Neo4j.Driver.Tests
                         {"plan", null}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -593,7 +593,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -619,7 +619,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -654,7 +654,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -705,7 +705,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -762,7 +762,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -793,7 +793,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -814,7 +814,7 @@ namespace Neo4j.Driver.Tests
                         {"profile", new Dictionary<string,object>()}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -835,7 +835,7 @@ namespace Neo4j.Driver.Tests
                         {"profile", null}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -863,7 +863,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -890,7 +890,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -917,7 +917,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -945,7 +945,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -985,7 +985,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -1043,7 +1043,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -1114,7 +1114,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -1153,7 +1153,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -1190,7 +1190,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;
@@ -1249,7 +1249,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneMessageRecordFunc = () =>
+                    builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
                         return false;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -50,7 +50,7 @@ namespace Neo4j.Driver.Tests
 
                 mockConn.Verify(x => x.Run(It.IsAny<ResultBuilder>(), "lalalal", null), Times.Once);
                 mockConn.Verify(x => x.PullAll(It.IsAny<ResultBuilder>()), Times.Once);
-                mockConn.Verify(x => x.Sync());
+                mockConn.Verify(x => x.SyncRun());
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -48,7 +48,7 @@ namespace Neo4j.Driver.Tests
         public class RunMethod
         {
             [Fact]
-            public void ShouldRunPullAllSync()
+            public void ShouldRunPullAllSyncRun()
             {
                 var mockConn = new Mock<IConnection>();
                 var tx = new Transaction(mockConn.Object);
@@ -57,7 +57,7 @@ namespace Neo4j.Driver.Tests
 
                 mockConn.Verify(x => x.Run(It.IsAny<ResultBuilder>(), "lalala", null), Times.Once);
                 mockConn.Verify(x => x.PullAll(It.IsAny<ResultBuilder>()), Times.Once);
-                mockConn.Verify(x => x.Sync(), Times.Once);
+                mockConn.Verify(x => x.SyncRun(), Times.Once);
                 tx.Finished.Should().BeFalse();
             }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -24,8 +24,8 @@ namespace Neo4j.Driver.Internal.Connector
     {
         void Sync();
         void SyncRun();
-        void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> parameters=null);
-        void PullAll(ResultBuilder resultBuilder);
+        void Run(IResultBuilder resultBuilder, string statement, IDictionary<string, object> parameters=null);
+        void PullAll(IResultBuilder resultBuilder);
         void DiscardAll();
         void Reset();
         bool IsOpen { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -23,6 +23,7 @@ namespace Neo4j.Driver.Internal.Connector
     internal interface IConnection : IDisposable
     {
         void Sync();
+        void SyncRun();
         void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> parameters=null);
         void PullAll(ResultBuilder resultBuilder);
         void DiscardAll();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -25,12 +25,10 @@ namespace Neo4j.Driver.Internal.Connector
         Task Start();
         Task Stop();
         void Send(IEnumerable<IRequestMessage> messages);
-        /* Recieve until unhandledMessageSize messages are left in unhandled message queue (client sent messages) */
+        /* Recieve until unhandledMessageSize messages are left in unhandled message queue */
         void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0);
-        /* Retive one server reply message from client's input buffer.
-         * Return true if a client message is complete (a success/failure/ignore message received),
-         * otherwise false (a record message received) */
-        bool ReceiveOne(IMessageResponseHandler responseHandler);
+        /* Return true if a record message is received, otherwise false. */
+        bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler);
         bool IsOpen { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -24,7 +24,13 @@ namespace Neo4j.Driver.Internal.Connector
     {
         Task Start();
         Task Stop();
-        void Send(IEnumerable<IRequestMessage> messages, IMessageResponseHandler responseHandler);
+        void Send(IEnumerable<IRequestMessage> messages);
+        /* Recieve until unhandledMessageSize messages are left in unhandled message queue (client sent messages) */
+        void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0);
+        /* Retive one server reply message from client's input buffer.
+         * Return true if a client message is complete (a success/failure/ignore message received),
+         * otherwise false (a record message received) */
+        bool ReceiveOne(IMessageResponseHandler responseHandler);
         bool IsOpen { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/MessageResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/MessageResponseHandler.cs
@@ -62,6 +62,7 @@ namespace Neo4j.Driver.Internal.Connector
                 // before summary method is called
                 CurrentResultBuilder?.CollectSummaryMeta(meta);
             }
+            Error = null;
             _logger?.Debug("S: ", new SuccessMessage(meta));
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/MessageResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/MessageResponseHandler.cs
@@ -14,6 +14,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Result;
@@ -25,14 +27,17 @@ namespace Neo4j.Driver.Internal.Connector
     {
         private readonly ILogger _logger;
         private readonly Queue<IResultBuilder> _resultBuilders = new Queue<IResultBuilder>();
-        private readonly Queue<IRequestMessage> _sentMessages = new Queue<IRequestMessage>();
+        private readonly Queue<IRequestMessage> _unhandledMessages = new Queue<IRequestMessage>();
         internal IResultBuilder CurrentResultBuilder { get; private set; }
+
+        public int UnhandledMessageSize => _unhandledMessages.Count;
+        public bool IsRecordMessageReceived { get; internal set; }
 
         public Neo4jException Error { get; internal set; }
         public bool HasError => Error != null;
 
         internal Queue<IResultBuilder> ResultBuilders => new Queue<IResultBuilder>(_resultBuilders);
-        internal Queue<IRequestMessage> SentMessages => new Queue<IRequestMessage>(_sentMessages);
+        internal Queue<IRequestMessage> SentMessages => new Queue<IRequestMessage>(_unhandledMessages);
 
         public MessageResponseHandler()
         {
@@ -45,8 +50,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void HandleSuccessMessage(IDictionary<string, object> meta)
         {
-            _sentMessages.Dequeue();
-            CurrentResultBuilder = _resultBuilders.Dequeue();
+            Unregister();
             if (meta.ContainsKey("fields"))
             {
                 // first success
@@ -63,7 +67,8 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void HandleRecordMessage(object[] fields)
         {
-            CurrentResultBuilder.Record(fields);
+            IsRecordMessageReceived = true;
+            CurrentResultBuilder.CollectRecord(fields);
             _logger?.Debug("S: ", new RecordMessage(fields));
         }
 
@@ -83,35 +88,37 @@ namespace Neo4j.Driver.Internal.Connector
                     Error = new DatabaseException(code, message);
                     break;
             }
-            _sentMessages.Dequeue();
-            _resultBuilders.Dequeue();
+            Unregister();
             _logger?.Debug("S: ", new FailureMessage(code, message));
         }
 
         public void HandleIgnoredMessage()
         {
-            _sentMessages.Dequeue();
-            _resultBuilders.Dequeue();
+            Unregister();
             _logger?.Debug("S: ", new IgnoredMessage());
         }
 
         public void Register(IRequestMessage requestMessage, IResultBuilder resultBuilder = null)
         {
-            _sentMessages.Enqueue(requestMessage);
+            _unhandledMessages.Enqueue(requestMessage);
             _resultBuilders.Enqueue(resultBuilder);
+        }
+
+        private void Unregister()
+        {
+            _unhandledMessages.Dequeue();
+            CurrentResultBuilder = _resultBuilders.Dequeue();
+            IsRecordMessageReceived = false;
         }
 
         public void Clear()
         {
             _resultBuilders.Clear();
-            _sentMessages.Clear();
+            _unhandledMessages.Clear();
+
             CurrentResultBuilder = null;
             Error = null;
-        }
-
-        public bool QueueIsEmpty()
-        {
-            return _sentMessages.Count == 0;
+            IsRecordMessageReceived = false;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -153,7 +153,7 @@ namespace Neo4j.Driver.Internal.Connector
         /// Return true if a record message is received, otherwise false.
         /// This method will throw the exception if a failure message is received.
         /// </summary>
-        public bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler)
+        public bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction )
         {
             if (responseHandler.UnhandledMessageSize == 0)
             {
@@ -162,7 +162,7 @@ namespace Neo4j.Driver.Internal.Connector
             ReceiveOne(responseHandler);
             if (responseHandler.HasError)
             {
-                throw responseHandler.Error;
+                onFailureAction.Invoke();
             }
             return responseHandler.IsRecordMessageReceived;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -116,8 +116,6 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void Reset()
         {
-            ClearQueue();
-            _responseHandler.Clear();
             Enqueue(new ResetMessage());
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -95,7 +95,7 @@ namespace Neo4j.Driver.Internal.Connector
         }
 
         public bool HasUnrecoverableError
-            => _responseHandler.Error is TransientException || _responseHandler.Error is DatabaseException;
+            => _responseHandler.Error is DatabaseException;
 
         public void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> paramters=null)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -97,16 +97,16 @@ namespace Neo4j.Driver.Internal.Connector
         public bool HasUnrecoverableError
             => _responseHandler.Error is DatabaseException;
 
-        public void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> paramters=null)
+        public void Run(IResultBuilder resultBuilder, string statement, IDictionary<string, object> paramters=null)
         {
             var runMessage = new RunMessage(statement, paramters);
             Enqueue(runMessage, resultBuilder);
         }
 
-        public void PullAll(ResultBuilder resultBuilder)
+        public void PullAll(IResultBuilder resultBuilder)
         {
             Enqueue(new PullAllMessage(), resultBuilder);
-            resultBuilder.ReceiveOneMessageRecordFunc = () => _client.ReceiveOneRecordMessage(_responseHandler, OnResponseHasError);
+            resultBuilder.ReceiveOneRecordMessageFunc = () => _client.ReceiveOneRecordMessage(_responseHandler, OnResponseHasError);
         }
 
         public void DiscardAll()
@@ -135,7 +135,7 @@ namespace Neo4j.Driver.Internal.Connector
             _messages.Clear();
         }
 
-        private void Enqueue(IRequestMessage requestMessage, ResultBuilder resultBuilder = null)
+        private void Enqueue(IRequestMessage requestMessage, IResultBuilder resultBuilder = null)
         {
             _messages.Enqueue(requestMessage);
             _responseHandler.Register(requestMessage, resultBuilder);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections;
 using System.Linq;
-using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/AckFailureMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/AckFailureMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2016 "Neo Technology,"
+﻿// Copyright (c) 2002-2016 "Neo Technology,"
 // Network Engine for Objects in Lund AB [http://neotechnology.com]
 // 
 // This file is part of Neo4j.
@@ -17,20 +17,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
-using Neo4j.Driver.Internal.Messaging;
 
-namespace Neo4j.Driver.Internal.Connector
+namespace Neo4j.Driver.Internal.Messaging
 {
-    internal interface ISocketClient
+    internal class AckFailureMessage : IRequestMessage
     {
-        Task Start();
-        Task Stop();
-        void Send(IEnumerable<IRequestMessage> messages);
-        /* Recieve until unhandledMessageSize messages are left in unhandled message queue */
-        void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0);
-        /* Return true if a record message is received, otherwise false. */
-        bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction );
-        bool IsOpen { get; }
+        public void Dispatch(IMessageRequestHandler messageRequestHandler)
+        {
+            messageRequestHandler.HandleAckFailureMessage();
+        }
+
+        public override string ToString()
+        {
+            return "ACK_FAILURE";
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -40,6 +40,7 @@ namespace Neo4j.Driver.Internal.Messaging
 
         void Register(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
         void Clear();
-        bool QueueIsEmpty();
+        int UnhandledMessageSize { get; }
+        bool IsRecordMessageReceived { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -27,6 +27,7 @@ namespace Neo4j.Driver.Internal.Messaging
         void HandlePullAllMessage();
         void HandleDiscardAllMessage();
         void HandleResetMessage();
+        void HandleAckFailureMessage();
     }
 
     internal interface IMessageResponseHandler

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -38,7 +38,6 @@ namespace Neo4j.Driver.Internal.Messaging
         void HandleFailureMessage(string code, string message);
         void HandleIgnoredMessage();
         void HandleRecordMessage(object[] fields);
-
         void Register(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
         void Clear();
         int UnhandledMessageSize { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
@@ -314,6 +314,12 @@ namespace Neo4j.Driver.Internal.Packstream
                 PackMessageTail();
             }
 
+            public void HandleAckFailureMessage()
+            {
+                _packer.PackStructHeader(0, MSG_ACK_FAILURE );
+                PackMessageTail();
+            }
+
             public void Write(IRequestMessage requestMessage)
             {
                 requestMessage.Dispatch(this);
@@ -356,6 +362,7 @@ namespace Neo4j.Driver.Internal.Packstream
         #region Consts
 
         public const byte MSG_INIT = 0x01;
+        public const byte MSG_ACK_FAILURE = 0x0E;
         public const byte MSG_RESET = 0x0F;
         public const byte MSG_RUN = 0x10;
         public const byte MSG_DISCARD_ALL = 0x2F;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Result
 {
@@ -27,6 +26,6 @@ namespace Neo4j.Driver.Internal.Result
         StatementResult Build();
         void CollectFields(IDictionary<string, object> meta);
         void CollectSummaryMeta(IDictionary<string, object> meta);
-        Func<bool> ReceiveOneMessageRecordFunc { set; }
+        Func<bool> ReceiveOneRecordMessageFunc { set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -14,15 +14,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
 using System.Collections.Generic;
+using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.Result
 {
     internal interface IResultBuilder
     {
-        void Record(object[] fields);
+        void CollectRecord(object[] fields);
         StatementResult Build();
         void CollectFields(IDictionary<string, object> meta);
         void CollectSummaryMeta(IDictionary<string, object> meta);
+        Func<bool> ReceiveOneFunc { set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -17,7 +17,7 @@
 
 using System;
 using System.Collections.Generic;
-using Neo4j.Driver.Internal.Messaging;
+using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Result
 {
@@ -27,6 +27,6 @@ namespace Neo4j.Driver.Internal.Result
         StatementResult Build();
         void CollectFields(IDictionary<string, object> meta);
         void CollectSummaryMeta(IDictionary<string, object> meta);
-        Func<bool> ReceiveOneFunc { set; }
+        Func<bool> ReceiveOneMessageRecordFunc { set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/RecordSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/RecordSet.cs
@@ -23,15 +23,15 @@ namespace Neo4j.Driver.Internal.Result
 {
     internal class RecordSet : IRecordSet
     {
-        private readonly Func<bool> _receiveOneFunc;
+        private readonly Func<bool> _receiveOneRecordMessageFunc;
         private readonly Func<IRecord> _recordFunc;
 
         private IRecord _peekedRecord;
 
-        public RecordSet(Func<IRecord> recordFunc, Func<bool> receiveOneFunc)
+        public RecordSet(Func<IRecord> recordFunc, Func<bool> receiveOneRecordMessageFunc)
         {
             _recordFunc = recordFunc;
-            _receiveOneFunc = receiveOneFunc;
+            _receiveOneRecordMessageFunc = receiveOneRecordMessageFunc;
         }
 
         public bool AtEnd { get; private set; }
@@ -51,7 +51,7 @@ namespace Neo4j.Driver.Internal.Result
                 }
                 else
                 {
-                    AtEnd = _receiveOneFunc.Invoke();
+                    AtEnd = !_receiveOneRecordMessageFunc.Invoke();
                     if (!AtEnd)
                     {
                         yield return _recordFunc.Invoke();
@@ -78,7 +78,7 @@ namespace Neo4j.Driver.Internal.Result
                 return null;
             }
             // we still in the middle of the stream and we need to pull from input buffer
-            AtEnd = _receiveOneFunc.Invoke();
+            AtEnd = !_receiveOneRecordMessageFunc.Invoke();
             if (AtEnd) // well the message received is a success
             {
                 return null;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -27,7 +27,7 @@ namespace Neo4j.Driver.Internal.Result
         private string[] _keys = new string[0];
         private readonly SummaryBuilder _summaryBuilder;
 
-        public Func<bool> ReceiveOneMessageRecordFunc { private get; set; }
+        public Func<bool> ReceiveOneRecordMessageFunc { private get; set; }
         public IRecord Record { get; private set; }
 
         public ResultBuilder() : this(null, null)
@@ -48,7 +48,7 @@ namespace Neo4j.Driver.Internal.Result
         {
             return new StatementResult(
                 _keys,
-                new RecordSet(() => Record, ReceiveOneMessageRecordFunc),
+                new RecordSet(() => Record, ReceiveOneRecordMessageFunc),
                 () => _summaryBuilder.Build());
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -25,11 +25,10 @@ namespace Neo4j.Driver.Internal.Result
     internal class ResultBuilder : IResultBuilder
     {
         private string[] _keys = new string[0];
-        public IRecord Record { get; private set; }
         private readonly SummaryBuilder _summaryBuilder;
-        public Func<bool> ReceiveOneFunc { private get; set; }
 
-        internal bool HasMoreRecords { get; private set; } = true;
+        public Func<bool> ReceiveOneMessageRecordFunc { private get; set; }
+        public IRecord Record { get; private set; }
 
         public ResultBuilder() : this(null, null)
         {
@@ -49,7 +48,8 @@ namespace Neo4j.Driver.Internal.Result
         {
             return new StatementResult(
                 _keys,
-                new RecordSet(() => Record, ReceiveOneFunc), () => _summaryBuilder.Build());
+                new RecordSet(() => Record, ReceiveOneMessageRecordFunc),
+                () => _summaryBuilder.Build());
         }
 
         public void CollectRecord(object[] fields)
@@ -68,7 +68,6 @@ namespace Neo4j.Driver.Internal.Result
 
         public void CollectSummaryMeta(IDictionary<string, object> meta)
         {
-            HasMoreRecords = false;
             if (meta == null)
             {
                 return;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -80,7 +80,7 @@ namespace Neo4j.Driver.Internal
                 var resultBuilder = new ResultBuilder(statement, statementParameters);
                 _connection.Run(resultBuilder, statement, statementParameters);
                 _connection.PullAll(resultBuilder);
-                _connection.Sync();
+                _connection.SyncRun();
 
                 return resultBuilder.Build();
             });

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Internal
         {
             return TryExecute(() =>
             {
-                EnsureConnectionIsValid();
+                EnsureCanRunMoreStatements();
                 var resultBuilder = new ResultBuilder(statement, statementParameters);
                 _connection.Run(resultBuilder, statement, statementParameters);
                 _connection.PullAll(resultBuilder);
@@ -90,24 +90,24 @@ namespace Neo4j.Driver.Internal
         {
             return TryExecute(() =>
             {
-                EnsureConnectionIsValid();
+                EnsureCanRunMoreStatements();
                 _transaction = new Transaction(_connection, _logger);
                 return _transaction;
             });
         }
 
-        private void EnsureConnectionIsValid()
+        private void EnsureCanRunMoreStatements()
         {
+            EnsureConnectionIsHealthy();
             EnsureNoOpenTransaction();
-            EnsureConnectionIsOpen();
         }
 
-        private void EnsureConnectionIsOpen()
+        private void EnsureConnectionIsHealthy()
         {
-            if (!_connection.IsOpen)
+            if (!IsHealthy)
             {
                 throw new ClientException("The current session cannot be reused as the underlying connection with the " +
-                                           "server has been closed due to unrecoverable errors. " +
+                                           "server has been closed or is going to be closed due to unrecoverable errors. " +
                                            "Please close this session and retry your statement in another new session.");
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/SessionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/SessionPool.cs
@@ -71,7 +71,7 @@ namespace Neo4j.Driver.Internal
                 {
                     session = new Session(_uri, _authToken, _config, _connection, Release);
                 }
-                else if (!IsSessionReusable(session))
+                else if (!session.IsHealthy)
                 {
                     session.Close();
                     return GetSession();
@@ -130,7 +130,7 @@ namespace Neo4j.Driver.Internal
                     _inUseSessions.Remove(sessionId);
                 }
 
-                if (session.IsHealthy)
+                if (IsSessionReusable(session))
                 {
                     lock (_availableSessions)
                     {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -109,7 +109,7 @@ namespace Neo4j.Driver.Internal
                     var resultBuilder = new ResultBuilder(statement, parameters);
                     _connection.Run(resultBuilder, statement, parameters);
                     _connection.PullAll(resultBuilder);
-                    _connection.Sync();
+                    _connection.SyncRun();
                     return resultBuilder.Build();
                 }
                 catch (Neo4jException)

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -40,6 +40,7 @@
     <DocumentationFile>bin\Release\Neo4j.Driver.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Internal\Messaging\AckFailureMessage.cs" />
     <Compile Include="V1\IAuthToken.cs" />
     <Compile Include="V1\IDriver.cs" />
     <Compile Include="Internal\AuthToken.cs" />

--- a/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
@@ -39,10 +39,15 @@ namespace Neo4j.Driver.V1
         public const int InfiniteMaxIdleSessionPoolSize = -1;
         static Config()
         {
-            DefaultConfig = new Config
+            DefaultConfig = CreateNewConfig();
+        }
+
+        private static Config CreateNewConfig()
+        {
+            return new Config
             {
                 EncryptionLevel = EncryptionLevel.None,
-                Logger = new DebugLogger {Level = LogLevel.Info},
+                Logger = new DebugLogger { Level = LogLevel.Info },
                 MaxIdleSessionPoolSize = 10
             };
         }
@@ -63,7 +68,7 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Create an instance of <see cref="IConfigBuilder"/> to build a <see cref="Config"/>.
         /// </summary>
-        public static IConfigBuilder Builder => new ConfigBuilder(new Config());
+        public static IConfigBuilder Builder => new ConfigBuilder(CreateNewConfig());
 
         /// <summary>
         /// Gets or sets the use of encryption for all the connections created by the <see cref="IDriver"/>.


### PR DESCRIPTION
**Example 1**:
If I run

```
using(var session = driver.Session())
{
    var result = session.Run("RETURN 1");
}
```

The sequence of messages to exchange between client and server are:

```
-> INIT
<- SUCC_init

-> RUN
-> PULL_ALL
<- SUCC_run
```

After `}` the `session.Dispose()` will result in message sequence:

```
-> RESET
<- RECORD 1
<- SUCC_pull_all
<- SUCC_reset
```

So the RUN, PULL_ALL messages are eagerly sent, the SUCC for RUN is also eagerly received, but for records, it will only be retrieved in `result.Consume()` or similar iterations. If no result is iterated before the session is disposed, then the `RESET` message will force to sync all unhandled messages to make sure the session is clean when it returned to pool.

**Example 2**:
When I run

```
using(var session = driver.Session())
{
    session.Run("RETURN 1");
    var result = session.Run("RETURN 2");
    result.ToList();
}
```

Then the sequence of the messages are:

```
-> INIT
<- SUCC_init

 // run(return 1)
-> RUN
-> PULL_ALL
<- SUCC_run

// run(return 2)
-> RUN'
-> PULL_ALL'
<- RECORD 1
<- SUCC_pull_all
<- SUCC_run'

// result.ToList
<- RECORD 2
<-SUCC_pull_all'
```

In this case, as we did not save the result of the first `Run`, so they will just get lost if the second `Run` start to consume the result first. (We will improve this to cleverly buffer the results latter)

**Example 3**:
If we have

```
using(var session = driver.Session())
{
    try{session.Run("Invalid");}
    catch{}
    session.Run("RETURN 1");
}
```

Then the sequence of messages for the first `Run` are:

```
-> INIT
<- SUCC_init

-> RUN
-> PULL_ALL
<- FAIL_run
<- IGNORE_pull_all
-> ACK_FAIL
```

Note, as we failed before streaming, on the `RUN` message, we will then give up streaming but just drain all the messages that wait for the reply immediately. Therefore we will also wait for `IGNORE` message for `PULL_ALL` message. Finally the `ACK_FAIL` is added so that we will try to reset the session back to a good state for the following statement. 

Then the messages for the second `Run` is the very same as the first example:

```
<- SUCC_ack_fail
-> RUN
-> PULL_ALL
<- SUCC_run

-> RESET
<- RECORD 1
<- SUCC_pull_all
<- SUCC_reset
```
