### PR TITLE
Config should provide default values if setting is not set by withXX methods

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) 2002-2016 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Neo4j.Driver.Internal;
+using Neo4j.Driver.V1;
+using Xunit;
+
+namespace Neo4j.Driver.Tests
+{
+    public class ConfigTests
+    {
+        public class DefaultConfigTests
+        {
+            [Fact]
+            public void DefaultConfigShouldGiveCorrectValueBack()
+            {
+                var config = Config.DefaultConfig;
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+        }
+
+        public class ConfigBuilderTests
+        {
+            [Fact]
+            public void WithLoggingShouldModifyTheSingleValue()
+            {
+                var config = Config.Builder.WithLogger(null).ToConfig();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeNull();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+
+            [Fact]
+            public void WithPoolSizeShouldModifyTheSingleValue()
+            {
+                var config = Config.Builder.WithMaxIdleSessionPoolSize(3).ToConfig();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(3);
+            }
+
+            [Fact]
+            public void WithEncryptionLevelShouldModifyTheSingleValue()
+            {
+                var config = Config.Builder.WithEncryptionLevel(EncryptionLevel.Encrypted).ToConfig();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.Encrypted);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+
+            [Fact]
+            public void ChangingNewConfigShouldNotAffectOtherConfig()
+            {
+                var config = Config.DefaultConfig;
+                var config1 = Config.Builder.WithMaxIdleSessionPoolSize(3).ToConfig();
+                var config2 = Config.Builder.WithLogger(null).ToConfig();
+                
+
+                config2.Logger.Should().BeNull();
+                config2.MaxIdleSessionPoolSize.Should().Be(10);
+
+                config1.MaxIdleSessionPoolSize.Should().Be(3);
+                config1.Logger.Should().BeOfType<DebugLogger>();
+
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.Logger.Should().BeOfType<DebugLogger>();
+                config.MaxIdleSessionPoolSize.Should().Be(10);
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -87,6 +87,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ConfigTests.cs" />
     <Compile Include="Connector\ChunkedOutputTest.cs" />
     <Compile Include="Connector\MessageResponseHandlerTests.cs" />
     <Compile Include="Connector\SocketExtensionTests.cs" />

--- a/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
@@ -39,10 +39,15 @@ namespace Neo4j.Driver.V1
         public const int InfiniteMaxIdleSessionPoolSize = -1;
         static Config()
         {
-            DefaultConfig = new Config
+            DefaultConfig = CreateNewConfig();
+        }
+
+        private static Config CreateNewConfig()
+        {
+            return new Config
             {
                 EncryptionLevel = EncryptionLevel.None,
-                Logger = new DebugLogger {Level = LogLevel.Info},
+                Logger = new DebugLogger { Level = LogLevel.Info },
                 MaxIdleSessionPoolSize = 10
             };
         }
@@ -63,7 +68,7 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Create an instance of <see cref="IConfigBuilder"/> to build a <see cref="Config"/>.
         /// </summary>
-        public static IConfigBuilder Builder => new ConfigBuilder(new Config());
+        public static IConfigBuilder Builder => new ConfigBuilder(CreateNewConfig());
 
         /// <summary>
         /// Gets or sets the use of encryption for all the connections created by the <see cref="IDriver"/>.


### PR DESCRIPTION
Fixed a bug in ConfigBuilder where the config returned by ConfigBuilder will not auto fill default values for the configs that are not changed.
