### PR TITLE
buffer stream result

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
@@ -107,6 +107,55 @@ namespace Neo4j.Driver.IntegrationTests
         }
 
         [Fact]
+        public void ResultsHaveNotBeenReadGetLostAfterSessionClosed()
+        {
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
+            {
+                IStatementResult result;
+                using (var session = driver.Session())
+                {
+                    result = session.Run("unwind range(1,3) as n RETURN n");
+                }
+                var resultAll = result.ToList();
+
+                // Records that has not been read inside session get lost
+                resultAll.Count.Should().Be(0);
+                resultAll.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder();
+
+                // Summary is still saved
+                result.Summary.Statement.Text.Should().Be("unwind range(1,3) as n RETURN n");
+                result.Summary.StatementType.Should().Be(StatementType.ReadOnly);
+            }
+        }
+
+        [Fact]
+        public void BuffersResultsOfOneTxSoTheyCanBeReadAfterAnotherSubsequentTx()
+        {
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
+            using (var session = driver.Session())
+            {
+                IStatementResult result1, result2;
+                using (var tx = session.BeginTransaction())
+                {
+                    result1 = tx.Run("unwind range(1,3) as n RETURN n");
+                    tx.Success();
+                }
+
+                using (var tx = session.BeginTransaction())
+                {
+                    result2 = tx.Run("unwind range(4,6) as n RETURN n");
+                    tx.Success();
+                }
+
+                var result2All = result2.ToList();
+                var result1All = result1.ToList();
+
+                result2All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(4, 5, 6);
+                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(1, 2, 3);
+            }
+        }
+
+        [Fact]
         public void TheSessionErrorShouldBeClearedForEachSession()
         {
             using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
@@ -102,7 +102,7 @@ namespace Neo4j.Driver.IntegrationTests
                 var result1All = result1.ToList();
 
                 result2All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(4, 5, 6);
-                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder();
+                result1All.Select(r => r.Values["n"].ValueAs<int>()).Should().ContainInOrder(1, 2, 3);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
@@ -32,6 +32,20 @@ namespace Neo4j.Driver.Tests
         public class HandleRecordMessageMethod
         {
             [Fact]
+            public void NotDequeueFromSentMessagesOrSetsCurrentBuilder()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+                var mrh = new MessageResponseHandler();
+
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.SentMessages.Should().HaveCount(1);
+                mrh.CurrentResultBuilder.Should().BeNull();
+                mrh.HandleRecordMessage(new object[] { "x" });
+                mrh.SentMessages.Should().HaveCount(1);
+                mrh.CurrentResultBuilder.Should().BeNull();
+            }
+
+            [Fact]
             public void CallsRecordOnTheCurrentResultBuilder()
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
@@ -69,7 +83,6 @@ namespace Neo4j.Driver.Tests
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
 
-                // Two messages are queued, as one will be popped off when handling a success message.
                 mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.SentMessages.Should().HaveCount(1);
                 mrh.CurrentResultBuilder.Should().BeNull();
@@ -84,22 +97,20 @@ namespace Neo4j.Driver.Tests
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
 
-                // Two messages are queued, as one will be popped off when handling a success message.
                 mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
                 mockResultBuilder.Verify(x=> x.CollectFields(It.IsAny<IDictionary<string, object>>()), Times.Once);
             }
 
             [Fact]
-            public void ShouldTryToCollectSummaryMetaIfMessageDoesNotContainFields()
+            public void ShouldTryToCollectSummaryIfMessageDoesNotContainFields()
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
 
-                // Two messages are queued, as one will be popped off when handling a success message.
                 mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "summary", new List<object> { "x" } } });
-                mockResultBuilder.Verify(x => x.CollectSummaryMeta(It.IsAny<IDictionary<string, object>>()), Times.Once);
+                mockResultBuilder.Verify(x => x.CollectSummary(It.IsAny<IDictionary<string, object>>()), Times.Once);
             }
 
             [Fact]
@@ -114,48 +125,72 @@ namespace Neo4j.Driver.Tests
 
                 mockLogger.Verify(x => x.Debug(It.Is<string>(actual => actual.StartsWith("S: ")), It.Is<object[]>(actual => actual.First() is SuccessMessage)), Times.Once);
             }
-        }
-
-        public class ClearMethod
-        {
-            [Fact]
-            public void ShouldClearResultBuildersSendMessagesAndTheCurrentBuilder()
-            {
-                var mockResultBuilder = new Mock<IResultBuilder>();
-                var mrh = new MessageResponseHandler();
-                
-                // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
-                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
-                // We need to handle the success message to et the CurrentResultBuilder
-                mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
-
-                mrh.SentMessages.Should().HaveCount(1);
-                mrh.ResultBuilders.Should().HaveCount(1);
-                mrh.CurrentResultBuilder.Should().NotBeNull();
-
-                mrh.Clear();
-
-                mrh.SentMessages.Should().HaveCount(0);
-                mrh.ResultBuilders.Should().HaveCount(0);
-                mrh.CurrentResultBuilder.Should().BeNull();
-            }
 
             [Fact]
             public void ShouldClearErrorState()
             {
-                var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage());
+                mrh.EnqueueMessage(new PullAllMessage());
 
                 mrh.HandleFailureMessage("Neo.ClientError.General.ReadOnly", "message");
                 mrh.HasError.Should().BeTrue();
                 mrh.Error.Should().BeOfType<ClientException>();
 
-                mrh.Clear();
+                mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
 
                 mrh.HasError.Should().BeFalse();
                 mrh.Error.Should().BeNull();
+            }
+        }
+
+        public class HandleIgnoredMessageMethod
+        {
+            [Fact]
+            public void DequeuesFromSentMessagesAndSetsCurrentBuilder()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+                var mrh = new MessageResponseHandler();
+
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.SentMessages.Should().HaveCount(1);
+                mrh.CurrentResultBuilder.Should().BeNull();
+                mrh.HandleIgnoredMessage();
+                mrh.SentMessages.Should().HaveCount(0);
+                mrh.CurrentResultBuilder.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void ShouldCallInvalidateResultIfCurrentResultBuilderNotNull()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.HandleIgnoredMessage();
+
+                mockResultBuilder.Verify(x => x.InvalidateResult(), Times.Once);
+            }
+
+            [Fact]
+            public void ShouldNoNPEIfCurrentResultBuilderIsNull()
+            {
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage());
+                mrh.HandleIgnoredMessage();
+            }
+
+            [Fact]
+            public void LogsTheMessageToDebug()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+                var mockLogger = new Mock<ILogger>();
+
+                var mrh = new MessageResponseHandler(mockLogger.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.HandleIgnoredMessage();
+
+                mockLogger.Verify(x => x.Debug(It.Is<string>(actual => actual.StartsWith("S: ")), It.Is<object[]>(actual => actual.First() is IgnoredMessage)), Times.Once);
             }
         }
 
@@ -195,6 +230,53 @@ namespace Neo4j.Driver.Tests
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();
                 mrh.Error.Should().BeOfType<DatabaseException>();
+            }
+
+            [Fact]
+            public void DequeuesFromSentMessagesAndSetsCurrentBuilder()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+                var mrh = new MessageResponseHandler();
+
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.SentMessages.Should().HaveCount(1);
+                mrh.CurrentResultBuilder.Should().BeNull();
+                mrh.HandleFailureMessage("code.error", "message");
+                mrh.SentMessages.Should().HaveCount(0);
+                mrh.CurrentResultBuilder.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void ShouldCallInvalidateResultIfCurrentResultBuilderNotNull()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.HandleFailureMessage("code.error", "message");
+
+                mockResultBuilder.Verify(x => x.InvalidateResult(), Times.Once);
+            }
+
+            [Fact]
+            public void ShouldNoNPEIfCurrentResultBuilderIsNull()
+            {
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage());
+                mrh.HandleFailureMessage("code.error", "message");
+            }
+
+            [Fact]
+            public void LogsTheMessageToDebug()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+                var mockLogger = new Mock<ILogger>();
+
+                var mrh = new MessageResponseHandler(mockLogger.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.HandleFailureMessage("code.error", "message");
+
+                mockLogger.Verify(x => x.Debug(It.Is<string>(actual => actual.StartsWith("S: ")), It.Is<object[]>(actual => actual.First() is FailureMessage)), Times.Once);
             }
 
             #region Test Data
@@ -271,6 +353,28 @@ namespace Neo4j.Driver.Tests
             };
 
             #endregion Test Data
+        }
+
+        public class EnqueueMessageMethod
+        {
+            [Fact]
+            public void ShouldNotBufferAnyRecordWhenResetIsEnqueue()
+            {
+                var mockResultBuilder = new Mock<IResultBuilder>();
+
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
+                mrh.HandleRecordMessage(new object[] { "x" });
+                mrh.CurrentResultBuilder.Should().NotBeNull();
+
+                mrh.EnqueueMessage(new ResetMessage());
+                mrh.CurrentResultBuilder.Should().BeNull();
+
+                mrh.HandleRecordMessage(new object[] { "x" });
+
+                mockResultBuilder.Verify(x => x.CollectRecord(It.IsAny<object[]>()), Times.Once);
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Tests
                 var mockResultBuilder = new Mock<IResultBuilder>();
 
                 var mrh = new MessageResponseHandler();
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> {{"fields", new List<object> {"x"}}});
                 mrh.HandleRecordMessage(new object[] {"x"});
 
@@ -51,7 +51,7 @@ namespace Neo4j.Driver.Tests
                 var mockLogger = new Mock<ILogger>();
 
                 var mrh = new MessageResponseHandler(mockLogger.Object);
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> {{"fields", new List<object> {"x"}}});
 
                 mockLogger.ResetCalls();
@@ -70,7 +70,7 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.SentMessages.Should().HaveCount(1);
                 mrh.CurrentResultBuilder.Should().BeNull();
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
@@ -85,7 +85,7 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
                 mockResultBuilder.Verify(x=> x.CollectFields(It.IsAny<IDictionary<string, object>>()), Times.Once);
             }
@@ -97,7 +97,7 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "summary", new List<object> { "x" } } });
                 mockResultBuilder.Verify(x => x.CollectSummaryMeta(It.IsAny<IDictionary<string, object>>()), Times.Once);
             }
@@ -109,7 +109,7 @@ namespace Neo4j.Driver.Tests
                 var mockLogger = new Mock<ILogger>();
 
                 var mrh = new MessageResponseHandler(mockLogger.Object);
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
 
                 mockLogger.Verify(x => x.Debug(It.Is<string>(actual => actual.StartsWith("S: ")), It.Is<object[]>(actual => actual.First() is SuccessMessage)), Times.Once);
@@ -125,8 +125,8 @@ namespace Neo4j.Driver.Tests
                 var mrh = new MessageResponseHandler();
                 
                 // Two messages are queued, as one will be popped off when handling a success message.
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
                 // We need to handle the success message to et the CurrentResultBuilder
                 mrh.HandleSuccessMessage(new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
 
@@ -146,7 +146,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage("Neo.ClientError.General.ReadOnly", "message");
                 mrh.HasError.Should().BeTrue();
@@ -166,7 +166,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();
@@ -178,7 +178,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();
@@ -190,7 +190,7 @@ namespace Neo4j.Driver.Tests
             {
                 var mockResultBuilder = new Mock<IResultBuilder>();
                 var mrh = new MessageResponseHandler();
-                mrh.RegisterMessage(new PullAllMessage(), mockResultBuilder.Object);
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
 
                 mrh.HandleFailureMessage(code, "message");
                 mrh.HasError.Should().BeTrue();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -79,10 +79,10 @@ namespace Neo4j.Driver.Tests
                 expectedBytes = expectedBytes.PadRight(ChunkedOutputStream.BufferSize);
 
                 var messageHandler = new MessageResponseHandler();
-                messageHandler.RegisterMessage(new InitMessage("MyClient/1.1", new Dictionary<string, object>()));
+                messageHandler.EnqueueMessage(new InitMessage("MyClient/1.1", new Dictionary<string, object>()));
                 var rb = new ResultBuilder();
-                messageHandler.RegisterMessage(messages[0], rb);
-                messageHandler.RegisterMessage(messages[1], rb);
+                messageHandler.EnqueueMessage(messages[0], rb);
+                messageHandler.EnqueueMessage(messages[1], rb);
 
                 using (var harness = new SocketClientTestHarness(FakeUri, null))
                 {
@@ -113,8 +113,8 @@ namespace Neo4j.Driver.Tests
                 {
                     var messages = new IRequestMessage[] {new RunMessage("This will cause a syntax error")};
                     var messageHandler = new MessageResponseHandler();
-                    messageHandler.RegisterMessage(new InitMessage("MyClient/1.1", new Dictionary<string, object>()));
-                    messageHandler.RegisterMessage(messages[0], new ResultBuilder());
+                    messageHandler.EnqueueMessage(new InitMessage("MyClient/1.1", new Dictionary<string, object>()));
+                    messageHandler.EnqueueMessage(messages[0], new ResultBuilder());
 
                     harness.SetupReadStream("00 00 00 01" +
                                             "00 03 b1 70 a0 00 00" +
@@ -152,9 +152,9 @@ namespace Neo4j.Driver.Tests
 
                     var messageHandler = new TestResponseHandler();
 
-                    messageHandler.RegisterMessage(new InitMessage("MyClient/1.1", new Dictionary<string, object>()));
-                    messageHandler.RegisterMessage(messages[0], new ResultBuilder());
-                    messageHandler.RegisterMessage(messages[1], new ResultBuilder());
+                    messageHandler.EnqueueMessage(new InitMessage("MyClient/1.1", new Dictionary<string, object>()));
+                    messageHandler.EnqueueMessage(messages[0], new ResultBuilder());
+                    messageHandler.EnqueueMessage(messages[1], new ResultBuilder());
 
                     harness.SetupReadStream("00 00 00 01" +
                                             "00 03 b1 70 a0 00 00" +
@@ -196,7 +196,7 @@ namespace Neo4j.Driver.Tests
 
                     var messageHandler = new TestResponseHandler();
 
-                    messageHandler.RegisterMessage(messages[0]);
+                    messageHandler.EnqueueMessage(messages[0]);
                     harness.SetupReadStream("00 00 00 01" +
                                             "00 02 b0 7e 00 00"); // read whatever message but not success
 
@@ -252,9 +252,9 @@ namespace Neo4j.Driver.Tests
                     _messageHandler.HandleRecordMessage(fields);
                 }
 
-                public void RegisterMessage(IRequestMessage requestMessage, IResultBuilder resultBuilder = null)
+                public void EnqueueMessage(IRequestMessage requestMessage, IResultBuilder resultBuilder = null)
                 {
-                    _messageHandler.RegisterMessage(requestMessage, resultBuilder);
+                    _messageHandler.EnqueueMessage(requestMessage, resultBuilder);
                 }
 
                 public void Clear()
@@ -263,7 +263,6 @@ namespace Neo4j.Driver.Tests
                 }
 
                 public int UnhandledMessageSize => _messageHandler.UnhandledMessageSize;
-                public bool IsRecordMessageReceived => _messageHandler.IsRecordMessageReceived;
 
                 public bool HasError => _messageHandler.HasError;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -53,7 +53,7 @@ namespace Neo4j.Driver.Tests
                 var mockHandler = new Mock<IMessageResponseHandler>();
                 new SocketConnection(mockClient.Object, AuthTokens.None, Logger, mockHandler.Object);
 
-                mockHandler.Verify(h => h.RegisterMessage(It.IsAny<InitMessage>(), null));
+                mockHandler.Verify(h => h.EnqueueMessage(It.IsAny<InitMessage>(), null));
 
                 mockClient.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>()), Times.Once);
                 mockClient.Verify(c => c.Receive(mockHandler.Object, 0), Times.Once);
@@ -136,7 +136,7 @@ namespace Neo4j.Driver.Tests
                 var rb = new ResultBuilder();
                 con.Run(rb, "statement");
 
-                mockResponseHandler.Verify(h => h.RegisterMessage(It.IsAny<RunMessage>(), rb), Times.Once);
+                mockResponseHandler.Verify(h => h.EnqueueMessage(It.IsAny<RunMessage>(), rb), Times.Once);
             }
         }
 
@@ -167,7 +167,7 @@ namespace Neo4j.Driver.Tests
                 var rb = new ResultBuilder();
                 con.PullAll(rb);
 
-                mockResponseHandler.Verify(h => h.RegisterMessage(It.IsAny<PullAllMessage>(), rb), Times.Once);
+                mockResponseHandler.Verify(h => h.EnqueueMessage(It.IsAny<PullAllMessage>(), rb), Times.Once);
             }
         }
 
@@ -186,8 +186,8 @@ namespace Neo4j.Driver.Tests
                 messages.Count.Should().Be(2);
                 messages[0].Should().BeOfType<RunMessage>();
                 messages[1].Should().BeOfType<ResetMessage>();
-                mockResponseHandler.Verify(x => x.RegisterMessage(It.IsAny<RunMessage>(), null), Times.Once);
-                mockResponseHandler.Verify(x => x.RegisterMessage(It.IsAny<ResetMessage>(), null), Times.Once);
+                mockResponseHandler.Verify(x => x.EnqueueMessage(It.IsAny<RunMessage>(), null), Times.Once);
+                mockResponseHandler.Verify(x => x.EnqueueMessage(It.IsAny<ResetMessage>(), null), Times.Once);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
@@ -34,11 +34,16 @@ namespace Neo4j.Driver.Tests
         public ListBasedRecordSet(IList<IRecord> records)
         {
             _records = records;
-            _recordSet = new RecordSet(() => _records[_count++], () => !AtEnd);
+            _recordSet = new RecordSet(NextRecord);
         }
 
         public bool AtEnd => _count >= _records.Count;
-        
+
+        private IRecord NextRecord()
+        {
+            return AtEnd ? null : _records[_count++];
+        }
+
         public IRecord Peek()
         {
             return _recordSet.Peek();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,293 +28,53 @@ namespace Neo4j.Driver.Tests
 {
     public class ResultBuilderTests
     {
-        public class CollectMetaMethod
+        private static ResultBuilder GenerateBuilder(IDictionary<string, object> meta = null)
         {
-            [Fact]
-            public void ShouldCollectKeys()
-            {
-                var builder = new ResultBuilder();
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                { {"fields", new List<object> {"fieldKey1", "fieldKey2", "fieldKey3"} },{"type", "r" } };
-                builder.CollectFields(meta);
-
-                var result = builder.Build();
-                result.Keys.Should().ContainInOrder("fieldKey1", "fieldKey2", "fieldKey3");
-            }
-
-            [Fact]
-            public void ShouldCollectType()
-            {
-                var builder = new ResultBuilder();
-                builder.IsStreamingRecords(false);
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                { {"type", "r" } };
-                builder.CollectSummaryMeta(meta);
-
-                var result = builder.Build();
-                result.Consume();
-                result.Summary.StatementType.Should().Be(StatementType.ReadOnly);
-            }
-
-            [Fact]
-            public void ShouldCollectStattistics()
-            {
-                var builder = new ResultBuilder();
-                builder.IsStreamingRecords(false);
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                { {"type", "r" }, {"stats", new Dictionary<string, object> { {"nodes-created", 10L}, {"nodes-deleted", 5L} } } };
-                builder.CollectSummaryMeta(meta);
-
-                var result = builder.Build();
-                result.Consume();
-                var statistics = result.Summary.Counters;
-                statistics.NodesCreated.Should().Be(10);
-
-            }
-
-            [Fact]
-            public void ShouldCollectNotifications()
-            {
-                var builder = new ResultBuilder();
-                builder.IsStreamingRecords(false);
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                {
-                    {"type", "r" },
-                    {
-                        "notifications", new List<object>
-                        {
-                            new Dictionary<string, object> {{"code", "CODE"}, {"title", "TITLE"}},
-                            new Dictionary<string, object>
-                            {
-                                {"description", "DES"},
-                                {
-                                    "position", new Dictionary<string, object>
-                                    {
-                                        {"offset", 11L}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                };
-
-                builder.CollectSummaryMeta(meta);
-
-                InputPosition position = new InputPosition(0,0,0);
-
-                var result = builder.Build();
-                result.Consume();
-                var notifications = result.Summary.Notifications;
-                notifications.Should().HaveCount(2);
-                notifications[0].Code.Should().Be("CODE");
-                notifications[0].Title.Should().Be("TITLE");
-                notifications[0].Position.Offset.Should().Be(0);
-                notifications[0].Position.Column.Should().Be(0);
-                notifications[0].Position.Line.Should().Be(0);
-                notifications[0].Description.Should().BeEmpty();
-
-                notifications[1].Description.Should().Be("DES");
-                notifications[1].Code.Should().BeEmpty();
-                notifications[1].Title.Should().BeEmpty();
-                notifications[1].Position.Offset.Should().Be(11);
-                notifications[1].Position.Column.Should().Be(0);
-                notifications[1].Position.Line.Should().Be(0);
-            }
-
-            [Fact]
-            public void ShouldCollectSimplePlan()
-            {
-                var builder = new ResultBuilder();
-                builder.IsStreamingRecords(false);
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                {   {"type", "r" },
-                    { "plan", new Dictionary<string, object>
-                {
-                    {"operatorType", "X"}
-                } } };
-                builder.CollectSummaryMeta(meta);
-
-                var result = builder.Build();
-                result.Consume();
-                var plan = result.Summary.Plan;
-                plan.OperatorType.Should().Be("X");
-                plan.Arguments.Should().BeEmpty();
-                plan.Children.Should().BeEmpty();
-                plan.Identifiers.Should().BeEmpty();
-
-            }
-
-            [Fact]
-            public void ShouldCollectPlanThatContainsPlans()
-            {
-                var builder = new ResultBuilder();
-                builder.IsStreamingRecords(false);
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                {
-                    {"type", "r"},
-                    {
-                        "plan", new Dictionary<string, object>
-                        {
-                            {"operatorType", "X"},
-                            {"args", new Dictionary<string, object> {{"a", 1}, {"b", "lala"}}},
-                            {"identifiers", new List<object> {"id1", "id2"}},
-                            {
-                                "children", new List<object>
-                                {
-                                    new Dictionary<string, object>
-                                    {
-                                        {"operatorType", "tt"},
-                                        {"children", new List<object>()}
-                                    },
-                                    new Dictionary<string, object>
-                                    {
-                                        { "operatorType", "Z" },
-                                        {
-                                            "children", new List<object>
-                                            {
-                                                new Dictionary<string, object> {{"operatorType", "Y"}}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                };
-                builder.CollectSummaryMeta(meta);
-
-                var result = builder.Build();
-                result.Consume();
-                var plan = result.Summary.Plan;
-                plan.OperatorType.Should().Be("X");
-                plan.Arguments.Should().ContainKey("a");
-                plan.Arguments["a"].Should().Be(1);
-                plan.Arguments.Should().ContainKey("b");
-                plan.Arguments["b"].Should().Be("lala");
-                plan.Identifiers.Should().ContainInOrder("id1", "id2");
-                plan.Children.Should().NotBeNull();
-                var children = plan.Children;
-                children.Should().HaveCount(2);
-                children[0].OperatorType.Should().Be("tt");
-                children[0].Children.Should().BeEmpty();
-                children[1].Children.Should().HaveCount(1);
-                children[1].Children[0].OperatorType.Should().Be("Y");
-            }
-
-            [Fact]
-            public void ShouldCollectProfiledPlanThatContainsProfiledPlans()
-            {
-                var builder = new ResultBuilder();
-                builder.IsStreamingRecords(false);
-                IDictionary<string, object> meta = new Dictionary<string, object>
-                {
-                    {"type", "r"},
-                    {
-                        "profile", new Dictionary<string, object>
-                        {
-                            {"operatorType", "X"},
-                            {"args", new Dictionary<string, object> {{"a", 1}, {"b", "lala"}}},
-                            {"dbHits", 1L},
-                            {"rows", 1L},
-                            {"identifiers", new List<object> {"id1", "id2"}},
-                            {
-                                "children", new List<object>
-                                {
-                                    new Dictionary<string, object>
-                                    {
-                                        {"dbHits", 1L},
-                                        {"rows", 1L},
-                                        {"operatorType", "tt"},
-                                        {"children", new List<object>()}
-                                    },
-                                    new Dictionary<string, object>
-                                    {
-                                        {"dbHits", 1L},
-                                        {"rows", 1L},
-                                        {"operatorType", "Z"},
-                                        {
-                                            "children", new List<object>
-                                            {
-                                                new Dictionary<string, object>
-                                                {
-                                                    {"dbHits", 1L},
-                                                    {"rows", 1L},
-                                                    { "operatorType", "Y"}
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                };
-                builder.CollectSummaryMeta(meta);
-
-                var result = builder.Build();
-                result.Consume();
-                var profile = result.Summary.Profile;
-                profile.DbHits.Should().Be(1L);
-                profile.OperatorType.Should().Be("X");
-                profile.Arguments.Should().ContainKey("a");
-                profile.Arguments["a"].Should().Be(1);
-                profile.Arguments.Should().ContainKey("b");
-                profile.Arguments["b"].Should().Be("lala");
-                profile.Identifiers.Should().ContainInOrder("id1", "id2");
-                profile.Children.Should().NotBeNull();
-                var children = profile.Children;
-                children.Should().HaveCount(2);
-                children[0].OperatorType.Should().Be("tt");
-                children[0].Children.Should().BeEmpty();
-                children[1].Children.Should().HaveCount(1);
-                children[1].Children[0].OperatorType.Should().Be("Y");
-            }
+            var builder = new ResultBuilder();
+            builder.CollectFields(meta ?? new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
+            return builder;
         }
 
-        public class BuildMethod
+        private static Task AssertGetExpectResults(StatementResult result, int numberExpected, List<object> exspectedRecordsValues = null)
         {
-            private static ResultBuilder GenerateBuilder(IDictionary<string, object> meta = null)
+            int count = 0;
+            var t = Task.Factory.StartNew(() =>
             {
-                var builder = new ResultBuilder();
-                builder.CollectFields(meta ?? new Dictionary<string, object> { { "fields", new List<object> { "x" } } });
-                return builder;
-            }
-
-            private static Task AssertGetExpectResults(StatementResult result, int numberExpected, List<object> exspectedRecordsValues = null)
-            {
-                int count = 0;
-                var t = Task.Factory.StartNew(() =>
+                // ReSharper disable once LoopCanBeConvertedToQuery
+                foreach (var item in result)
                 {
-                    // ReSharper disable once LoopCanBeConvertedToQuery
-                    foreach (var item in result)
+                    if (exspectedRecordsValues != null)
                     {
-                        if (exspectedRecordsValues != null)
-                        {
-                            item.Values.First().Value.Should().Be(exspectedRecordsValues[count]);
-                        }
-                        count++;
+                        item.Values.First().Value.Should().Be(exspectedRecordsValues[count]);
                     }
-                    count.Should().Be(numberExpected);
-                });
-                return t;
-            }
+                    count++;
+                }
+                count.Should().Be(numberExpected);
+            });
+            return t;
+        }
 
+        public class CollectRecordMethod
+        {
             [Fact]
             public void ShouldStreamResults()
             {
                 var builder = GenerateBuilder();
                 var i = 0;
-                builder.ReceiveOneRecordMessageFunc = () =>
+                builder.ReceiveOneFun = () =>
                 {
                     if (i++ >= 3)
                     {
-                        builder.CollectSummaryMeta(null);
+                        builder.CollectSummary(null);
                     }
-                    builder.CollectRecord(new object[] { 123 });
+                    else
+                    {
+                        builder.CollectRecord(new object[] {123 + i});
+                    }
                 };
-                var cursor = builder.Build();
+                var result = builder.Build();
 
-                var t = AssertGetExpectResults(cursor, 3);
+                var t = AssertGetExpectResults(result, 3, new List<object> {124, 125, 126});
                 t.Wait();
             }
 
@@ -322,13 +82,13 @@ namespace Neo4j.Driver.Tests
             public void ShouldReturnNoResultsWhenNoneRecieved()
             {
                 var builder = GenerateBuilder();
-                builder.ReceiveOneRecordMessageFunc = () =>
+                builder.ReceiveOneFun = () =>
                 {
-                    builder.CollectSummaryMeta(null);
+                    builder.CollectSummary(null);
                 };
-                var cursor = builder.Build();
+                var result = builder.Build();
 
-                var t = AssertGetExpectResults(cursor, 0);
+                var t = AssertGetExpectResults(result, 0);
 
                 t.Wait();
             }
@@ -344,34 +104,28 @@ namespace Neo4j.Driver.Tests
                     false,
                     10
                 };
-                var i = 0;
-                builder.ReceiveOneRecordMessageFunc = () =>
+                for (int i = 0; i < recordValues.Count; i++)
                 {
-                    if (i < recordValues.Count)
-                    {
-                        builder.CollectRecord(new[] { recordValues[i++] });
-                    }
-                    builder.CollectSummaryMeta(null);
-                };
-                var cursor = builder.Build();
+                    builder.CollectRecord(new[] { recordValues[i] });
+                }
+                builder.CollectSummary(null);
 
-                var task = AssertGetExpectResults(cursor, recordValues.Count, recordValues);
+                var result = builder.Build();
+
+                var task = AssertGetExpectResults(result, recordValues.Count, recordValues);
                 task.Wait();
             }
         }
 
-        public class CollectSummaryMetaMethod
+        public class CollectSummaryMethod
         {
             private static ICounters DefaultCounters => new Counters();
 
             [Fact]
-            public void DoesNothingWhenMetaIsNull()
+            public void DoesNothingWhenSummaryIsNull()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () =>
-                {
-                    builder.CollectSummaryMeta(null);
-                };
+                builder.CollectSummary(null);
                 var actual = builder.Build();
                 actual.Consume();
 
@@ -400,10 +154,7 @@ namespace Neo4j.Driver.Tests
                         {"type", typeValue}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -419,10 +170,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.StatementType.Should().Be(StatementType.Unknown);
@@ -437,7 +185,7 @@ namespace Neo4j.Driver.Tests
                         {"type", "unknown"}
                     };
 
-                    var ex = Xunit.Record.Exception(() => builder.CollectSummaryMeta(meta));
+                    var ex = Xunit.Record.Exception(() => builder.CollectSummary(meta));
                     ex.Should().BeOfType<ClientException>();
                 }
             }
@@ -453,10 +201,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Counters.ShouldBeEquivalentTo(DefaultCounters);
@@ -483,10 +228,7 @@ namespace Neo4j.Driver.Tests
                             {"constraints-removed", 11L },
                         } }
                     };
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build().Consume().Counters;
                     actual.Should().NotBeNull();
 
@@ -514,10 +256,7 @@ namespace Neo4j.Driver.Tests
                     {
                         {"something", "unknown"}
                     };
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -534,10 +273,7 @@ namespace Neo4j.Driver.Tests
                         {"plan", new Dictionary<string,object>()}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -554,10 +290,7 @@ namespace Neo4j.Driver.Tests
                         {"plan", null}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -579,13 +312,9 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
-                    var actual = builder.Build();
+                   ;
 
-                    var ex = Xunit.Record.Exception(() => actual.Consume());
+                    var ex = Xunit.Record.Exception(() => builder.CollectSummary(meta));
                     ex.Should().BeOfType<Neo4jException>();
                     ex.Message.Should().Be("Required property 'operatorType' is not in the response.");
                 }
@@ -604,10 +333,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -638,10 +364,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -688,10 +411,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build().Consume().Plan.Children.Single();
 
                     actual.Arguments.Should().HaveCount(1);
@@ -744,10 +464,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build().Consume().Plan.Children.Single().Children.Single();
 
                     actual.Arguments.Should().HaveCount(1);
@@ -774,10 +491,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -794,10 +508,7 @@ namespace Neo4j.Driver.Tests
                         {"profile", new Dictionary<string,object>()}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -814,10 +525,7 @@ namespace Neo4j.Driver.Tests
                         {"profile", null}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -841,13 +549,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
-                    var actual = builder.Build();
-
-                    var ex = Xunit.Record.Exception(() => actual.Consume());
+                    var ex = Xunit.Record.Exception(() => builder.CollectSummary(meta));
                     ex.Should().BeOfType<Neo4jException>();
                     ex.Message.Should().Be("Required property 'operatorType' is not in the response.");
                 }
@@ -867,13 +569,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
-                    var actual = builder.Build();
-
-                    var ex = Xunit.Record.Exception(() => actual.Consume());
+                    var ex = Xunit.Record.Exception(() => builder.CollectSummary(meta));
                     ex.Should().BeOfType<Neo4jException>();
                     ex.Message.Should().Be("Required property 'rows' is not in the response.");
                 }
@@ -893,13 +589,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
-                    var actual = builder.Build();
-
-                    var ex = Xunit.Record.Exception(() => actual.Consume());
+                    var ex = Xunit.Record.Exception(() => builder.CollectSummary(meta));
                     ex.Should().BeOfType<Neo4jException>();
                     ex.Message.Should().Be("Required property 'dbHits' is not in the response.");
                 }
@@ -920,10 +610,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
 
@@ -959,10 +646,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Profile.Should().NotBeNull();
@@ -1015,11 +699,7 @@ namespace Neo4j.Driver.Tests
                             }
                         }
                     };
-
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Profile.Should().NotBeNull();
@@ -1085,11 +765,8 @@ namespace Neo4j.Driver.Tests
                             }
                         }
                     };
-
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Profile.Should().NotBeNull();
@@ -1124,10 +801,7 @@ namespace Neo4j.Driver.Tests
                         {"something", "unknown"}
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Notifications.Should().BeEmpty();
@@ -1160,10 +834,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Notifications.Should().HaveCount(1);
@@ -1218,10 +889,7 @@ namespace Neo4j.Driver.Tests
                         }
                     };
 
-                    builder.ReceiveOneRecordMessageFunc = () =>
-                    {
-                        builder.CollectSummaryMeta(meta);
-                    };
+                    builder.CollectSummary(meta);
                     var actual = builder.Build();
                     actual.Consume();
                     actual.Summary.Notifications.Should().HaveCount(2);
@@ -1240,13 +908,22 @@ namespace Neo4j.Driver.Tests
         public class CollectFieldsMethod
         {
             [Fact]
+            public void ShouldPassDefaultKeysToResultIfNoKeySet()
+            {
+                var builder = new ResultBuilder();
+                var result = builder.Build();
+
+                result.Keys.Should().BeEmpty();
+            }
+
+            [Fact]
             public void ShouldDoNothingWhenMetaIsNull()
             {
                 var builder = new ResultBuilder();
                 builder.CollectFields(null);
 
-                var actual = builder.Build();
-                actual.Keys.Should().BeEmpty();
+                var result = builder.Build();
+                result.Keys.Should().BeEmpty();
             }
 
             [Fact]
@@ -1259,8 +936,46 @@ namespace Neo4j.Driver.Tests
                 };
                 builder.CollectFields(meta);
 
-                var actual = builder.Build();
-                actual.Keys.Should().BeEmpty();
+                var result = builder.Build();
+                result.Keys.Should().BeEmpty();
+            }
+
+            [Fact]
+            public void ShouldCollectKeys()
+            {
+                IDictionary<string, object> meta = new Dictionary<string, object>
+                { {"fields", new List<object> {"fieldKey1", "fieldKey2", "fieldKey3"} },{"type", "r" } };
+
+                var builder = new ResultBuilder();
+                builder.CollectFields(meta);
+                var result = builder.Build();
+
+                result.Keys.Should().ContainInOrder("fieldKey1", "fieldKey2", "fieldKey3");
+            }
+        }
+
+        public class InvalidateResultMethod
+        {
+            [Fact]
+            public void ShouldStopStreamingWhenResultIsInvalid()
+            {
+                var builder = GenerateBuilder();
+                var i = 0;
+                builder.ReceiveOneFun = () =>
+                {
+                    if (i++ >= 3)
+                    {
+                        builder.InvalidateResult();
+                    }
+                    else
+                    {
+                        builder.CollectRecord(new object[] { 123 + i });
+                    }
+                };
+                var result = builder.Build();
+
+                var t = AssertGetExpectResults(result, 3, new List<object> { 124, 125, 126 });
+                t.Wait();
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -46,7 +46,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectType()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () => false;
+                builder.IsStreamingRecords(false);
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 { {"type", "r" } };
                 builder.CollectSummaryMeta(meta);
@@ -60,7 +60,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectStattistics()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () => false;
+                builder.IsStreamingRecords(false);
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 { {"type", "r" }, {"stats", new Dictionary<string, object> { {"nodes-created", 10L}, {"nodes-deleted", 5L} } } };
                 builder.CollectSummaryMeta(meta);
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectNotifications()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () => false;
+                builder.IsStreamingRecords(false);
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r" },
@@ -125,7 +125,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectSimplePlan()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () => false;
+                builder.IsStreamingRecords(false);
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {   {"type", "r" },
                     { "plan", new Dictionary<string, object>
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectPlanThatContainsPlans()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () => false;
+                builder.IsStreamingRecords(false);
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r"},
@@ -205,7 +205,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldCollectProfiledPlanThatContainsProfiledPlans()
             {
                 var builder = new ResultBuilder();
-                builder.ReceiveOneRecordMessageFunc = () => false;
+                builder.IsStreamingRecords(false);
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
                     {"type", "r"},
@@ -309,10 +309,8 @@ namespace Neo4j.Driver.Tests
                     if (i++ >= 3)
                     {
                         builder.CollectSummaryMeta(null);
-                        return false;
                     }
                     builder.CollectRecord(new object[] { 123 });
-                    return true;
                 };
                 var cursor = builder.Build();
 
@@ -327,7 +325,6 @@ namespace Neo4j.Driver.Tests
                 builder.ReceiveOneRecordMessageFunc = () =>
                 {
                     builder.CollectSummaryMeta(null);
-                    return false;
                 };
                 var cursor = builder.Build();
 
@@ -353,10 +350,8 @@ namespace Neo4j.Driver.Tests
                     if (i < recordValues.Count)
                     {
                         builder.CollectRecord(new[] { recordValues[i++] });
-                        return true;
                     }
                     builder.CollectSummaryMeta(null);
-                    return false;
                 };
                 var cursor = builder.Build();
 
@@ -376,7 +371,6 @@ namespace Neo4j.Driver.Tests
                 builder.ReceiveOneRecordMessageFunc = () =>
                 {
                     builder.CollectSummaryMeta(null);
-                    return false;
                 };
                 var actual = builder.Build();
                 actual.Consume();
@@ -409,7 +403,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -429,7 +422,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -464,7 +456,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -492,11 +483,9 @@ namespace Neo4j.Driver.Tests
                             {"constraints-removed", 11L },
                         } }
                     };
-
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build().Consume().Counters;
                     actual.Should().NotBeNull();
@@ -528,7 +517,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -549,7 +537,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -570,7 +557,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -596,7 +582,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
 
@@ -622,7 +607,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -657,7 +641,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -708,7 +691,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build().Consume().Plan.Children.Single();
 
@@ -765,7 +747,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build().Consume().Plan.Children.Single().Children.Single();
 
@@ -796,7 +777,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -817,7 +797,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -838,7 +817,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -866,7 +844,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
 
@@ -893,7 +870,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
 
@@ -920,7 +896,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
 
@@ -948,7 +923,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -988,7 +962,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -1046,7 +1019,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -1117,7 +1089,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -1156,7 +1127,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -1193,7 +1163,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();
@@ -1252,7 +1221,6 @@ namespace Neo4j.Driver.Tests
                     builder.ReceiveOneRecordMessageFunc = () =>
                     {
                         builder.CollectSummaryMeta(meta);
-                        return false;
                     };
                     var actual = builder.Build();
                     actual.Consume();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -29,7 +29,7 @@ namespace Neo4j.Driver.Internal.Connector
         void Send(IEnumerable<IRequestMessage> messages);
         /* Recieve until unhandledMessageSize messages are left in unhandled message queue */
         void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0);
-        void ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction );
+        void ReceiveOne(IMessageResponseHandler responseHandler, Action onFailureAction );
         bool IsOpen { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -29,8 +29,7 @@ namespace Neo4j.Driver.Internal.Connector
         void Send(IEnumerable<IRequestMessage> messages);
         /* Recieve until unhandledMessageSize messages are left in unhandled message queue */
         void Receive(IMessageResponseHandler responseHandler, int unhandledMessageSize = 0);
-        /* Return true if a record message is received, otherwise false. */
-        bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction );
+        void ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction );
         bool IsOpen { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -125,7 +125,7 @@ namespace Neo4j.Driver.Internal.Connector
         }
 
         /// <summary>
-        /// This method will not throw exception if a railure message is received
+        /// This method will not throw exception if a failure message is received
         /// </summary>
         private void ReceiveOne(IMessageResponseHandler responseHandler)
         {
@@ -153,18 +153,17 @@ namespace Neo4j.Driver.Internal.Connector
         /// Return true if a record message is received, otherwise false.
         /// This method will throw the exception if a failure message is received.
         /// </summary>
-        public bool ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction)
+        public void ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction)
         {
             if (responseHandler.UnhandledMessageSize == 0)
             {
-                return false;
+                return;
             }
             ReceiveOne(responseHandler);
             if (responseHandler.HasError)
             {
                 onFailureAction.Invoke();
             }
-            return responseHandler.IsRecordMessageReceived;
         }
 
         private async Task<int> DoHandshake()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -124,9 +124,6 @@ namespace Neo4j.Driver.Internal.Connector
             }
         }
 
-        /// <summary>
-        /// This method will not throw exception if a failure message is received
-        /// </summary>
         private void ReceiveOne(IMessageResponseHandler responseHandler)
         {
             try
@@ -150,10 +147,9 @@ namespace Neo4j.Driver.Internal.Connector
         }
 
         /// <summary>
-        /// Return true if a record message is received, otherwise false.
-        /// This method will throw the exception if a failure message is received.
+        /// Perform failure action if error
         /// </summary>
-        public void ReceiveOneRecordMessage(IMessageResponseHandler responseHandler, Action onFailureAction)
+        public void ReceiveOne(IMessageResponseHandler responseHandler, Action onFailureAction)
         {
             if (responseHandler.UnhandledMessageSize == 0)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -105,7 +105,7 @@ namespace Neo4j.Driver.Internal.Connector
         public void PullAll(IResultBuilder resultBuilder)
         {
             Enqueue(new PullAllMessage(), resultBuilder);
-            resultBuilder.ReceiveOneRecordMessageFunc = () => _client.ReceiveOneRecordMessage(_responseHandler, OnResponseHasError);
+            resultBuilder.ReceiveOneFun = () => _client.ReceiveOne(_responseHandler, OnResponseHasError);
         }
 
         public void DiscardAll()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -137,7 +137,7 @@ namespace Neo4j.Driver.Internal.Connector
         private void Enqueue(IRequestMessage requestMessage, IResultBuilder resultBuilder = null)
         {
             _messages.Enqueue(requestMessage);
-            _responseHandler.RegisterMessage(requestMessage, resultBuilder);
+            _responseHandler.EnqueueMessage(requestMessage, resultBuilder);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -38,9 +38,8 @@ namespace Neo4j.Driver.Internal.Messaging
         void HandleFailureMessage(string code, string message);
         void HandleIgnoredMessage();
         void HandleRecordMessage(object[] fields);
-        void RegisterMessage(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
+        void EnqueueMessage(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
         void Clear();
         int UnhandledMessageSize { get; }
-        bool IsRecordMessageReceived { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -39,7 +39,6 @@ namespace Neo4j.Driver.Internal.Messaging
         void HandleIgnoredMessage();
         void HandleRecordMessage(object[] fields);
         void EnqueueMessage(IRequestMessage requestMessage, IResultBuilder resultBuilder = null);
-        void Clear();
         int UnhandledMessageSize { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -26,6 +26,7 @@ namespace Neo4j.Driver.Internal.Result
         StatementResult Build();
         void CollectFields(IDictionary<string, object> meta);
         void CollectSummaryMeta(IDictionary<string, object> meta);
-        Func<bool> ReceiveOneRecordMessageFunc { set; }
+        Action ReceiveOneRecordMessageFunc { set; }
+        void IsStreamingRecords(bool value);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultBuilder.cs
@@ -22,11 +22,11 @@ namespace Neo4j.Driver.Internal.Result
 {
     internal interface IResultBuilder
     {
-        void CollectRecord(object[] fields);
         StatementResult Build();
         void CollectFields(IDictionary<string, object> meta);
-        void CollectSummaryMeta(IDictionary<string, object> meta);
-        Action ReceiveOneRecordMessageFunc { set; }
-        void IsStreamingRecords(bool value);
+        void CollectRecord(object[] fields);
+        void CollectSummary(IDictionary<string, object> meta);
+        void InvalidateResult();
+        Action ReceiveOneFun { set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -27,7 +27,7 @@ namespace Neo4j.Driver.Internal.Result
         private string[] _keys = new string[0];
         private readonly SummaryBuilder _summaryBuilder;
 
-        public Action ReceiveOneRecordMessageFunc { private get; set; }
+        public Action ReceiveOneFun { private get; set; }
 
         private readonly Queue<IRecord> _records = new Queue<IRecord>();
         private bool _isStreamingRecords;
@@ -62,14 +62,14 @@ namespace Neo4j.Driver.Internal.Result
         {
             if (_isStreamingRecords)
             {
-                ReceiveOneRecordMessageFunc.Invoke();
+                ReceiveOneFun.Invoke();
             }
             return _records.Count > 0 ? _records.Dequeue() : null;
         }
 
-        public void IsStreamingRecords(bool value)
+        public void InvalidateResult()
         {
-            _isStreamingRecords = value;
+            _isStreamingRecords = false;
         }
 
         public void CollectRecord(object[] fields)
@@ -77,19 +77,20 @@ namespace Neo4j.Driver.Internal.Result
             var record = new Record(_keys, fields);
             _records.Enqueue(record);
         }
-       
+
         public void CollectFields(IDictionary<string, object> meta)
         {
+            _isStreamingRecords = true;
             if (meta == null)
             {
                 return;
             }
             CollectKeys(meta, "fields");
-            _isStreamingRecords = true;
         }
 
-        public void CollectSummaryMeta(IDictionary<string, object> meta)
+        public void CollectSummary(IDictionary<string, object> meta)
         {
+            _isStreamingRecords = false;
             if (meta == null)
             {
                 return;


### PR DESCRIPTION
Buffer records within a session, but discard records if session is going to be returned to pool (RESET).
The current impl highly relies on the fact that in this driver `RUN` is synced immediately, while `PULL_ALL` is not. So we would have a result waiting to be filled if `PULL_ALL` has not been handled when we `RESET`. Interrupting this result receiving (setting this result to null) will result in no records being saved in memory. Right now, interrupt is performed only by `RESET`.

Note, if we run txs in a session, then the record will always be buffered if we commit the result. If we rollback the tx, then records get buffered if more txs afterwards, otherwise no record get buffered if we return the session to pool.

Session: 
RUN, sync, PULL_ALL, RESET, sync

Tx:
RUN_begin, DISCARD_ALL, RUN, sync, PULL_ALL, RUN_commit, DISCARD_ALL, **sync**, RESET, sync
RUN_begin, DISCARD_ALL, RUN, sync, PULL_ALL, RUN_rollback, DISCARD_ALL, RESET, sync

Where do we sync messages in this driver?
- INIT
- RUN (PULL_ALL)
- RUN commit, DISCARD_ALL
- RESET

What messages are enqueue but not synced?
- PULL_ALL
- ACK_FAIL
- RUN rollback, DISCARD_ALL
- DISCARD_ALL
