### PR TITLE
Streaming result

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
@@ -63,7 +63,7 @@ namespace Neo4j.Driver.IntegrationTests
             using (var session = driver.Session())
             {
                 var result = session.Run("PROFILE CREATE (p:Person { Name: 'Test'})");
-                var stats = result.Summary.Counters;
+                var stats = result.Consume().Counters;
                 _output.WriteLine(stats.ToString());
             }
         }
@@ -102,7 +102,7 @@ namespace Neo4j.Driver.IntegrationTests
                 var result1All = result1.ToList();
 
                 result2All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(4, 5, 6);
-                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(1, 2, 3);
+                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder();
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverEqualsFeatureSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/DriverEqualsFeatureSteps.cs
@@ -29,7 +29,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [Given(@"`(.*)` is single value result of: (.*)")]
         public void GivenValue1IsSingleValueResultOf(string key, string statement)
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 var statementResult = session.Run(statement);
                 var value = statementResult.Single()[0];

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/ErrorReportingSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/ErrorReportingSteps.cs
@@ -38,7 +38,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [When(@"`run` a query with that same session without closing the transaction first")]
         public void WhenRunAQueryWithThatSameSessionWithoutClosingTheTransactionFirst()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             using (var tx = session.BeginTransaction())
             {
                 var ex = Xunit.Record.Exception(() => session.Run("RETURN 1"));
@@ -50,7 +50,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [When(@"I start a new `Transaction` with the same session before closing the previous")]
         public void WhenIStartANewTransactionWithTheSameSessionBeforeClosingThePrevious()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             using (var tx = session.BeginTransaction())
             {
                 var ex = Xunit.Record.Exception(() => session.BeginTransaction());
@@ -62,7 +62,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [When(@"I run a non valid cypher statement")]
         public void WhenIRunANonValidCypherStatement()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 var ex = Xunit.Record.Exception(() => session.Run("Invalid Cypher"));
                 ex.Should().BeOfType<ClientException>();

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/MatchAcceptanceTestSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/MatchAcceptanceTestSteps.cs
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [Given(@"init: (.*)$")]
         public void GivenInit(string statement)
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 session.Run(statement);
             }
@@ -43,15 +43,13 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             ScenarioContext.Current.Pending();
         }
-        
+
         [When(@"running: (.*)$")]
         public void WhenRunning(string statement)
         {
-            using (var session = TckHooks.Driver.Session())
-            {
-                var result = session.Run(statement);
-                ScenarioContext.Current.Set(result);
-            }
+            var session = TckHooks.CreateSession();
+            var result = session.Run(statement);
+            ScenarioContext.Current.Set(result);
         }
 
         [Given(@"running: (.*)$")]
@@ -70,13 +68,13 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         public void WhenRunningParameterized(string statement, Table table)
         {
             table.RowCount.Should().Be(1);
-            var dict = table.Rows[0].Keys.ToDictionary<string, string, object>(key => key, key => _parser.Parse(table.Rows[0][key]));
+            var dict = table.Rows[0].Keys.ToDictionary<string, string, object>(key => key,
+                key => _parser.Parse(table.Rows[0][key]));
 
-            using (var session = TckHooks.Driver.Session())
-            {
-                var resultCursor = session.Run(statement, dict);
-                ScenarioContext.Current.Set(resultCursor);
-            }
+            var session = TckHooks.CreateSession();
+            var result = session.Run(statement, dict);
+            ScenarioContext.Current.Set(result);
+
         }
 
         [Given(@"running parametrized: (.*)$")]
@@ -88,7 +86,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         [BeforeScenario("@reset_database")]
         public void ResetDatabase()
         {
-            using (var session = TckHooks.Driver.Session())
+            using (var session = TckHooks.CreateSession())
             {
                 session.Run("MATCH (n) DETACH DELETE n");
             }
@@ -102,8 +100,8 @@ namespace Neo4j.Driver.Tck.Tests.TCK
             {
                 records.Add( new Record(row.Keys.ToArray(), row.Values.Select(value => _parser.Parse(value)).ToArray()));
             }
-            var resultCursor = ScenarioContext.Current.Get<IStatementResult>();
-            TckUtil.AssertRecordsAreTheSame(resultCursor.ToList(), records);
+            var result = ScenarioContext.Current.Get<IStatementResult>();
+            TckUtil.AssertRecordsAreTheSame(result.ToList(), records);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/TCK/TypeSystem.feature.steps.cs
@@ -112,11 +112,8 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         public void WhenTheDriverAsksTheServerToEchoThisValueBack()
         {
             var expected = ScenarioContext.Current.Get<object>(KeyExpected);
-            using (var session = TckHooks.Driver.Session())
-            {
-                _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", expected } });
-            }
-            
+            var session = TckHooks.CreateSession();
+            _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", expected } });
         }
 
         [When(@"the driver asks the server to echo this list back")]
@@ -124,11 +121,9 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             var list = ScenarioContext.Current.Get<IList<object>>(KeyList);
             ScenarioContext.Current.Set((object)list, KeyExpected);
-            using (var session = TckHooks.Driver.Session())
-            {
-                _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", list } });
-            }
-            
+
+            var session = TckHooks.CreateSession();
+            _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", list } });
         }
 
         [When(@"the driver asks the server to echo this map back")]
@@ -136,10 +131,9 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             var map = ScenarioContext.Current.Get<IDictionary<string, object>>(Keymap);
             ScenarioContext.Current.Set((object)map, KeyExpected);
-            using (var session = TckHooks.Driver.Session())
-            {
-                _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", map } });
-            }
+
+            var session = TckHooks.CreateSession();
+            _statementResult = session.Run("Return {input}", new Dictionary<string, object> { { "input", map } });
         }
 
         [When(@"the value given in the result should be the same as what was sent")]

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/TckHooks.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/TckHooks.cs
@@ -15,6 +15,7 @@
 // limitations under the License.
 using System;
 using Neo4j.Driver.IntegrationTests.Internals;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
 using TechTalk.SpecFlow;
 
@@ -23,10 +24,25 @@ namespace Neo4j.Driver.Tck.Tests.TCK
     [Binding]
     public static class TckHooks
     {
-        public static IDriver Driver;
+        private static IDriver _driver;
         public static INeo4jInstaller Installer;
         public const string Uri = "bolt://localhost";
         public static IAuthToken AuthToken;
+
+        public static ISession CreateSession()
+        {
+            var session = _driver.Session();
+            ScenarioContext.Current.Set(session);
+            return session;
+        }
+
+        [AfterScenario]
+        public static void DisposeSession()
+        {
+            ISession session;
+            ScenarioContext.Current.TryGetValue(out session);
+            session?.Dispose();
+        }
 
         [BeforeTestRun]
         public static void GlobalBeforeTestRun()
@@ -88,12 +104,12 @@ namespace Neo4j.Driver.Tck.Tests.TCK
 
         private static void DisposeDriver()
         {
-            Driver?.Dispose();
+            _driver?.Dispose();
         }
 
         private static void CreateNewDriver()
         {
-            Driver = GraphDatabase.Driver(Uri, AuthToken);
+            _driver = GraphDatabase.Driver(Uri, AuthToken);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
@@ -37,11 +37,11 @@ namespace Neo4j.Driver.Tests
                 var mockResultBuilder = new Mock<IResultBuilder>();
 
                 var mrh = new MessageResponseHandler();
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> {{"fields", new List<object> {"x"}}});
                 mrh.HandleRecordMessage(new object[] {"x"});
 
-                mockResultBuilder.Verify(x => x.Record(It.IsAny<object[]>()), Times.Once);
+                mockResultBuilder.Verify(x => x.CollectRecord(It.IsAny<object[]>()), Times.Once);
             }
 
             [Fact]
@@ -51,7 +51,7 @@ namespace Neo4j.Driver.Tests
                 var mockLogger = new Mock<ILogger>();
 
                 var mrh = new MessageResponseHandler(mockLogger.Object);
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> {{"fields", new List<object> {"x"}}});
 
                 mockLogger.ResetCalls();
@@ -70,7 +70,7 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.SentMessages.Should().HaveCount(1);
                 mrh.CurrentResultBuilder.Should().BeNull();
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
@@ -85,7 +85,7 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
                 mockResultBuilder.Verify(x=> x.CollectFields(It.IsAny<IDictionary<string, object>>()), Times.Once);
             }
@@ -97,7 +97,7 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "summary", new List<object> { "x" } } });
                 mockResultBuilder.Verify(x => x.CollectSummaryMeta(It.IsAny<IDictionary<string, object>>()), Times.Once);
             }
@@ -109,7 +109,7 @@ namespace Neo4j.Driver.Tests
                 var mockLogger = new Mock<ILogger>();
 
                 var mrh = new MessageResponseHandler(mockLogger.Object);
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
 
                 mockLogger.Verify(x => x.Debug(It.Is<string>(actual => actual.StartsWith("S: ")), It.Is<object[]>(actual => actual.First() is SuccessMessage)), Times.Once);
@@ -125,8 +125,8 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
                 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
                 // We need to handle the success message to et the CurrentResultBuilder
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
 
@@ -146,7 +146,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage("Neo.ClientError.General.ReadOnly", "message");
                 mrh.HasError.Should().BeTrue();
@@ -166,7 +166,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();
@@ -178,7 +178,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();
@@ -190,7 +190,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.Register(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
@@ -28,17 +28,17 @@ namespace Neo4j.Driver.Tests
     internal class ListBasedRecordSet : IRecordSet
     {
         private readonly IList<IRecord> _records;
+        private int _count = 0;
         private readonly RecordSet _recordSet;
-
-        public int Position => _recordSet.Position;
 
         public ListBasedRecordSet(IList<IRecord> records)
         {
             _records = records;
-            _recordSet = new RecordSet(_records, ()=>AtEnd);
+            _recordSet = new RecordSet(() => _records[_count++], () => !AtEnd);
         }
 
-        public bool AtEnd => _recordSet.Position >= _records.Count;
+        public bool AtEnd => _count >= _records.Count;
+        
         public IRecord Peek()
         {
             return _recordSet.Peek();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -14,6 +14,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -44,11 +46,13 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectType()
             {
                 var builder = new ResultBuilder();
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 { {"type", "r" } };
                 builder.CollectSummaryMeta(meta);
 
                 var result = builder.Build();
+                result.Consume();
                 result.Summary.StatementType.Should().Be(StatementType.ReadOnly);
             }
 
@@ -56,11 +60,13 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectStattistics()
             {
                 var builder = new ResultBuilder();
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 { {"type", "r" }, {"stats", new Dictionary<string, object> { {"nodes-created", 10L}, {"nodes-deleted", 5L} } } };
                 builder.CollectSummaryMeta(meta);
 
                 var result = builder.Build();
+                result.Consume();
                 var statistics = result.Summary.Counters;
                 statistics.NodesCreated.Should().Be(10);
 
@@ -70,6 +76,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectNotifications()
             {
                 var builder = new ResultBuilder();
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r" },
@@ -96,6 +103,7 @@ namespace Neo4j.Driver.Tests
                 InputPosition position = new InputPosition(0,0,0);
 
                 var result = builder.Build();
+                result.Consume();
                 var notifications = result.Summary.Notifications;
                 notifications.Should().HaveCount(2);
                 notifications[0].Code.Should().Be("CODE");
@@ -117,6 +125,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectSimplePlan()
             {
                 var builder = new ResultBuilder();
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {   {"type", "r" },
                     { "plan", new Dictionary<string, object>
@@ -126,6 +135,7 @@ namespace Neo4j.Driver.Tests
                 builder.CollectSummaryMeta(meta);
 
                 var result = builder.Build();
+                result.Consume();
                 var plan = result.Summary.Plan;
                 plan.OperatorType.Should().Be("X");
                 plan.Arguments.Should().BeEmpty();
@@ -138,6 +148,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectPlanThatContainsPlans()
             {
                 var builder = new ResultBuilder();
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r"},
@@ -173,6 +184,7 @@ namespace Neo4j.Driver.Tests
                 builder.CollectSummaryMeta(meta);
 
                 var result = builder.Build();
+                result.Consume();
                 var plan = result.Summary.Plan;
                 plan.OperatorType.Should().Be("X");
                 plan.Arguments.Should().ContainKey("a");
@@ -193,6 +205,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectProfiledPlanThatContainsProfiledPlans()
             {
                 var builder = new ResultBuilder();
+                builder.ReceiveOneRecordMessageFunc = () => false;
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r"},
@@ -239,6 +252,7 @@ namespace Neo4j.Driver.Tests
                 builder.CollectSummaryMeta(meta);
 
                 var result = builder.Build();
+                result.Consume();
                 var profile = result.Summary.Profile;
                 profile.DbHits.Should().Be(1L);
                 profile.OperatorType.Should().Be("X");
@@ -289,13 +303,20 @@ namespace Neo4j.Driver.Tests
             public void ShouldStreamResults()
             {
                 var builder = GenerateBuilder();
+                var i = 0;
+                builder.ReceiveOneRecordMessageFunc = () =>
+                {
+                    if (i++ >= 3)
+                    {
+                        builder.CollectSummaryMeta(null);
+                        return false;
+                    }
+                    builder.CollectRecord(new object[] { 123 });
+                    return true;
+                };
                 var cursor = builder.Build();
 
                 var t = AssertGetExpectResults(cursor, 3);
-                builder.Record(new object[] {123});
-                builder.Record(new object[] {123});
-                builder.Record(new object[] {123});
-                builder.CollectSummaryMeta(null);
                 t.Wait();
             }
 
@@ -303,27 +324,15 @@ namespace Neo4j.Driver.Tests
             public void ShouldReturnNoResultsWhenNoneRecieved()
             {
                 var builder = GenerateBuilder();
+                builder.ReceiveOneRecordMessageFunc = () =>
+                {
+                    builder.CollectSummaryMeta(null);
+                    return false;
+                };
                 var cursor = builder.Build();
 
                 var t = AssertGetExpectResults(cursor, 0);
 
-                builder.CollectSummaryMeta(null);
-
-                t.Wait();
-            }
-
-            [Fact]
-            public void ShouldReturnQueuedResults()
-            {
-                var builder = GenerateBuilder();
-                var cursor = builder.Build();
-
-                builder.Record(new object[] { 123 });
-                builder.Record(new object[] { 123 });
-                builder.Record(new object[] { 123 });
-                builder.CollectSummaryMeta(null);
-
-                var t = AssertGetExpectResults(cursor, 3);
                 t.Wait();
             }
 
@@ -331,8 +340,6 @@ namespace Neo4j.Driver.Tests
             public void ShouldReturnQueuedResultsWithExspectedValue()
             {
                 var builder = GenerateBuilder();
-                var cursor = builder.Build();
-
                 List<object> recordValues = new List<object>
                 {
                     1,
@@ -340,12 +347,18 @@ namespace Neo4j.Driver.Tests
                     false,
                     10
                 };
-
-                foreach (var recordValue in recordValues)
-                { 
-                    builder.Record(new object[] { recordValue });
-                }
-                builder.CollectSummaryMeta(null);
+                var i = 0;
+                builder.ReceiveOneRecordMessageFunc = () =>
+                {
+                    if (i < recordValues.Count)
+                    {
+                        builder.CollectRecord(new[] { recordValues[i++] });
+                        return true;
+                    }
+                    builder.CollectSummaryMeta(null);
+                    return false;
+                };
+                var cursor = builder.Build();
 
                 var task = AssertGetExpectResults(cursor, recordValues.Count, recordValues);
                 task.Wait();
@@ -357,22 +370,16 @@ namespace Neo4j.Driver.Tests
             private static ICounters DefaultCounters => new Counters();
 
             [Fact]
-            public void ShouldSetNoMoreRecords()
-            {
-                var builder = new ResultBuilder();
-
-                builder.HasMoreRecords.Should().BeTrue();
-                builder.CollectSummaryMeta(null);
-                builder.HasMoreRecords.Should().BeFalse();
-            }
-
-            [Fact]
             public void DoesNothingWhenMetaIsNull()
             {
                 var builder = new ResultBuilder();
-
-                builder.CollectSummaryMeta(null);
+                builder.ReceiveOneRecordMessageFunc = () =>
+                {
+                    builder.CollectSummaryMeta(null);
+                    return false;
+                };
                 var actual = builder.Build();
+                actual.Consume();
 
                 actual.Summary.HasPlan.Should().BeFalse();
                 actual.Summary.HasProfile.Should().BeFalse();
@@ -399,8 +406,13 @@ namespace Neo4j.Driver.Tests
                         {"type", typeValue}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
 
                     actual.Summary.StatementType.Should().Be(expected);
                 }
@@ -414,8 +426,13 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.StatementType.Should().Be(StatementType.Unknown);
                 }
 
@@ -444,8 +461,13 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Counters.ShouldBeEquivalentTo(DefaultCounters);
                 }
 
@@ -471,8 +493,12 @@ namespace Neo4j.Driver.Tests
                         } }
                     };
 
-                    builder.CollectSummaryMeta(meta);
-                    var actual = builder.Build().Summary.Counters;
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build().Consume().Counters;
                     actual.Should().NotBeNull();
 
                     actual.NodesCreated.Should().Be(1);
@@ -499,9 +525,14 @@ namespace Neo4j.Driver.Tests
                     {
                         {"something", "unknown"}
                     };
-
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Plan.Should().BeNull();
                     actual.Summary.HasPlan.Should().BeFalse();
                 }
@@ -515,8 +546,14 @@ namespace Neo4j.Driver.Tests
                         {"plan", new Dictionary<string,object>()}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Plan.Should().BeNull();
                     actual.Summary.HasPlan.Should().BeFalse();
                 }
@@ -530,8 +567,14 @@ namespace Neo4j.Driver.Tests
                         {"plan", null}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Plan.Should().BeNull();
                     actual.Summary.HasPlan.Should().BeFalse();
                 }
@@ -550,8 +593,16 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    var ex = Xunit.Record.Exception(() => builder.CollectSummaryMeta(meta));
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build();
+
+                    var ex = Xunit.Record.Exception(() => actual.Consume());
                     ex.Should().BeOfType<Neo4jException>();
+                    ex.Message.Should().Be("Required property 'operatorType' is not in the response.");
                 }
 
                 [Fact]
@@ -568,8 +619,14 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Plan.Should().NotBeNull();
                     actual.Summary.HasPlan.Should().BeTrue();
                     
@@ -597,8 +654,14 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Plan.Should().NotBeNull();
                     actual.Summary.HasPlan.Should().BeTrue();
 
@@ -642,8 +705,12 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
-                    var actual = builder.Build().Summary.Plan.Children.Single();
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build().Consume().Plan.Children.Single();
 
                     actual.Arguments.Should().HaveCount(1);
                     actual.Arguments.Should().ContainKey("child_a");
@@ -695,8 +762,12 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
-                    var actual = builder.Build().Summary.Plan.Children.Single().Children.Single();
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build().Consume().Plan.Children.Single().Children.Single();
 
                     actual.Arguments.Should().HaveCount(1);
                     actual.Arguments.Should().ContainKey("childChild_a");
@@ -722,8 +793,14 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Profile.Should().BeNull();
                     actual.Summary.HasProfile.Should().BeFalse();
                 }
@@ -737,8 +814,14 @@ namespace Neo4j.Driver.Tests
                         {"profile", new Dictionary<string,object>()}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Profile.Should().BeNull();
                     actual.Summary.HasProfile.Should().BeFalse();
                 }
@@ -752,8 +835,14 @@ namespace Neo4j.Driver.Tests
                         {"profile", null}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Profile.Should().BeNull();
                     actual.Summary.HasProfile.Should().BeFalse();
                 }
@@ -774,8 +863,16 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    var ex = Xunit.Record.Exception(() => builder.CollectSummaryMeta(meta));
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build();
+
+                    var ex = Xunit.Record.Exception(() => actual.Consume());
                     ex.Should().BeOfType<Neo4jException>();
+                    ex.Message.Should().Be("Required property 'operatorType' is not in the response.");
                 }
 
                 [Fact]
@@ -793,8 +890,16 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    var ex = Xunit.Record.Exception(() => builder.CollectSummaryMeta(meta));
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build();
+
+                    var ex = Xunit.Record.Exception(() => actual.Consume());
                     ex.Should().BeOfType<Neo4jException>();
+                    ex.Message.Should().Be("Required property 'rows' is not in the response.");
                 }
 
                 [Fact]
@@ -812,8 +917,16 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    var ex = Xunit.Record.Exception(() => builder.CollectSummaryMeta(meta));
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
+                    var actual = builder.Build();
+
+                    var ex = Xunit.Record.Exception(() => actual.Consume());
                     ex.Should().BeOfType<Neo4jException>();
+                    ex.Message.Should().Be("Required property 'dbHits' is not in the response.");
                 }
 
                 [Fact]
@@ -832,8 +945,14 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
+
                     actual.Summary.Profile.Should().NotBeNull();
                     actual.Summary.HasProfile.Should().BeTrue();
 
@@ -866,8 +985,13 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Profile.Should().NotBeNull();
                     actual.Summary.HasProfile.Should().BeTrue();
 
@@ -919,8 +1043,13 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Profile.Should().NotBeNull();
                     actual.Summary.HasProfile.Should().BeTrue();
 
@@ -985,8 +1114,13 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Profile.Should().NotBeNull();
                     actual.Summary.HasProfile.Should().BeTrue();
 
@@ -1019,8 +1153,13 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Notifications.Should().BeEmpty();
                 }
 
@@ -1051,8 +1190,13 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Notifications.Should().HaveCount(1);
 
                     var n = actual.Summary.Notifications.Single();
@@ -1105,8 +1249,13 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.CollectSummaryMeta(meta);
+                    builder.ReceiveOneRecordMessageFunc = () =>
+                    {
+                        builder.CollectSummaryMeta(meta);
+                        return false;
+                    };
                     var actual = builder.Build();
+                    actual.Consume();
                     actual.Summary.Notifications.Should().HaveCount(2);
 
                     var n = actual.Summary.Notifications.Skip(1).Single();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -50,7 +50,7 @@ namespace Neo4j.Driver.Tests
 
                 mockConn.Verify(x => x.Run(It.IsAny<ResultBuilder>(), "lalalal", null), Times.Once);
                 mockConn.Verify(x => x.PullAll(It.IsAny<ResultBuilder>()), Times.Once);
-                mockConn.Verify(x => x.Sync());
+                mockConn.Verify(x => x.SyncRun());
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -48,7 +48,7 @@ namespace Neo4j.Driver.Tests
         public class RunMethod
         {
             [Fact]
-            public void ShouldRunPullAllSync()
+            public void ShouldRunPullAllSyncRun()
             {
                 var mockConn = new Mock<IConnection>();
                 var tx = new Transaction(mockConn.Object);
@@ -57,7 +57,7 @@ namespace Neo4j.Driver.Tests
 
                 mockConn.Verify(x => x.Run(It.IsAny<ResultBuilder>(), "lalala", null), Times.Once);
                 mockConn.Verify(x => x.PullAll(It.IsAny<ResultBuilder>()), Times.Once);
-                mockConn.Verify(x => x.Sync(), Times.Once);
+                mockConn.Verify(x => x.SyncRun(), Times.Once);
                 tx.Finished.Should().BeFalse();
             }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -23,8 +23,9 @@ namespace Neo4j.Driver.Internal.Connector
     internal interface IConnection : IDisposable
     {
         void Sync();
-        void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> parameters=null);
-        void PullAll(ResultBuilder resultBuilder);
+        void SyncRun();
+        void Run(IResultBuilder resultBuilder, string statement, IDictionary<string, object> parameters=null);
+        void PullAll(IResultBuilder resultBuilder);
         void DiscardAll();
         void Reset();
         bool IsOpen { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -14,6 +14,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Messaging;
@@ -24,7 +26,11 @@ namespace Neo4j.Driver.Internal.Connector
     {
         Task Start();
         Task Stop();
-        void Send(IEnumerable<IRequestMessage> messages, IMessageResponseHandler responseHandler);
+        void Send(IEnumerable<IRequestMessage> messages);
+        /* Recieve until unhandledMessageSize messages are left in unhandled message queue */
+        void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0);
+        /* Return true if a record message is received, otherwise false. */
+        bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction );
         bool IsOpen { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -94,47 +94,77 @@ namespace Neo4j.Driver.Internal.Connector
             IsOpen = false;
         }
 
-        public void Send(IEnumerable<IRequestMessage> messages, IMessageResponseHandler responseHandler)
+        public void Send(IEnumerable<IRequestMessage> messages)
         {
             foreach (var message in messages)
             {
                 _writer.Write(message);
                 _config.Logger?.Debug("C: ", message);
             }
-
             _writer.Flush();
-
-            Receive(responseHandler);
         }
 
         public bool IsOpen { get; private set; }
 
-        private void Receive(IMessageResponseHandler responseHandler)
+        /// <summary>
+        /// This method highly relies on the fact that the session is not threadsafe and could only be used in a single thread
+        /// as if two threads trying to modify the message size, then we might
+        /// 1. force to pull all instead of streaming records
+        /// 2. lose some records as only one record is buffered in result builder on client.
+        /// </summary>
+        public void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0)
         {
-            while (!responseHandler.QueueIsEmpty())
+            while (responseHandler.UnhandledMessageSize > unhandledMessageSize 
+                || (responseHandler.HasError && responseHandler.UnhandledMessageSize > 0)
+                /*if error happens, then just drain the whole unhandledMessage queue*/)
             {
-                try
+                ReceiveOne(responseHandler);
+                //Read 1 message
+                //Send to handler
+            }
+        }
+
+        /// <summary>
+        /// This method will not throw exception if a railure message is received
+        /// </summary>
+        private void ReceiveOne(IMessageResponseHandler responseHandler)
+        {
+            try
+            {
+                _reader.Read(responseHandler);
+            }
+            catch (Exception ex)
+            {
+                _config.Logger.Error("Unable to unpack message from server, connection has been terminated.", ex);
+                Task.Run(() => Stop()).Wait();
+                throw;
+            }
+            if (responseHandler.HasError)
+            {
+                if (responseHandler.Error.Code.ToLowerInvariant().Contains("clienterror.request"))
                 {
-                    _reader.Read(responseHandler);
-                }
-                catch (Exception ex)
-                {
-                    _config.Logger.Error("Unable to unpack message from server, connection has been terminated.", ex);
                     Task.Run(() => Stop()).Wait();
-                    throw;
-                }
-                if (responseHandler.HasError)
-                {
-                    if (responseHandler.Error.Code.ToLowerInvariant().Contains("clienterror.request"))
-                    {
-                        Task.Run(() => Stop()).Wait();
-                        throw responseHandler.Error;
-                    }
+                    throw responseHandler.Error;
                 }
             }
-            //Read 1 message
-            //Send to handler,
-            //While messages read < messages handled keep doing above.
+        }
+
+        /// <summary>
+        /// Return true if a record message is received, otherwise false.
+        /// This method will throw the exception if a failure message is received.
+        /// </summary>
+        public bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction)
+        {
+            if (responseHandler.UnhandledMessageSize == 0)
+            {
+                return false;
+            }
+            ReceiveOne(responseHandler);
+            if (responseHandler.HasError)
+            {
+                onFailureAction.Invoke();
+            }
+            return responseHandler.IsRecordMessageReceived;
         }
 
         private async Task<int> DoHandshake()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -27,7 +27,7 @@ namespace Neo4j.Driver.Internal.Connector
     internal class SocketConnection : IConnection
     {
         private readonly ISocketClient _client;
-        private readonly IMessageResponseHandler _messageHandler;
+        private readonly IMessageResponseHandler _responseHandler;
 
         private readonly Queue<IRequestMessage> _messages = new Queue<IRequestMessage>();
 
@@ -35,13 +35,13 @@ namespace Neo4j.Driver.Internal.Connector
             IMessageResponseHandler messageResponseHandler = null)
         {
             Throw.ArgumentNullException.IfNull(socketClient, nameof(socketClient));
-            _messageHandler = messageResponseHandler ?? new MessageResponseHandler(logger);
+            _responseHandler = messageResponseHandler ?? new MessageResponseHandler(logger);
 
             _client = socketClient;
             Task.Run(() => _client.Start()).Wait();
 
             // add init requestMessage by default
-            Enqueue(new InitMessage("neo4j-dotnet/1.0", authToken.AsDictionary()));
+            Enqueue(new InitMessage("neo4j-dotnet/1.1", authToken.AsDictionary()));
             Sync();
         }
 
@@ -58,35 +58,54 @@ namespace Neo4j.Driver.Internal.Connector
             GC.SuppressFinalize(this);
         }
 
-        public void Sync()
+        private void SendAndReceive(int unhandledMessageCount = 0)
         {
             if (_messages.Count == 0)
             {
                 return;
             }
 
-            _client.Send(_messages, _messageHandler);
+            // blocking to send
+            _client.Send(_messages);
             ClearQueue(); // clear sending queue
+            // blocking to receive
+            _client.Receive(_responseHandler, unhandledMessageCount);
 
-            if (_messageHandler.HasError)
+            if (_responseHandler.HasError)
             {
-                Enqueue(new AckFailureMessage());
-                throw _messageHandler.Error;
+                OnResponseHasError();
             }
         }
 
-        public bool HasUnrecoverableError
-            => _messageHandler.Error is DatabaseException;
+        private void OnResponseHasError()
+        {
+            Enqueue(new AckFailureMessage());
+            throw _responseHandler.Error;
+        }
 
-        public void Run(ResultBuilder resultBuilder, string statement, IDictionary<string, object> paramters=null)
+        public void Sync()
+        {
+            SendAndReceive();
+        }
+
+        public void SyncRun()
+        {
+            SendAndReceive(1); // blocking to receive unitl 1 message unhandled left (PULL_ALL)
+        }
+
+        public bool HasUnrecoverableError
+            => _responseHandler.Error is DatabaseException;
+
+        public void Run(IResultBuilder resultBuilder, string statement, IDictionary<string, object> paramters=null)
         {
             var runMessage = new RunMessage(statement, paramters);
             Enqueue(runMessage, resultBuilder);
         }
 
-        public void PullAll(ResultBuilder resultBuilder)
+        public void PullAll(IResultBuilder resultBuilder)
         {
             Enqueue(new PullAllMessage(), resultBuilder);
+            resultBuilder.ReceiveOneRecordMessageFunc = () => _client.ReceiveOneRecordMessage(_responseHandler, OnResponseHasError);
         }
 
         public void DiscardAll()
@@ -96,8 +115,6 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void Reset()
         {
-            ClearQueue();
-            _messageHandler.Clear();
             Enqueue(new ResetMessage());
         }
 
@@ -117,10 +134,10 @@ namespace Neo4j.Driver.Internal.Connector
             _messages.Clear();
         }
 
-        private void Enqueue(IRequestMessage requestMessage, ResultBuilder resultBuilder = null)
+        private void Enqueue(IRequestMessage requestMessage, IResultBuilder resultBuilder = null)
         {
             _messages.Enqueue(requestMessage);
-            _messageHandler.Register(requestMessage, resultBuilder);
+            _responseHandler.RegisterMessage(requestMessage, resultBuilder);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DebugLogger.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections;
 using System.Linq;
-using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -38,8 +38,9 @@ namespace Neo4j.Driver.Internal.Messaging
         void HandleFailureMessage(string code, string message);
         void HandleIgnoredMessage();
         void HandleRecordMessage(object[] fields);
-        void Register(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
+        void RegisterMessage(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
         void Clear();
-        bool QueueIsEmpty();
+        int UnhandledMessageSize { get; }
+        bool IsRecordMessageReceived { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -14,15 +14,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
 using System.Collections.Generic;
 
 namespace Neo4j.Driver.Internal.Result
 {
     internal interface IResultBuilder
     {
-        void Record(object[] fields);
+        void CollectRecord(object[] fields);
         StatementResult Build();
         void CollectFields(IDictionary<string, object> meta);
         void CollectSummaryMeta(IDictionary<string, object> meta);
+        Func<bool> ReceiveOneRecordMessageFunc { set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/RecordSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/RecordSet.cs
@@ -14,56 +14,80 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Result
 {
     internal class RecordSet : IRecordSet
     {
-        private readonly Func<bool> _atEnd;
-        internal int Position = 0;
-        private readonly IList<IRecord> _records;
+        private readonly Func<bool> _receiveOneRecordMessageFunc;
+        private readonly Func<IRecord> _recordFunc;
 
-        public RecordSet(IList<IRecord> records, Func<bool> atEnd)
+        private IRecord _peekedRecord;
+
+        public RecordSet(Func<IRecord> recordFunc, Func<bool> receiveOneRecordMessageFunc)
         {
-            _records = records;
-            _atEnd = atEnd;
+            _recordFunc = recordFunc;
+            _receiveOneRecordMessageFunc = receiveOneRecordMessageFunc;
         }
 
-        public bool AtEnd => _atEnd();
+        public bool AtEnd { get; private set; }
 
         public IEnumerable<IRecord> Records()
         {
-            while (!AtEnd || Position <= _records.Count)
+            while (!HasReadAllRecords())
             {
-                while (Position == _records.Count)
-                {
-                    Task.Delay(50).Wait();
-                    if (AtEnd && Position == _records.Count)
-                        yield break;
-                }
+                // first try to return if already retrived,
+                // otherwise pull from input stream
 
-                yield return _records[Position++];
-//                Position++;
+                if (_peekedRecord != null)
+                {
+                    var record = _peekedRecord;
+                    _peekedRecord = null;
+                    yield return record;
+                }
+                else
+                {
+                    AtEnd = !_receiveOneRecordMessageFunc.Invoke();
+                    if (!AtEnd)
+                    {
+                        yield return _recordFunc.Invoke();
+                    }
+                }
             }
+        }
+
+        private bool HasReadAllRecords()
+        {
+            return AtEnd && _peekedRecord == null;
         }
 
         public IRecord Peek()
         {
-            while (Position >= _records.Count) // Peeking record not received
+            // we did not move the cursor in the stream
+            if (_peekedRecord != null)
             {
-                if (AtEnd && Position >= _records.Count)
-                {
-                    return null;
-                }
-
-                Task.Delay(50).Wait();
+                return _peekedRecord;
             }
-
-            return _records[Position];
+            // we already arrived at the end of the stream
+            if (AtEnd)
+            {
+                return null;
+            }
+            // we still in the middle of the stream and we need to pull from input buffer
+            AtEnd = !_receiveOneRecordMessageFunc.Invoke();
+            if (AtEnd) // well the message received is a success
+            {
+                return null;
+            }
+            else // we get another record message
+            {
+                _peekedRecord = _recordFunc.Invoke();
+                return _peekedRecord;
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -80,7 +80,7 @@ namespace Neo4j.Driver.Internal
                 var resultBuilder = new ResultBuilder(statement, statementParameters);
                 _connection.Run(resultBuilder, statement, statementParameters);
                 _connection.PullAll(resultBuilder);
-                _connection.Sync();
+                _connection.SyncRun();
 
                 return resultBuilder.Build();
             });

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -109,7 +109,7 @@ namespace Neo4j.Driver.Internal
                     var resultBuilder = new ResultBuilder(statement, parameters);
                     _connection.Run(resultBuilder, statement, parameters);
                     _connection.PullAll(resultBuilder);
-                    _connection.Sync();
+                    _connection.SyncRun();
                     return resultBuilder.Build();
                 }
                 catch (Neo4jException)


### PR DESCRIPTION
**Example 1**:
If I run

```
using(var session = driver.Session())
{
    var result = session.Run("RETURN 1");
}
```

The sequence of messages to exchange between client and server are:

```
-> INIT
<- SUCC_init

-> RUN
-> PULL_ALL
<- SUCC_run
```

After `}` the `session.Dispose()` will result in message sequence:

```
-> RESET
<- RECORD 1
<- SUCC_pull_all
<- SUCC_reset
```

So the RUN, PULL_ALL messages are eagerly sent, the SUCC for RUN is also eagerly received, but for records, it will only be retrieved in `result.Consume()` or similar iterations. If no result is iterated before the session is disposed, then the `RESET` message will force to sync all unhandled messages to make sure the session is clean when it returned to pool.

**Example 2**:
When I run

```
using(var session = driver.Session())
{
    session.Run("RETURN 1");
    var result = session.Run("RETURN 2");
    result.ToList();
}
```

Then the sequence of the messages are:

```
-> INIT
<- SUCC_init

 // run(return 1)
-> RUN
-> PULL_ALL
<- SUCC_run

// run(return 2)
-> RUN'
-> PULL_ALL'
<- RECORD 1
<- SUCC_pull_all
<- SUCC_run'

// result.ToList
<- RECORD 2
<-SUCC_pull_all'
```

In this case, as we did not save the result of the first `Run`, so they will just get lost if the second `Run` start to consume the result first. (We will improve this to cleverly buffer the results latter)

**Example 3**:
If we have

```
using(var session = driver.Session())
{
    try{session.Run("Invalid");}
    catch{}
    session.Run("RETURN 1");
}
```

Then the sequence of messages for the first `Run` are:

```
-> INIT
<- SUCC_init

-> RUN
-> PULL_ALL
<- FAIL_run
<- IGNORE_pull_all
-> ACK_FAIL
```

Note, as we failed before streaming, on the `RUN` message, we will then give up streaming but just drain all the messages that wait for the reply immediately. Therefore we will also wait for `IGNORE` message for `PULL_ALL` message. Finally the `ACK_FAIL` is added so that we will try to reset the session back to a good state for the following statement.

Then the messages for the second `Run` is the very same as the first example:

```
<- SUCC_ack_fail
-> RUN
-> PULL_ALL
<- SUCC_run

-> RESET
<- RECORD 1
<- SUCC_pull_all
<- SUCC_reset
```

In the new streaming design, there are two paths to receive messages from the server.
One is SocketClient.Receive (Session.Run()), another is iterator in RecordSet (result.Next()).
The one in RecordSet is pulled out for streaming records in result.

When handing failures, we also need to consider the two paths.
If an error happens before we start streaming records, then we will drain all the unhandled message queue and then throw the exception to the user to report the failure
INIT (sync), RUN, PULL_ALL (syncRun)
SUCC,        FAIL,IGNORE

However when the error arises after we start streaming the records, if the error is seen in streaming, then exception will be thrown immediately and the streaming will be stopped.
Any unhandled messages in the queue will not be addressed until ACK_FAIL or RESET is sent next time.
If the error is not seen during streaming, then the exception will be thrown when RESET is sent (in session.Dispose()).
INIT (sync), RUN, PULL_ALL (syncRun), (result.Consume()),RESET(sync)
SUCC,        SUCC,                     RECORD, FAIL,     SUCC

On Reset, all pending messages will be synced to ensure all records from the current session are consumed
