### PR TITLE
Fix the bug in load balancer that the new connection pools are not connecting to the specified server

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -56,14 +56,6 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sockets.Plugin, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sockets.Plugin.Abstractions, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\rda.SocketsForPCL.1.2.2\lib\net45\Sockets.Plugin.Abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.AppContext.4.1.0\lib\net46\System.AppContext.dll</HintPath>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -37,6 +37,7 @@ namespace Neo4j.Driver.Internal
 
         // for test only
         private readonly IConnection _fakeConnection;
+        private readonly Uri _uri;
         internal int NumberOfInUseConnections => _inUseConnections.Count;
         internal int NumberOfAvailableConnections => _availableConnections.Count;
 
@@ -46,12 +47,14 @@ namespace Neo4j.Driver.Internal
         }
 
         public ConnectionPool(
+            Uri uri,
             ConnectionSettings connectionSettings,
             ConnectionPoolSettings connectionPoolSettings,
             ILogger logger,
             IConnectionErrorHandler exteralErrorHandler = null)
             : base(logger)
         {
+            _uri = uri;
             _connectionSettings = connectionSettings;
             _idleSessionPoolSize = connectionPoolSettings.MaxIdleSessionPoolSize;
 
@@ -66,7 +69,7 @@ namespace Neo4j.Driver.Internal
             ILogger logger = null,
             ConnectionPoolSettings settings = null,
             IConnectionErrorHandler exteralErrorHandler = null)
-            : this(null, settings ?? new ConnectionPoolSettings(Config.DefaultConfig.MaxIdleSessionPoolSize), 
+            : this(null, null, settings ?? new ConnectionPoolSettings(Config.DefaultConfig.MaxIdleSessionPoolSize), 
                   logger, exteralErrorHandler)
         {
             _fakeConnection = connection;
@@ -81,7 +84,7 @@ namespace Neo4j.Driver.Internal
             {
                 conn = _fakeConnection != null
                     ? new PooledConnection(_fakeConnection, Release)
-                    : new PooledConnection(new SocketConnection(_connectionSettings, _logger), Release);
+                    : new PooledConnection(new SocketConnection(_uri, _connectionSettings, _logger), Release);
                 if (_externalErrorHandler != null)
                 {
                     conn.AddConnectionErrorHander(_externalErrorHandler);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -41,10 +41,10 @@ namespace Neo4j.Driver.Internal.Connector
         private readonly ILogger _logger;
         private readonly IList<IConnectionErrorHandler> _handlers = new List<IConnectionErrorHandler>();
 
-        public SocketConnection(ConnectionSettings connectionSettings, ILogger logger)
-            : this(new SocketClient(connectionSettings.InitialServerUri, connectionSettings.EncryptionManager, logger),
+        public SocketConnection(Uri uri, ConnectionSettings connectionSettings, ILogger logger)
+            : this(new SocketClient(uri, connectionSettings.EncryptionManager, logger),
                   connectionSettings.AuthToken, connectionSettings.ConnectionTimeout, connectionSettings.UserAgent,
-                  logger, new ServerInfo(connectionSettings.InitialServerUri))
+                  logger, new ServerInfo(uri))
         {
         }
 
@@ -79,8 +79,7 @@ namespace Neo4j.Driver.Internal.Connector
             }
             catch (Exception error)
             {
-                error = OnConnectionError(error);
-                throw error;
+                throw OnConnectionError(error);
             }
 
             Init(_authToken);
@@ -118,8 +117,7 @@ namespace Neo4j.Driver.Internal.Connector
                 }
                 catch (Exception error)
                 {
-                    error = OnConnectionError(error);
-                    throw error;
+                    throw OnConnectionError(error);
                 }
                 
                 _messages.Clear();
@@ -141,8 +139,7 @@ namespace Neo4j.Driver.Internal.Connector
             }
             catch (Exception error)
             {
-                error = OnConnectionError(error);
-                throw error;
+                throw OnConnectionError(error);
             }
             
             AssertNoServerFailure();
@@ -156,8 +153,7 @@ namespace Neo4j.Driver.Internal.Connector
             }
             catch (Exception error)
             {
-                error = OnConnectionError(error);
-                throw error;
+                throw OnConnectionError(error);
             }
             
             AssertNoServerFailure();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DirectDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DirectDriver.cs
@@ -24,15 +24,16 @@ namespace Neo4j.Driver.Internal
     {
         private readonly IConnectionPool _connectionPool;
         private ILogger _logger;
+        private readonly Uri _uri;
 
         internal DirectDriver(ConnectionSettings connectionSettings, ConnectionPoolSettings connectionPoolSettings, ILogger logger)
         {
             Throw.ArgumentNullException.IfNull(connectionSettings, nameof(connectionSettings));
             Throw.ArgumentNullException.IfNull(connectionPoolSettings, nameof(connectionPoolSettings));
 
-            Uri = connectionSettings.InitialServerUri;
+            _uri = connectionSettings.InitialServerUri;
             _logger = logger;
-            _connectionPool = new ConnectionPool(connectionSettings, connectionPoolSettings, _logger);
+            _connectionPool = new ConnectionPool(_uri, connectionSettings, connectionPoolSettings, _logger);
         }
 
         public override ISession NewSession(AccessMode mode)
@@ -48,6 +49,6 @@ namespace Neo4j.Driver.Internal
             _logger = null;
         }
 
-        public override Uri Uri { get; }
+        public override Uri Uri => _uri;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -64,7 +64,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         private IConnectionPool CreateNewConnectionPool(Uri uri)
         {
-            return _fakeConnectionPool ?? new ConnectionPool(_connectionSettings, _poolSettings, Logger, _clusterErrorHandlerCreator.Invoke(uri));
+            return _fakeConnectionPool ?? new ConnectionPool(uri, _connectionSettings, _poolSettings, Logger, _clusterErrorHandlerCreator.Invoke(uri));
         }
 
         public bool TryAcquire(Uri uri, out IPooledConnection conn)


### PR DESCRIPTION
Fix the bug where the connection pool was always using the initial uri rather than the new uri specified by load balancer when creating a new connection pool

Removed some compilation warnings