### PR TITLE
Always rollback tx when failed to commit

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriverIT.cs
@@ -330,6 +330,7 @@ namespace Neo4j.Driver.IntegrationTests
                     // The following code is the same as using(var tx = session.BeginTx()) {...}
                     // While we have the full control of where the error is thrown
                     var tx = session.BeginTransaction();
+                    tx.Run("CREATE (a { name: 'lizhen' })");
                     tx.Run("Invalid Cypher");
                     tx.Success();
                     var ex = Record.Exception(() => tx.Dispose());
@@ -339,8 +340,8 @@ namespace Neo4j.Driver.IntegrationTests
                     // Then can still run more afterwards
                     using (var anotherTx = session.BeginTransaction())
                     {
-                        var result = anotherTx.Run("RETURN 1");
-                        result.Single()[0].ValueAs<int>().Should().Be(1);
+                        var result = anotherTx.Run("MATCH (a {name : 'lizhen'}) RETURN count(a)");
+                        result.Single()[0].ValueAs<int>().Should().Be(0);
                     }
                 }
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -158,7 +158,7 @@ namespace Neo4j.Driver.Tests
                 var tx = session.BeginTransaction();
                 session.Dispose();
 
-                mockConn.Verify(x => x.Run("ROLLBACK", null, It.IsAny<IMessageResponseCollector>(), true), Times.Once);
+                mockConn.Verify(x => x.Run("ROLLBACK", null, null, false), Times.Once);
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -139,7 +139,7 @@ namespace Neo4j.Driver.Tests
                 // Even if success is called, but if failure is called afterwards, then we rollback
                 tx.Failure();
                 tx.Dispose();
-                mockConn.Verify(x => x.Run("ROLLBACK", null, It.IsAny<IMessageResponseCollector>(), true), Times.Once);
+                mockConn.Verify(x => x.Run("ROLLBACK", null, null, false), Times.Once);
                 mockConn.Verify(x => x.Sync(), Times.Once);
             }
 
@@ -152,7 +152,7 @@ namespace Neo4j.Driver.Tests
                 mockConn.ResetCalls();
                 // Even if success is called, but if failure is called afterwards, then we rollback
                 tx.Dispose();
-                mockConn.Verify(x => x.Run("ROLLBACK", null, It.IsAny<IMessageResponseCollector>(), true), Times.Once);
+                mockConn.Verify(x => x.Run("ROLLBACK", null, null, false), Times.Once);
                 mockConn.Verify(x => x.Sync(), Times.Once);
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -126,7 +126,7 @@ namespace Neo4j.Driver.Internal
 
         private void RollBackTx()
         {
-            _connection.Run(Rollback, null, new BookmarkCollector(s => Bookmark = s));
+            _connection.Run(Rollback, null, null, false/*DiscardAll*/);
             _connection.Sync();
             _state = State.RolledBack;
         }


### PR DESCRIPTION
Fix the bug where if we forget to consume a tx in using with resources, then the tx is left without being rolled back if the tx failed to commit.

Also added back test `ShouldNotThrowExceptionWhenDisposeSessionAfterDriver` that is lost during refactoring