### PR TITLE
1.1 expose timings

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ConnectionIT.cs
@@ -15,11 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Neo4j.Driver.IntegrationTests.Internals;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
 using Xunit;
@@ -34,6 +37,7 @@ namespace Neo4j.Driver.IntegrationTests
     {
         private readonly string _serverEndPoint;
         private readonly IAuthToken _authToken;
+        private readonly Config _debugConfig = Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Trace}).ToConfig();
 
         private readonly ITestOutputHelper _output;
 
@@ -48,10 +52,7 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public void ShouldDoHandShake()
         {
-            using (var driver = GraphDatabase.Driver(
-                _serverEndPoint,
-                _authToken,
-                Config.Builder.WithLogger( new DebugLogger {Level = LogLevel.Trace}).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             {
                 using (var session = driver.Session())
                 {
@@ -69,9 +70,7 @@ namespace Neo4j.Driver.IntegrationTests
             var oldAuthToken = _authToken.AsDictionary();
             var newAuthToken = AuthTokens.Basic(oldAuthToken["principal"].ValueAs<string>(), oldAuthToken["credentials"].ValueAs<string>(), "native");
 
-            using (var driver = GraphDatabase.Driver(
-                _serverEndPoint,
-                newAuthToken))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, newAuthToken))
             {
                 using (var session = driver.Session())
                 {
@@ -93,9 +92,7 @@ namespace Neo4j.Driver.IntegrationTests
                 "native",
                 "basic");
 
-            using (var driver = GraphDatabase.Driver(
-                _serverEndPoint,
-                newAuthToken))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, newAuthToken))
             {
                 using (var session = driver.Session())
                 {
@@ -118,9 +115,7 @@ namespace Neo4j.Driver.IntegrationTests
                 "basic",
                 new Dictionary<string, object> {{"secret", 42}});
 
-            using (var driver = GraphDatabase.Driver(
-                _serverEndPoint,
-                newAuthToken))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, newAuthToken))
             {
                 using (var session = driver.Session())
                 {
@@ -135,19 +130,33 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public void GetsSummary()
         {
-            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken, Config.Builder.WithLogger(new DebugLogger { Level = LogLevel.Trace }).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             using (var session = driver.Session())
             {
                 var result = session.Run("PROFILE CREATE (p:Person { Name: 'Test'})");
                 var stats = result.Consume().Counters;
-                _output.WriteLine(stats.ToString());
+                stats.ToString().Should()
+                    .Be("Counters{NodesCreated=1, NodesDeleted=0, RelationshipsCreated=0, " +
+                    "RelationshipsDeleted=0, PropertiesSet=1, LabelsAdded=1, LabelsRemoved=0, " +
+                    "IndexesAdded=0, IndexesRemoved=0, ConstraintsAdded=0, ConstraintsRemoved=0}");
+
+                if (ServerVersion.Version(session.Server()) >= ServerVersion.V3_1_0)
+                {
+                    result.Summary.ResultAvailableAfter.Should().BeGreaterOrEqualTo(TimeSpan.Zero);
+                    result.Summary.ResultConsumedAfter.Should().BeGreaterOrEqualTo(TimeSpan.Zero);
+                }
+                else
+                {
+                    result.Summary.ResultAvailableAfter.Should().BeLessThan(TimeSpan.Zero);
+                    result.Summary.ResultConsumedAfter.Should().BeLessThan(TimeSpan.Zero);
+                }
             }
         }
 
         [Fact]
         public void ShouldBeAbleToRunMultiStatementsInOneTransaction()
         {
-            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken, Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Trace}).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             using (var session = driver.Session())
             using (var tx = session.BeginTransaction())
             {
@@ -248,8 +257,7 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public void AfterErrorTheFirstSyncShouldAckFailureSoThatNewStatementCouldRun()
         {
-            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken,
-                Config.Builder.WithLogger(new DebugLogger { Level = LogLevel.Trace }).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             {
                 using (var session = driver.Session())
                 {
@@ -265,8 +273,7 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public void AfterErrorTheFirstSyncShouldAckFailureSoThatNewStatementCouldRunForTx()
         {
-            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken,
-                Config.Builder.WithLogger(new DebugLogger { Level = LogLevel.Trace }).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             {
                 using (var session = driver.Session())
                 {
@@ -286,8 +293,7 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public void ShouldNotThrowExceptionWhenDisposeSessionAfterDriver()
         {
-            var driver = GraphDatabase.Driver(_serverEndPoint, _authToken,
-                Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Trace}).ToConfig());
+            var driver = GraphDatabase.Driver(_serverEndPoint, _authToken);
 
             var session = driver.Session();
 
@@ -308,8 +314,7 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public async void ShouldKillLongRunningStatement()
         {
-            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken,
-                Config.Builder.WithLogger(new DebugLogger { Level = LogLevel.Debug }).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             {
                 using (var session = driver.Session())
                 {
@@ -334,8 +339,7 @@ namespace Neo4j.Driver.IntegrationTests
         [Fact]
         public async void ShouldKillLongStreamingResult()
         {
-            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken,
-                Config.Builder.WithLogger(new DebugLogger { Level = LogLevel.Debug }).ToConfig()))
+            using (var driver = GraphDatabase.Driver(_serverEndPoint, _authToken))
             {
                 using (var session = driver.Session())
                 {

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/IntegrationTestFixture.cs
@@ -65,9 +65,7 @@ namespace Neo4j.Driver.IntegrationTests
         {
             try
             {
-                _installer.StopServer();
                 _installer.EnsureProcedures(sourceProcedureJarPath);
-                _installer.StartServer();
             }
             catch
             {

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ExternalPythonInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ExternalPythonInstaller.cs
@@ -73,7 +73,9 @@ namespace Neo4j.Driver.IntegrationTests.Internals
 
             if (!File.Exists(destProcedureJarPath))
             {
+                StopServer();
                 File.Copy(sourceProcedureJarPath, destProcedureJarPath);
+                StartServer();
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/INeo4jInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/INeo4jInstaller.cs
@@ -65,7 +65,8 @@ namespace Neo4j.Driver.IntegrationTests.Internals
         void UpdateSettings(IDictionary<string, string> keyValuePair);
 
         /// <summary>
-        /// Ensure a procedure jar with the same name as the given jar file name presented in the plugin folder on server
+        /// Ensure a procedure jar with the same name as the given jar file name presented in the plugin folder on server.
+        /// This method might restart the server if it is required to load the new procedures.
         /// </summary>
         /// <param name="sourceProcedureJarPath">Copy the jar from this path if not found</param>
         void EnsureProcedures(string sourceProcedureJarPath);

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ServerVersion.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ServerVersion.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) 2002-2016 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    internal class ServerVersion : IComparable<ServerVersion>
+    {
+        public int Major { get; }
+        public int Minor { get; }
+        public int Patch { get; }
+
+        public static readonly ServerVersion V3_1_0 = new ServerVersion(3,1,0);
+
+        private static readonly Regex VersionRegex = new Regex(@"Neo4j/(\d+)\.(\d+)(?:\.)?(\d*)(\.|-|\+)?([0-9A-Za-z-.]*)?", RegexOptions.IgnoreCase);
+
+        public ServerVersion(int major, int minor, int patch)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+        }
+
+        public static ServerVersion Version(string version)
+        {
+            if (version == null)
+            {
+                return null;
+            }
+            var match = VersionRegex.Match(version);
+            if (match.Success)
+            {
+                var major = int.Parse(match.Groups[1].ToString());
+                var minor = int.Parse(match.Groups[2].ToString());
+                var patch = int.Parse(match.Groups[3].ToString());
+                return new ServerVersion(major, minor, patch);
+            }
+            return null;
+        }
+
+        private static int Compare(ServerVersion v1, ServerVersion v2)
+        {
+            if (v1 == null && v2 == null)
+            {
+                return 0;
+            }
+            if (v1 == null)
+            {
+                return -1;
+            }
+            if (v2 == null)
+            {
+                return 1;
+            }
+
+            var code = v1.Major - v2.Major;
+            if (code == 0)
+            {
+                code = v1.Minor - v2.Minor;
+                if (code == 0)
+                {
+                    code = v1.Patch - v2.Patch;
+                }
+            }
+            return code;
+        }
+
+        public int CompareTo(ServerVersion other)
+        {
+            return Compare(this, other);
+        }
+
+        public static bool operator <=(ServerVersion v1, ServerVersion v2)
+        {
+            return Compare(v1, v2) <= 0;
+        }
+
+        public static bool operator >=(ServerVersion v1, ServerVersion v2)
+        {
+            return Compare(v1, v2) >= 0;
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -109,6 +109,7 @@
   <ItemGroup>
     <Compile Include="ConnectionIT.cs" />
     <Compile Include="Examples.cs" />
+    <Compile Include="Internals\ServerVersion.cs" />
     <Compile Include="Internals\ExternalPythonInstaller.cs" />
     <Compile Include="Internals\INeo4jInstaller.cs" />
     <Compile Include="IntegrationTestFixture.cs" />

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -53,7 +53,7 @@ namespace Neo4j.Driver.Tests
                 mockHandler.Setup(x => x.UnhandledMessageSize).Returns(1);
                 new SocketConnection(mockClient.Object, AuthTokens.None, Logger, mockHandler.Object);
 
-                mockHandler.Verify(h => h.EnqueueMessage(It.IsAny<InitMessage>(), null));
+                mockHandler.Verify(h => h.EnqueueMessage(It.IsAny<InitMessage>(), It.IsAny<InitCollector>()));
 
                 mockClient.Verify(c => c.Send(It.IsAny<IEnumerable<IRequestMessage>>()), Times.Once);
                 mockClient.Verify(c => c.Receive(mockHandler.Object), Times.Once);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -959,7 +959,27 @@ namespace Neo4j.Driver.Tests
         public class ResultAvailableAndConsumedAfterMethod
         {
             [Fact]
-            public void ShouldCollectResultAvailableAndConsumedAfter()
+            public void ShouldCollectResultAvailableAfter()
+            {
+                IDictionary<string, object> meta = new Dictionary<string, object>
+                {
+                    {"fields",  new List<object>() },
+                    {"result_available_after", 12345},
+                    {"result_consumed_after", 67890}
+                };
+
+                var builder = new ResultBuilder();
+                var result = builder.PreBuild();
+                builder.CollectFields(meta);
+                builder.CollectSummary(null);
+                result.Consume();
+
+                result.Summary.ResultAvailableAfter.ToString().Should().Be("00:00:12.3450000");
+                result.Summary.ResultConsumedAfter.ToString().Should().Be("-00:00:00.0010000");
+            }
+
+            [Fact]
+            public void ShouldCollectResultConsumedAfter()
             {
                 IDictionary<string, object> meta = new Dictionary<string, object>
                 {
@@ -972,7 +992,7 @@ namespace Neo4j.Driver.Tests
                 var result = builder.PreBuild();
                 result.Consume();
 
-                result.Summary.ResultAvailableAfter.ToString().Should().Be("00:00:12.3450000");
+                result.Summary.ResultAvailableAfter.ToString().Should().Be("-00:00:00.0010000");
                 result.Summary.ResultConsumedAfter.ToString().Should().Be("00:01:07.8900000");
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -137,6 +137,8 @@ namespace Neo4j.Driver.Tests
                 actual.Summary.Statement.Text.Should().BeNull();
                 actual.Summary.StatementType.Should().Be(StatementType.Unknown);
                 actual.Summary.Counters.ShouldBeEquivalentTo(DefaultCounters);
+                actual.Summary.ResultAvailableAfter.ToString().Should().Be("-00:00:00.0010000");
+                actual.Summary.ResultConsumedAfter.ToString().Should().Be("-00:00:00.0010000");
             }
 
             public class TypeMeta
@@ -951,6 +953,27 @@ namespace Neo4j.Driver.Tests
                 var result = builder.PreBuild();
 
                 result.Keys.Should().ContainInOrder("fieldKey1", "fieldKey2", "fieldKey3");
+            }
+        }
+
+        public class ResultAvailableAndConsumedAfterMethod
+        {
+            [Fact]
+            public void ShouldCollectResultAvailableAndConsumedAfter()
+            {
+                IDictionary<string, object> meta = new Dictionary<string, object>
+                {
+                    {"result_available_after", 12345},
+                    {"result_consumed_after", 67890}
+                };
+
+                var builder = new ResultBuilder();
+                builder.CollectSummary(meta);
+                var result = builder.PreBuild();
+                result.Consume();
+
+                result.Summary.ResultAvailableAfter.ToString().Should().Be("00:00:12.3450000");
+                result.Summary.ResultConsumedAfter.ToString().Should().Be("00:01:07.8900000");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -377,6 +377,8 @@ namespace Neo4j.Driver.Tests
             public IPlan Plan { get; }
             public IProfiledPlan Profile { get; }
             public IList<INotification> Notifications { get; }
+            public TimeSpan ResultAvailableAfter { get; }
+            public TimeSpan ResultConsumedAfter { get; }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -49,6 +49,15 @@ namespace Neo4j.Driver.Internal.Connector
         /// Return true if more statements could be run on this connection, otherwise false.
         /// </summary>
         bool IsHealthy { get; }
+
+        /// <summary>
+        /// The version of the server the connection connected to. Default to <c>null</c> if not supported by server
+        /// </summary>
+        /// <remarks>
+        /// Introduced since Neo4j 3.1.
+        /// </remarks>
+        string Server { get; }
+
         /// <summary>
         /// Close and release related resources
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -73,6 +73,7 @@ namespace Neo4j.Driver.Internal.Connector
         public bool HasUnrecoverableError => _connection.HasUnrecoverableError;
 
         public bool IsHealthy => _connection.IsHealthy;
+        public string Server => _connection.Server;
 
         /// <summary>
         /// Close the connection and all resources all for good

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IMessageResponseCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IMessageResponseCollector.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Result
 {
@@ -31,40 +32,61 @@ namespace Neo4j.Driver.Internal.Result
         void DoneIgnored();
     }
 
-    internal class ResetCollector : IMessageResponseCollector
+    internal class ResetCollector : NoOperationCollector
     {
-        private readonly Action _successCallBackAction;
+        private readonly Action _successCallbackAction;
         public ResetCollector(Action successCallBackAction = null)
         {
-            _successCallBackAction = successCallBackAction ?? (() => { });
+            _successCallbackAction = successCallBackAction ?? (() => { });
 
         }
-        public void CollectFields(IDictionary<string, object> meta)
+
+        public override void DoneSuccess()
+        {
+            _successCallbackAction.Invoke();
+        }
+    }
+
+    internal class InitCollector : NoOperationCollector
+    {
+        public string Server { private set; get; }
+        public override void CollectSummary(IDictionary<string, object> meta)
+        {
+            if (meta.ContainsKey("server"))
+            {
+                Server = meta["server"].As<string>();
+            }
+        }
+    }
+
+    internal abstract class NoOperationCollector : IMessageResponseCollector
+    {
+        public virtual void CollectFields(IDictionary<string, object> meta)
         {
             // left empty
         }
 
-        public void CollectRecord(object[] fields)
+        public virtual void CollectRecord(object[] fields)
         {
             // left empty
         }
 
-        public void CollectSummary(IDictionary<string, object> meta)
+        public virtual void CollectSummary(IDictionary<string, object> meta)
         {
             // left empty
         }
 
-        public void DoneSuccess()
-        {
-            _successCallBackAction.Invoke();
-        }
-
-        public void DoneFailure()
+        public virtual void DoneSuccess()
         {
             // left empty
         }
 
-        public void DoneIgnored()
+        public virtual void DoneFailure()
+        {
+            // left empty
+        }
+
+        public virtual void DoneIgnored()
         {
             // left empty
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -87,6 +87,7 @@ namespace Neo4j.Driver.Internal.Result
                 return;
             }
             CollectKeys(meta, "fields");
+            CollectResultAvailableAfter(meta, "result_available_after");
         }
 
         public void CollectSummary(IDictionary<string, object> meta)
@@ -102,7 +103,6 @@ namespace Neo4j.Driver.Internal.Result
             CollectPlan(meta, "plan");
             CollectProfile(meta, "profile");
             CollectNotifications(meta, "notifications");
-            CollectResultAvailableAfter(meta, "result_available_after");
             CollectResultConsumedAfter(meta, "result_consumed_after");
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -102,6 +102,8 @@ namespace Neo4j.Driver.Internal.Result
             CollectPlan(meta, "plan");
             CollectProfile(meta, "profile");
             CollectNotifications(meta, "notifications");
+            CollectResultAvailableAfter(meta, "result_available_after");
+            CollectResultConsumedAfter(meta, "result_consumed_after");
         }
 
         public void DoneSuccess()
@@ -259,6 +261,24 @@ namespace Neo4j.Driver.Internal.Result
                 notifications.Add(new Notification(code, title, description, position, severity));
             }
             _summaryBuilder.Notifications = notifications;
+        }
+
+        private void CollectResultAvailableAfter(IDictionary<string, object> meta, string name)
+        {
+            if (!meta.ContainsKey(name))
+            {
+                return;
+            }
+            _summaryBuilder.ResultAvailableAfter = meta[name].As<long>();
+        }
+
+        private void CollectResultConsumedAfter(IDictionary<string, object> meta, string name)
+        {
+            if (!meta.ContainsKey(name))
+            {
+                return;
+            }
+            _summaryBuilder.ResultConsumedAfter = meta[name].As<long>();
         }
 
         private static int CountersValue(IDictionary<string, object> counters, string name)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/SummaryBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/SummaryBuilder.cs
@@ -28,6 +28,8 @@ namespace Neo4j.Driver.Internal.Result
         public IPlan Plan { private get; set; }
         public IProfiledPlan Profile { private get; set; }
         public IList<INotification> Notifications { private get; set; }
+        public long ResultAvailableAfter { private get; set; } = -1L;
+        public long ResultConsumedAfter { private get; set; } = -1L;
 
         public SummaryBuilder(Statement statement)
         {
@@ -51,6 +53,9 @@ namespace Neo4j.Driver.Internal.Result
                 Profile = builder.Profile;
                 Plan = Profile ?? builder.Plan;
                 Notifications = builder.Notifications ?? new List<INotification>();
+                ResultAvailableAfter = TimeSpan.FromMilliseconds(builder.ResultAvailableAfter);
+                ResultConsumedAfter = TimeSpan.FromMilliseconds(builder.ResultConsumedAfter);
+
             }
 
             public Statement Statement { get; }
@@ -61,6 +66,8 @@ namespace Neo4j.Driver.Internal.Result
             public IPlan Plan { get; }
             public IProfiledPlan Profile { get; }
             public IList<INotification> Notifications { get; }
+            public TimeSpan ResultAvailableAfter { get; }
+            public TimeSpan ResultConsumedAfter { get; }
 
             public override string ToString()
             {
@@ -69,7 +76,9 @@ namespace Neo4j.Driver.Internal.Result
                        $"{nameof(StatementType)}={StatementType}, " +
                        $"{nameof(Plan)}={Plan}, " +
                        $"{nameof(Profile)}={Profile}, " +
-                       $"{nameof(Notifications)}={Notifications.ToContentString()}}}";
+                       $"{nameof(Notifications)}={Notifications.ToContentString()}, " +
+                       $"{nameof(ResultAvailableAfter)}={ResultAvailableAfter.ToString("g")}, " +
+                       $"{nameof(ResultConsumedAfter)}={ResultConsumedAfter.ToString("g")}}}";
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -188,6 +188,11 @@ namespace Neo4j.Driver.Internal
             _connection.ResetAsync();
         }
 
+        public string Server()
+        {
+            return _connection.Server;
+        }
+
         public void Close()
         {
             Dispose(true);

--- a/Neo4j.Driver/Neo4j.Driver/V1/IResultSummary.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/IResultSummary.cs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Neo4j.Driver.V1
@@ -102,5 +103,23 @@ namespace Neo4j.Driver.V1
         /// 
         /// </remarks>
         IList<INotification> Notifications { get; }
+
+        /// <summary>
+        /// The time it took the server to make the result available for consumption.
+        /// Default to <c>-00:00:00.001</c> if the server version does not support this field in summary.
+        /// </summary>
+        /// <remarks>
+        /// Field introduced in Neo4j 3.1.
+        /// </remarks>
+        TimeSpan ResultAvailableAfter { get; }
+
+        /// <summary>
+        /// The time it took the server to consume the result.
+        /// Default to <c>-00:00:00.001</c> if the server version does not support this field in summary.
+        /// </summary>
+        /// <remarks>
+        /// Field introduced in Neo4j 3.1.
+        /// </remarks>
+        TimeSpan ResultConsumedAfter { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
@@ -57,6 +57,12 @@ namespace Neo4j.Driver.V1
         /// have been acknowledged.
         /// </summary>
         void Reset();
+
+        /// <summary>
+        /// Returns a string telling which version of the server the session is connected to.
+        /// </summary>
+        /// <returns>The server version of <c>null</c> if not available.</returns>
+        string Server();
     }
 
     /// <summary>


### PR DESCRIPTION
Exposes `resultAvailableAfter` and `resultConsumedAfter` on `ResultSummary` and `server` on `Session`. 
