### PR TITLE
Buffer result for StatementResult.Summary

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -302,16 +302,6 @@ namespace Neo4j.Driver.Tests
         public class SummaryProperty
         {
             [Fact]
-            public void ShouldThrowInvalidOperationExceptionWhenNotAtEnd()
-            {
-                var result = ResultCreator.CreateResult(1);
-                result.AtEnd.Should().BeFalse();
-
-                var ex = Xunit.Record.Exception(() => result.Summary);
-                ex.Should().BeOfType<InvalidOperationException>();
-            }
-
-            [Fact]
             public void ShouldCallGetSummaryWhenGetSummaryIsNotNull()
             {
                 bool getSummaryCalled = false;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -49,7 +49,22 @@ namespace Neo4j.Driver.Internal.Result
 
         public StatementResult PreBuild()
         {
-            return new StatementResult(_keys, new RecordSet(NextRecord), ()=> _summaryBuilder.Build());
+            return new StatementResult(_keys, new RecordSet(NextRecord), Summary);
+        }
+
+        /// <summary>
+        /// Buffer all records left unread into memory and return the summary
+        /// </summary>
+        /// <returns>The final summary</returns>
+        private IResultSummary Summary()
+        {
+            // read all records into memory
+            while (_hasMoreRecords)
+            {
+                _receiveOneFun.Invoke();
+            }
+            // return the summary
+            return _summaryBuilder.Build();
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/StatementResult.cs
@@ -49,10 +49,6 @@ namespace Neo4j.Driver.Internal.Result
         {
             get
             {
-                if (!AtEnd)
-                {
-                    throw new InvalidOperationException("Cannot get summary before consuming all records.");
-                }
                 if (_summary == null && _getSummary != null)
                 {
                     _summary = _getSummary();

--- a/Neo4j.Driver/Neo4j.Driver/V1/IStatementResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/IStatementResult.cs
@@ -33,9 +33,14 @@ namespace Neo4j.Driver.V1
         /// </summary>
         IReadOnlyList<string> Keys { get; }
         /// <summary>
-        /// Gets the <see cref="IResultSummary"/> after streaming the whole records to the client. 
+        /// Gets the <see cref="IResultSummary"/> after streaming the whole records to the client.
+        /// If the records in the result are not fully consumed,
+        /// then calling this method will force to pull all remaining records into buffer to yield the summary.
+        ///
+        /// If you want to obtain the summary but discard the records, use <see cref="Consume"/> instead.
+        ///
+        /// If all records in the records stream are already consumed, then this method will return the summary directly.
         /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if this is called before all the records have been visited.</exception>
         IResultSummary Summary { get; }
         /// <summary>
         /// Investigate the next upcoming record without changing the current position in the result.


### PR DESCRIPTION
Changed the behaviour of StatementResult.Summary to not throw an exception when not at the end of the record stream,
but to buffer records for latter access in result.