### PR TITLE
Better error handling

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/AuthenticationIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/AuthenticationIT.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
@@ -9,9 +10,21 @@ namespace Neo4j.Driver.IntegrationTests
 {
     public class AuthenticationIT : DirectDriverIT
     {
-        public AuthenticationIT(ITestOutputHelper output, IntegrationTestFixture fixture)
+        public AuthenticationIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
             : base(output, fixture)
         { }
+
+        [Fact]
+        public void AuthenticationErrorIfWrongAuthToken()
+        {
+            Exception exception;
+            using (var driver = GraphDatabase.Driver(ServerEndPoint, AuthTokens.Basic("fake", "fake")))
+            {
+                exception = Record.Exception(()=>driver.Session());
+            }
+            exception.Should().BeOfType<AuthenticationException>();
+            exception.Message.Should().Contain("The client is unauthorized due to authentication failure.");
+        }
 
         [Fact]
         public void ShouldProvideRealmWithBasicAuthToken()

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DirectDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DirectDriverIT.cs
@@ -23,7 +23,7 @@ using Xunit.Abstractions;
 
 namespace Neo4j.Driver.IntegrationTests
 {
-    [Collection(SIIntegrationCollection.CollectionName)]
+    [Collection(SAIntegrationCollection.CollectionName)]
     public abstract class DirectDriverIT : IDisposable
     {
         public static readonly Config DebugConfig = Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Debug}).ToConfig();

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DirectDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DirectDriverIT.cs
@@ -23,8 +23,8 @@ using Xunit.Abstractions;
 
 namespace Neo4j.Driver.IntegrationTests
 {
-    [Collection(IntegrationCollection.CollectionName)]
-    public class DirectDriverIT : IDisposable
+    [Collection(SIIntegrationCollection.CollectionName)]
+    public abstract class DirectDriverIT : IDisposable
     {
         public static readonly Config DebugConfig = Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Debug}).ToConfig();
         protected ITestOutputHelper Output { get; }
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.IntegrationTests
         protected string ServerEndPoint { get; }
         protected IAuthToken AuthToken { get; }
 
-        public DirectDriverIT(ITestOutputHelper output, IntegrationTestFixture fixture)
+        protected DirectDriverIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
         {
             Output = output;
             Server = fixture.StandAlone;

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/ResultIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/ResultIT.cs
@@ -12,7 +12,7 @@ namespace Neo4j.Driver.IntegrationTests
     {
         private IDriver Driver => Server.Driver;
 
-        public ResultIT(ITestOutputHelper output, IntegrationTestFixture fixture) : base(output, fixture)
+        public ResultIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture) : base(output, fixture)
         {}
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionResetIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionResetIT.cs
@@ -15,7 +15,7 @@ namespace Neo4j.Driver.IntegrationTests
     {
         private IDriver Driver => Server.Driver;
 
-        public SessionResetIT(ITestOutputHelper output, IntegrationTestFixture fixture)
+        public SessionResetIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
             : base(output, fixture)
         {
             Server.RestartServerWithProcedures(new DirectoryInfo("../../Resources/longRunningStatement.jar").FullName);

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
@@ -27,13 +27,13 @@ using Xunit.Abstractions;
 
 namespace Neo4j.Driver.Examples
 {
-    [Collection(IntegrationCollection.CollectionName)]
+    [Collection(SIIntegrationCollection.CollectionName)]
     public class Examples : IDisposable
     {
         private ITestOutputHelper Output { get; }
         private IDriver Driver { get; }
 
-        public Examples(ITestOutputHelper output, IntegrationTestFixture fixture)
+        public Examples(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
         {
             Output = output;
             Driver = fixture.StandAlone.Driver;

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
@@ -27,7 +27,7 @@ using Xunit.Abstractions;
 
 namespace Neo4j.Driver.Examples
 {
-    [Collection(SIIntegrationCollection.CollectionName)]
+    [Collection(SAIntegrationCollection.CollectionName)]
     public class Examples : IDisposable
     {
         private ITestOutputHelper Output { get; }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
@@ -20,16 +20,37 @@ using Xunit;
 
 namespace Neo4j.Driver.IntegrationTests
 {
-    public class IntegrationTestFixture : IDisposable
+    public class StandAloneIntegrationTestFixture : IDisposable
     {
         public StandAlone StandAlone { get; }
-        public CausalCluster Cluster { get; }
 
-        public IntegrationTestFixture()
+        public StandAloneIntegrationTestFixture()
         {
             try
             {
                 StandAlone = new StandAlone();
+            }
+            catch (Exception)
+            {
+                Dispose();
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            StandAlone?.Dispose();
+        }
+    }
+
+    public class CausalClusterIntegrationTestFixture : IDisposable
+    {
+        public CausalCluster Cluster { get; }
+
+        public CausalClusterIntegrationTestFixture()
+        {
+            try
+            {
                 Cluster = new CausalCluster();
             }
             catch (Exception)
@@ -37,20 +58,26 @@ namespace Neo4j.Driver.IntegrationTests
                 Dispose();
                 throw;
             }
-            
         }
-
         public void Dispose()
         {
-            StandAlone?.Dispose();
             Cluster?.Dispose();
         }
     }
 
     [CollectionDefinition(CollectionName)]
-    public class IntegrationCollection : ICollectionFixture<IntegrationTestFixture>
+    public class SIIntegrationCollection : ICollectionFixture<StandAloneIntegrationTestFixture>
     {
-        public const string CollectionName = "Integration";
+        public const string CollectionName = "SAIntegration";
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+
+    [CollectionDefinition(CollectionName)]
+    public class CCIntegrationCollection : ICollectionFixture<CausalClusterIntegrationTestFixture>
+    {
+        public const string CollectionName = "CCIntegration";
         // This class has no code, and is never created. Its purpose is simply
         // to be the place to apply [CollectionDefinition] and all the
         // ICollectionFixture<> interfaces.

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
@@ -66,9 +66,9 @@ namespace Neo4j.Driver.IntegrationTests
     }
 
     [CollectionDefinition(CollectionName)]
-    public class SIIntegrationCollection : ICollectionFixture<StandAloneIntegrationTestFixture>
+    public class SAIntegrationCollection : ICollectionFixture<StandAloneIntegrationTestFixture>
     {
-        public const string CollectionName = "SAIntegration";
+        public const string CollectionName = "StandAloneIntegration";
         // This class has no code, and is never created. Its purpose is simply
         // to be the place to apply [CollectionDefinition] and all the
         // ICollectionFixture<> interfaces.
@@ -77,7 +77,7 @@ namespace Neo4j.Driver.IntegrationTests
     [CollectionDefinition(CollectionName)]
     public class CCIntegrationCollection : ICollectionFixture<CausalClusterIntegrationTestFixture>
     {
-        public const string CollectionName = "CCIntegration";
+        public const string CollectionName = "CausalClusterIntegration";
         // This class has no code, and is never created. Its purpose is simply
         // to be the place to apply [CollectionDefinition] and all the
         // ICollectionFixture<> interfaces.

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
@@ -10,8 +10,7 @@ using Xunit.Abstractions;
 
 namespace Neo4j.Driver.IntegrationTests
 {
-    // If I have a cluster, then I should be able to do the following tests
-    [Collection(IntegrationCollection.CollectionName)]
+    [Collection(CCIntegrationCollection.CollectionName)]
     public class RoutingDriverIT : IDisposable
     {
         public static readonly Config DebugConfig = Config.Builder.WithLogger(new DebugLogger { Level = LogLevel.Debug }).ToConfig();
@@ -22,7 +21,7 @@ namespace Neo4j.Driver.IntegrationTests
         private string RoutingServer => Cluster.AnyCore().BoltRoutingUri.ToString();
         private string WrongServer => "bolt+routing://localhost:1234";
 
-        public RoutingDriverIT(ITestOutputHelper output, IntegrationTestFixture fixture)
+        public RoutingDriverIT(ITestOutputHelper output, CausalClusterIntegrationTestFixture fixture)
         {
             Output = output;
             Cluster = fixture.Cluster;

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/ErrorReportingSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/ErrorReportingSteps.cs
@@ -77,7 +77,7 @@ namespace Neo4j.Driver.Tck.Tests.TCK
             using (var driver = GraphDatabase.Driver("bolt://localhost:1234"))
             {
                 var ex = Xunit.Record.Exception(() => driver.Session());
-                ex.Should().BeOfType<AggregateException>();
+                ex.Should().BeOfType<ServiceUnavailableException>();
                 ex = ex.GetBaseException();
                 ex.Should().BeOfType<SocketException>();
                 ex.Message.Should().Be("No connection could be made because the target machine actively refused it 127.0.0.1:1234");

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -57,11 +57,11 @@ namespace Neo4j.Driver.Tests
                 var mockedHandler = new Mock<IConnectionErrorHandler>();
                 var connectionPool = new ConnectionPool(mock.Object, exteralErrorHandler:mockedHandler.Object);
                 // When
-                connectionPool.Acquire();
+                var conn = connectionPool.Acquire();
 
                 //Then
-                mock.Verify(x=>x.AddConnectionErrorHander(mockedHandler.Object), Times.Once);
-                mock.Verify(x => x.Init(), Times.Once);
+                mock.Verify(x => x.ExternalConnectionErrorHander(It.IsAny<IConnectionErrorHandler>()), Times.Once);
+                ((PooledConnection)conn).ExternalConnectionErrorHandler().Should().Be(mockedHandler.Object);
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MessageResponseHandlerTests.cs
@@ -219,6 +219,30 @@ namespace Neo4j.Driver.Tests
                 mrh.Error.Should().BeOfType<ClientException>();
             }
 
+            [Theory, MemberData("ProtocolErrors")]
+            public void ShouldCreateProtocolExceptionWhenClassificationContainsProtocolError(string code)
+            {
+                var mockResultBuilder = new Mock<IMessageResponseCollector>();
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+
+                mrh.HandleFailureMessage(code, "message");
+                mrh.HasError.Should().BeTrue();
+                mrh.Error.Should().BeOfType<ProtocolException>();
+            }
+
+            [Theory, MemberData("AuthErrors")]
+            public void ShouldCreateAuthExceptionWhenClassificationContainsAuthError(string code)
+            {
+                var mockResultBuilder = new Mock<IMessageResponseCollector>();
+                var mrh = new MessageResponseHandler();
+                mrh.EnqueueMessage(new PullAllMessage(), mockResultBuilder.Object);
+
+                mrh.HandleFailureMessage(code, "message");
+                mrh.HasError.Should().BeTrue();
+                mrh.Error.Should().BeOfType<AuthenticationException>();
+            }
+
             [Theory, MemberData("TransientErrors")]
             public void ShouldCreateTransientExceptionWhenClassificationContainsTransientError(string code)
             {
@@ -291,12 +315,22 @@ namespace Neo4j.Driver.Tests
             }
 
             #region Test Data
+
+            public static IEnumerable<object[]> ProtocolErrors => new[]
+            {
+                new object[] {"Neo.ClientError.Request.Invalid"},
+                new object[] {"Neo.ClientError.Request.InvalidFormat"}
+            };
+
+            public static IEnumerable<object[]> AuthErrors => new[]
+            {
+                new object[] {"Neo.ClientError.Security.Unauthorized"}
+            };
+
             public static IEnumerable<object[]> ClientErrors => new[]
             {
                 new object[] {"Neo.ClientError.General.ReadOnly"},
                 new object[] {"Neo.ClientError.LegacyIndex.NoSuchIndex"},
-                new object[] {"Neo.ClientError.Request.Invalid"},
-                new object[] {"Neo.ClientError.Request.InvalidFormat"},
                 new object[] {"Neo.ClientError.Schema.ConstraintAlreadyExists"},
                 new object[] {"Neo.ClientError.Schema.ConstraintVerificationFailure"},
                 new object[] {"Neo.ClientError.Schema.ConstraintViolation"},

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/PooledConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/PooledConnectionTests.cs
@@ -33,7 +33,7 @@ namespace Neo4j.Driver.Tests.Connector
             {
                 var mockedSocketConn = new Mock<IConnection>();
                 var conn = new PooledConnection(mockedSocketConn.Object);
-                mockedSocketConn.Verify(x=>x.AddConnectionErrorHander(It.IsAny<PooledConnection.PooledConnectionErrorHandler>()), Times.Once);
+                mockedSocketConn.Verify(x=>x.ExternalConnectionErrorHander(It.IsAny<PooledConnection.PooledConnectionErrorHandler>()), Times.Once);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -61,7 +61,7 @@ namespace Neo4j.Driver.Tests
             }
         }
 
-        public class SendMethod
+        public class SendReceiveMethod
         {
             [Fact]
             public async Task ShouldSendMessagesAsExpected()
@@ -204,12 +204,12 @@ namespace Neo4j.Driver.Tests
                     await harness.Client.Start();
 
                     // force to recive an error
-                    messageHandler.Error = new ClientException("Neo.ClientError.Request.Invalid", "Test Message");
+                    messageHandler.Error = new ProtocolException("Neo.ClientError.Request.Invalid", "Test Message");
 
                     // When
                     harness.Client.Send(messages);
                     var ex = Record.Exception(() => harness.Client.Receive(messageHandler));
-                    ex.Should().BeOfType<ClientException>();
+                    ex.Should().BeOfType<ProtocolException>();
 
                     harness.MockTcpSocketClient.Verify(x => x.DisconnectAsync(), Times.Once);
                     harness.MockTcpSocketClient.Verify(x => x.Dispose(), Times.Once);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -118,7 +119,7 @@ namespace Neo4j.Driver.Tests
                 // When
                 var error = Exception(()=>conn.Init());
                 // Then
-                error.Should().BeOfType<ClientException>();
+                error.Should().BeOfType<IOException>();
                 error.Message.Should().Be("Failed to connect to the server neo4j.com:80 within connection timeout 5000ms");
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackerTests.cs
@@ -22,6 +22,7 @@ using Moq;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Packstream;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.V1;
 using Xunit;
 
 namespace Neo4j.Driver.Tests
@@ -440,7 +441,7 @@ namespace Neo4j.Driver.Tests
                 {
                     var packer = new PackStream.Packer(null);
                     var ex = Xunit.Record.Exception(() => packer.Pack(new {Name = "Test"}));
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                 }
             }
 
@@ -564,7 +565,7 @@ namespace Neo4j.Driver.Tests
                 {
                     var packer = new PackStream.Packer(null);
                     var ex = Xunit.Record.Exception(() => packer.PackStructHeader(short.MaxValue +1, 0x1));
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                 }
             }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/UnpackerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/UnpackerTests.cs
@@ -20,6 +20,7 @@ using FluentAssertions;
 using Moq;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Packstream;
+using Neo4j.Driver.V1;
 using Xunit;
 
 namespace Neo4j.Driver.Tests
@@ -52,7 +53,7 @@ namespace Neo4j.Driver.Tests
                     var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackNull());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                 }
             }
 
@@ -92,7 +93,7 @@ namespace Neo4j.Driver.Tests
                     var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackBoolean());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                 }
             }
 
@@ -186,7 +187,7 @@ namespace Neo4j.Driver.Tests
                     var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackLong());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                 }
             }
 
@@ -216,7 +217,7 @@ namespace Neo4j.Driver.Tests
                     var unpacker = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => unpacker.UnpackDouble());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                 }
             }
 
@@ -309,7 +310,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackString());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                     mockInput.Verify(x => x.ReadInt(), Times.Once);
                 }
@@ -323,7 +324,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackString());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                 }
             }
@@ -397,7 +398,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackBytes());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                     mockInput.Verify(x => x.ReadInt(), Times.Once);
                 }
@@ -411,7 +412,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackBytes());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                 }
             }
@@ -480,7 +481,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackMapHeader());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                 }
             }
@@ -549,7 +550,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackListHeader());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                 }
             }
@@ -620,7 +621,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.UnpackStructHeader());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.ReadByte(), Times.Once);
                 }
             }
@@ -674,7 +675,7 @@ namespace Neo4j.Driver.Tests
                     var u = new PackStream.Unpacker(mockInput.Object);
 
                     var ex = Xunit.Record.Exception(() => u.PeekNextType());
-                    ex.Should().BeOfType<ArgumentOutOfRangeException>();
+                    ex.Should().BeOfType<ProtocolException>();
                     mockInput.Verify(x => x.PeekByte(), Times.Once);
                 }
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
@@ -137,7 +137,7 @@ namespace Neo4j.Driver.Tests
 
                 // Then
                 exception.Should().BeOfType<ProtocolException>();
-                exception.Message.Should().Be("Error when parsing `getServers` result: keys (2) dose not equal values (1).");
+                exception.Message.Should().Be("Error when parsing `getServers` result: keys (2) does not equal to values (1).");
                 clientMock.Verify(x => x.Dispose(), Times.Once);
             }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
@@ -137,7 +137,7 @@ namespace Neo4j.Driver.Tests
 
                 // Then
                 exception.Should().BeOfType<ProtocolException>();
-                exception.Message.Should().Be("Error when parsing `getServers` result: keys (2) did not equal values (1).");
+                exception.Message.Should().Be("Error when parsing `getServers` result: keys (2) dose not equal values (1).");
                 clientMock.Verify(x => x.Dispose(), Times.Once);
             }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
@@ -250,7 +250,7 @@ namespace Neo4j.Driver.Tests
                         if (connection.Server.Address.Equals(uriA.ToString())) // uri2
                         {
                             throw balancer.CreateClusterPooledConnectionErrorHandler(uriA)
-                                .OnConnectionError(new IOException("failed init"));
+                                .OnConnectionError(new ServiceUnavailableException("failed init"));
                         }
                         if (connection.Server.Address.Equals(uriB.ToString())) // uri2
                         {
@@ -465,7 +465,7 @@ namespace Neo4j.Driver.Tests
                         .Callback(() =>
                         {
                             throw balancer.CreateClusterPooledConnectionErrorHandler(uri)
-                                .OnConnectionError(new IOException("failed init"));
+                                .OnConnectionError(new ServiceUnavailableException("failed init"));
                         });
 
                     // When

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -123,28 +123,6 @@ namespace Neo4j.Driver.Tests
                 var error = Record.Exception(() => session.BeginTransaction());
                 error.Should().BeOfType<ClientException>();
             }
-
-            [Fact]
-            public void ShouldNotAllowMoreStatementsInSessionWhileConnectionHasUnrecoverableError()
-            {
-                var mockConn = new Mock<IPooledConnection>();
-                mockConn.Setup(x => x.HasUnrecoverableError).Returns(true);
-                var session = new Session(mockConn.Object, null);
-
-                var error = Record.Exception(() => session.Run("lalal"));
-                error.Should().BeOfType<ClientException>();
-            }
-
-            [Fact]
-            public void ShouldNotAllowMoreTransactionsInSessionWhileConnectionHasUnrecoverableError()
-            {
-                var mockConn = new Mock<IPooledConnection>();
-                mockConn.Setup(x => x.HasUnrecoverableError).Returns(true);
-                var session = new Session(mockConn.Object, null);
-
-                var error = Record.Exception(() => session.BeginTransaction());
-                error.Should().BeOfType<ClientException>();
-            }
         }
 
         public class DisposeMethod

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -51,14 +51,14 @@ namespace Neo4j.Driver.Internal
             ConnectionSettings connectionSettings,
             ConnectionPoolSettings connectionPoolSettings,
             ILogger logger,
-            IConnectionErrorHandler exteralErrorHandler = null)
+            IConnectionErrorHandler externalErrorHandler = null)
             : base(logger)
         {
             _uri = uri;
             _connectionSettings = connectionSettings;
             _idleSessionPoolSize = connectionPoolSettings.MaxIdleSessionPoolSize;
 
-            _externalErrorHandler = exteralErrorHandler;
+            _externalErrorHandler = externalErrorHandler;
             _logger = logger;
         }
 
@@ -87,7 +87,7 @@ namespace Neo4j.Driver.Internal
                     : new PooledConnection(new SocketConnection(_uri, _connectionSettings, _logger), Release);
                 if (_externalErrorHandler != null)
                 {
-                    conn.AddConnectionErrorHander(_externalErrorHandler);
+                    conn.ExternalConnectionErrorHander(_externalErrorHandler);
                 }
                 conn.Init();
                 return conn;
@@ -264,10 +264,5 @@ namespace Neo4j.Driver.Internal
         /// Try to reset the connection to a clean state to prepare it for a new session.
         /// </summary>
         void ClearConnection();
-
-        /// <summary>
-        /// Return true if unrecoverable error has been received on this connection, otherwise false.
-        /// </summary>
-        bool HasUnrecoverableError { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
@@ -127,7 +127,7 @@ namespace Neo4j.Driver.Internal.Connector
             var numberOfbytesRead = _tcpSocketClient.ReadStream.Read(buffer);
             if (numberOfbytesRead != buffer.Length)
             {
-                throw new Neo4jException($"Expect {buffer.Length}, but got {numberOfbytesRead}");
+                throw new ProtocolException($"Expect {buffer.Length}, but got {numberOfbytesRead}");
             }
 
             _logger?.Trace("S: ", buffer, 0, buffer.Length);
@@ -139,7 +139,7 @@ namespace Neo4j.Driver.Internal.Connector
             ReadSpecifiedSize(_headTailBuffer);
             if (_headTailBuffer.Equals(Tail))
             {
-                throw new Neo4jException("Not chunked correctly");
+                throw new ProtocolException("Not chunked correctly");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
@@ -134,7 +134,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         private void WriteBytesInChunk(byte[] bytes, int offset = 0, int? length = null)
         {
-            Throw.ArgumentOutOfRangeException.IfNotTrue(_isInChunk, nameof(_isInChunk));
+            Throw.ArgumentOutOfRangeException.IfFalse(_isInChunk, nameof(_isInChunk));
             Array.Copy(bytes, offset, _buffer, _pos, length ?? bytes.Length);
             _pos += length ?? bytes.Length;
             _chunkLength += length ?? bytes.Length;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedOutputStream.cs
@@ -134,7 +134,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         private void WriteBytesInChunk(byte[] bytes, int offset = 0, int? length = null)
         {
-            Throw.ArgumentException.IfNotTrue(_isInChunk, nameof(_isInChunk));
+            Throw.ArgumentOutOfRangeException.IfNotTrue(_isInChunk, nameof(_isInChunk));
             Array.Copy(bytes, offset, _buffer, _pos, length ?? bytes.Length);
             _pos += length ?? bytes.Length;
             _chunkLength += length ?? bytes.Length;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -57,7 +57,8 @@ namespace Neo4j.Driver.Internal.Connector
         void Close();
 
         /// <summary>
-        /// Adds a external error handler that you wish to be called back when a consreponding error is received
+        /// Adds a external error handler that you wish to be called backa when a consreponding error is received.
+        /// The external error handler will be called after internal error handlers if any has been registered internally.
         /// </summary>
         /// <param name="handler">The extra error handler to add.</param>
         void ExternalConnectionErrorHander(IConnectionErrorHandler handler);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -57,9 +57,9 @@ namespace Neo4j.Driver.Internal.Connector
         void Close();
 
         /// <summary>
-        /// Adds an extra error handler that you wish to be called back when a consreponding error is received
+        /// Adds a external error handler that you wish to be called back when a consreponding error is received
         /// </summary>
         /// <param name="handler">The extra error handler to add.</param>
-        void AddConnectionErrorHander(IConnectionErrorHandler handler);
+        void ExternalConnectionErrorHander(IConnectionErrorHandler handler);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnectionErrorHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnectionErrorHandler.cs
@@ -15,13 +15,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.IO;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Connector
 {
     internal interface IConnectionErrorHandler
     {
+        /// <summary>
+        /// Define what to do when a connection error happens when sending and receiving data
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
         Exception OnConnectionError(Exception e);
-        Neo4jException OnNeo4jError(Neo4jException e);
+        /// <summary>
+        /// Define what to do when a failure received from the server after data received from the server
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
+        Neo4jException OnServerError(Neo4jException e);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -16,6 +16,8 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
 using Neo4j.Driver.Internal.Result;
 using Neo4j.Driver.V1;
 
@@ -25,6 +27,7 @@ namespace Neo4j.Driver.Internal.Connector
     {
         private readonly Action<Guid> _releaseAction;
         private readonly IConnection _connection;
+        private IConnectionErrorHandler _externalErrorHandler;
 
         public PooledConnection(IConnection connection, Action<Guid> releaseAction = null)
         {
@@ -32,7 +35,7 @@ namespace Neo4j.Driver.Internal.Connector
             _releaseAction = releaseAction ?? (x => { });
 
             //Adds call back error handler
-            AddConnectionErrorHander(new PooledConnectionErrorHandler(OnNeo4jError));
+            _connection.ExternalConnectionErrorHander(new PooledConnectionErrorHandler(OnServerError, OnConnectionError));
         }
         public Guid Id { get; } = Guid.NewGuid();
 
@@ -93,11 +96,6 @@ namespace Neo4j.Driver.Internal.Connector
             _connection.Close();
         }
 
-        public void AddConnectionErrorHander(IConnectionErrorHandler handler)
-        {
-            _connection.AddConnectionErrorHander(handler);
-        }
-
         /// <summary>
         /// Disposing a pooled connection will try to release the connection resource back to pool
         /// </summary>
@@ -106,9 +104,13 @@ namespace Neo4j.Driver.Internal.Connector
             _releaseAction(Id);
         }
 
-        public bool HasUnrecoverableError { private set; get; }
+        /// <summary>
+        /// Return true if unrecoverable error has been received on this connection, otherwise false.
+        /// The connection that has been marked as has unrecoverable errors will be eventally closed when returning back to the pool.
+        /// </summary>
+        internal bool HasUnrecoverableError { private set; get; }
 
-        private Neo4jException OnNeo4jError(Neo4jException error)
+        private Neo4jException OnServerError(Neo4jException error)
         {
             if (error.IsRecoverableError())
             {
@@ -118,7 +120,32 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 HasUnrecoverableError = true;
             }
-            return error;
+            return _externalErrorHandler == null ? error: _externalErrorHandler.OnServerError(error);
+        }
+
+        private Exception OnConnectionError(Exception error)
+        {
+            // No connection error is recoverable
+            HasUnrecoverableError = true;
+
+            if ( error is IOException || error is SocketException ||
+                error.GetBaseException() is IOException || error.GetBaseException() is SocketException )
+            {
+                error = new ServiceUnavailableException(
+                    $"Connection with the server breaks due to {error.GetType().Name}: {error.Message}", error);
+            }
+
+            return _externalErrorHandler == null ? error: _externalErrorHandler.OnConnectionError(error);
+        }
+
+        public void ExternalConnectionErrorHander(IConnectionErrorHandler handler)
+        {
+            _externalErrorHandler = handler;
+        }
+
+        internal IConnectionErrorHandler ExternalConnectionErrorHandler()
+        {
+            return _externalErrorHandler;
         }
 
         internal class PooledConnectionErrorHandler : IConnectionErrorHandler
@@ -128,7 +155,7 @@ namespace Neo4j.Driver.Internal.Connector
 
             public PooledConnectionErrorHandler(
                 Func<Neo4jException, Neo4jException> onNeo4JErrorFunc,
-                Func<Exception, Exception> onConnectionErrorFunc = null)
+                Func<Exception, Exception> onConnectionErrorFunc)
             {
                 _onNeo4jErrorFunc = onNeo4JErrorFunc;
                 _onConnErrorFunc = onConnectionErrorFunc;
@@ -136,10 +163,10 @@ namespace Neo4j.Driver.Internal.Connector
 
             public Exception OnConnectionError(Exception e)
             {
-                return _onConnErrorFunc == null ? e : _onConnErrorFunc.Invoke(e);
+                return _onConnErrorFunc.Invoke(e);
             }
 
-            public Neo4jException OnNeo4jError(Neo4jException e)
+            public Neo4jException OnServerError(Neo4jException e)
             {
                 return _onNeo4jErrorFunc.Invoke(e);
             }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -150,14 +150,14 @@ namespace Neo4j.Driver.Internal.Connector
 
         internal class PooledConnectionErrorHandler : IConnectionErrorHandler
         {
-            private readonly Func<Neo4jException, Neo4jException> _onNeo4jErrorFunc;
+            private readonly Func<Neo4jException, Neo4jException> _onServerErrorFunc;
             private readonly Func<Exception, Exception> _onConnErrorFunc;
 
             public PooledConnectionErrorHandler(
-                Func<Neo4jException, Neo4jException> onNeo4JErrorFunc,
+                Func<Neo4jException, Neo4jException> onServerErrorFunc,
                 Func<Exception, Exception> onConnectionErrorFunc)
             {
-                _onNeo4jErrorFunc = onNeo4JErrorFunc;
+                _onServerErrorFunc = onServerErrorFunc;
                 _onConnErrorFunc = onConnectionErrorFunc;
             }
 
@@ -168,7 +168,7 @@ namespace Neo4j.Driver.Internal.Connector
 
             public Neo4jException OnServerError(Neo4jException e)
             {
-                return _onNeo4jErrorFunc.Invoke(e);
+                return _onServerErrorFunc.Invoke(e);
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -40,7 +40,7 @@ namespace Neo4j.Driver.Internal.Connector
         private readonly object _syncLock = new object();
 
         private readonly ILogger _logger;
-        public IConnectionErrorHandler _externalErrorHandler;
+        private IConnectionErrorHandler _externalErrorHandler;
 
         public SocketConnection(Uri uri, ConnectionSettings connectionSettings, ILogger logger)
             : this(new SocketClient(uri, connectionSettings.EncryptionManager, logger),
@@ -234,7 +234,7 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 var error = _responseHandler.Error;
 
-                error = OnNeo4jError(error);
+                error = OnServerError(error);
 
                 _responseHandler.Error = null;
                 _interrupted = false;
@@ -247,7 +247,7 @@ namespace Neo4j.Driver.Internal.Connector
             return _externalErrorHandler == null ? e : _externalErrorHandler.OnConnectionError(e);
         }
 
-        public Neo4jException OnNeo4jError(Neo4jException e)
+        public Neo4jException OnServerError(Neo4jException e)
         {
             return _externalErrorHandler == null ? e : _externalErrorHandler.OnServerError(e);
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Messaging;
@@ -39,7 +40,7 @@ namespace Neo4j.Driver.Internal.Connector
         private readonly object _syncLock = new object();
 
         private readonly ILogger _logger;
-        private readonly IList<IConnectionErrorHandler> _handlers = new List<IConnectionErrorHandler>();
+        public IConnectionErrorHandler _externalErrorHandler;
 
         public SocketConnection(Uri uri, ConnectionSettings connectionSettings, ILogger logger)
             : this(new SocketClient(uri, connectionSettings.EncryptionManager, logger),
@@ -74,7 +75,7 @@ namespace Neo4j.Driver.Internal.Connector
                 var connected = Task.Run(() => _client.Start()).Wait(_connectionTimeout);
                 if (!connected)
                 {
-                    throw new ClientException($"Failed to connect to the server {Server.Address} within connection timeout {_connectionTimeout.TotalMilliseconds}ms");
+                    throw new IOException($"Failed to connect to the server {Server.Address} within connection timeout {_connectionTimeout.TotalMilliseconds}ms");
                 }
             }
             catch (Exception error)
@@ -205,11 +206,6 @@ namespace Neo4j.Driver.Internal.Connector
             Dispose();
         }
 
-        public void AddConnectionErrorHander(IConnectionErrorHandler handler)
-        {
-            _handlers.Add(handler);
-        }
-
         public void Dispose()
         {
             Dispose(true);
@@ -248,20 +244,12 @@ namespace Neo4j.Driver.Internal.Connector
 
         private Exception OnConnectionError(Exception e)
         {
-            foreach (var handler in _handlers)
-            {
-                e = handler.OnConnectionError(e);
-            }
-            return e;
+            return _externalErrorHandler == null ? e : _externalErrorHandler.OnConnectionError(e);
         }
 
         public Neo4jException OnNeo4jError(Neo4jException e)
         {
-            foreach (var handler in _handlers)
-            {
-                e = handler.OnNeo4jError(e);
-            }
-            return e;
+            return _externalErrorHandler == null ? e : _externalErrorHandler.OnServerError(e);
         }
 
         private void Enqueue(IRequestMessage requestMessage, IMessageResponseCollector resultBuilder = null, IRequestMessage requestStreamingMessage = null)
@@ -299,6 +287,11 @@ namespace Neo4j.Driver.Internal.Connector
                         "running the statement which get reset in this session.", e);
                 }
             }
+        }
+
+        public void ExternalConnectionErrorHander(IConnectionErrorHandler handler)
+        {
+            _externalErrorHandler = handler;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -20,10 +20,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Neo4j.Driver.V1;
-<<<<<<< HEAD
 using static System.Security.Authentication.SslProtocols;
-=======
->>>>>>> Added support for security errors
 
 namespace Neo4j.Driver.Internal.Connector
 {
@@ -31,7 +28,6 @@ namespace Neo4j.Driver.Internal.Connector
     {
         private readonly TcpClient _client;
         private Stream _stream;
-        private ILogger _logger;
 
         private readonly EncryptionManager _encryptionManager;
 
@@ -39,7 +35,6 @@ namespace Neo4j.Driver.Internal.Connector
         {
             _encryptionManager = encryptionManager;
             _client = new TcpClient();
-            _logger = logger;
         }
 
         public Stream ReadStream => _stream;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -20,7 +20,10 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Neo4j.Driver.V1;
+<<<<<<< HEAD
 using static System.Security.Authentication.SslProtocols;
+=======
+>>>>>>> Added support for security errors
 
 namespace Neo4j.Driver.Internal.Connector
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
@@ -36,7 +36,7 @@ namespace Neo4j.Driver.Internal
             }
         }
 
-        public static class ArgumentException
+        public static class ProtocolException
         {
             public static void IfNotEqual(int first, int second, string firstParam, string secondParam)
             {
@@ -54,13 +54,13 @@ namespace Neo4j.Driver.Internal
             public static void If(Func<bool> func, object first, object second, string firstParam, string secondParam)
             {
                 if(func())
-                    throw new System.ArgumentException($"{firstParam} ({first}) did not equal {secondParam} ({second})");
+                    throw new V1.ProtocolException($"{firstParam} ({first}) does not equal to {secondParam} ({second})");
             }
 
             public static void IfNotTrue(bool value, string nameofValue)
             {
                 if(!value)
-                    throw new System.ArgumentException($"Expecting {nameofValue} to be true, however the value is false");
+                    throw new V1.ProtocolException($"Expecting {nameofValue} to be true, however the value is false");
             }
         }
 
@@ -76,6 +76,11 @@ namespace Neo4j.Driver.Internal
             {
                 if(value > limit)
                     throw new System.ArgumentOutOfRangeException(parameterName, value, $"Value given ({value}) cannot be greater than {limit}.");
+            }
+            public static void IfNotTrue(bool value, string nameofValue)
+            {
+                if (!value)
+                    throw new System.ArgumentOutOfRangeException($"Expecting {nameofValue} to be true, however the value is false");
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
@@ -57,7 +57,7 @@ namespace Neo4j.Driver.Internal
                     throw new V1.ProtocolException($"{firstParam} ({first}) does not equal to {secondParam} ({second})");
             }
 
-            public static void IfNotTrue(bool value, string nameofValue)
+            public static void IfFalse(bool value, string nameofValue)
             {
                 if(!value)
                     throw new V1.ProtocolException($"Expecting {nameofValue} to be true, however the value is false");
@@ -77,7 +77,7 @@ namespace Neo4j.Driver.Internal
                 if(value > limit)
                     throw new System.ArgumentOutOfRangeException(parameterName, value, $"Value given ({value}) cannot be greater than {limit}.");
             }
-            public static void IfNotTrue(bool value, string nameofValue)
+            public static void IfFalse(bool value, string nameofValue)
             {
                 if (!value)
                     throw new System.ArgumentOutOfRangeException($"Expecting {nameofValue} to be true, however the value is false");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
@@ -19,6 +19,7 @@ using System.Collections;
 using System.Globalization;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;
+using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Packstream
 {
@@ -218,7 +219,7 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 else
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value.GetType(),
+                    throw new ProtocolException(
                         $"Cannot understand {nameof(value)} with type {value.GetType().FullName}");
                 }
             }
@@ -345,7 +346,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     _out.Write(STRUCT_16, BitConverter.GetBytes((short) size)).Write(signature);
                 }
                 else
-                    throw new ArgumentOutOfRangeException(nameof(size), size,
+                    throw new ProtocolException(
                         $"Structures cannot have more than {short.MaxValue} fields");
             }
         }
@@ -365,7 +366,7 @@ namespace Neo4j.Driver.Internal.Packstream
                 byte markerByte = _in.ReadByte();
                 if (markerByte != NULL)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                    throw new ProtocolException(
                         $"Expected a null, but got: 0x{(markerByte & 0xFF).ToString("X2")}");
                 }
                 return null;
@@ -381,7 +382,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     case FALSE:
                         return false;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected a boolean, but got: 0x{(markerByte & 0xFF).ToString("X2")}");
                 }
             }
@@ -404,7 +405,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     case INT_64:
                         return _in.ReadLong();
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected an integer, but got: 0x{markerByte.ToString("X2")}");
                 }
             }
@@ -416,7 +417,7 @@ namespace Neo4j.Driver.Internal.Packstream
                 {
                     return _in.ReadDouble();
                 }
-                throw new ArgumentOutOfRangeException( nameof(markerByte), markerByte,
+                throw new ProtocolException(
                     $"Expected a double, but got: 0x{markerByte.ToString("X2")}");
             }
 
@@ -450,12 +451,12 @@ namespace Neo4j.Driver.Internal.Packstream
                         }
                         else
                         {
-                            throw new ArgumentOutOfRangeException(nameof(size), size,
+                            throw new ProtocolException(
                                 $"BYTES_32 {size} too long for PackStream");
                         }
                     }
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected binary data, but got: 0x{(markerByte & 0xFF).ToString("X2")}");
                 }
             }
@@ -489,11 +490,11 @@ namespace Neo4j.Driver.Internal.Packstream
                         {
                             return UnpackBytes((int) size);
                         }
-                        throw new ArgumentOutOfRangeException(nameof(size), size, 
+                        throw new ProtocolException(
                             $"STRING_32 {size} too long for PackStream");
                     }
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected a string, but got: 0x{(markerByte & 0xFF).ToString("X2")}");
                 }
             }
@@ -517,7 +518,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     case MAP_32:
                         return UnpackUint32();
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected a map, but got: {markerByte.ToString("X2")}");
                 }
             }
@@ -541,7 +542,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     case LIST_32:
                         return UnpackUint32();
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected a list, but got: {(markerByte & 0xFF).ToString("X2")}");
                 }
             }
@@ -568,7 +569,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     case STRUCT_16:
                         return UnpackUint16();
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Expected a struct, but got: {markerByte.ToString("X2")}");
                 }
             }
@@ -627,7 +628,7 @@ namespace Neo4j.Driver.Internal.Packstream
                     case INT_64:
                         return PackType.Integer;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(markerByte), markerByte,
+                        throw new ProtocolException(
                             $"Unknown type 0x{markerByte.ToString("X2")}");
                 }
             }
@@ -658,7 +659,6 @@ namespace Neo4j.Driver.Internal.Packstream
 
     internal interface IReader
     {
-//        bool HasNext();
         void Read(IMessageResponseHandler responseHandler);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStream.cs
@@ -519,7 +519,7 @@ namespace Neo4j.Driver.Internal.Packstream
                         return UnpackUint32();
                     default:
                         throw new ProtocolException(
-                            $"Expected a map, but got: {markerByte.ToString("X2")}");
+                            $"Expected a map, but got: 0x{markerByte.ToString("X2")}");
                 }
             }
 
@@ -543,7 +543,7 @@ namespace Neo4j.Driver.Internal.Packstream
                         return UnpackUint32();
                     default:
                         throw new ProtocolException(
-                            $"Expected a list, but got: {(markerByte & 0xFF).ToString("X2")}");
+                            $"Expected a list, but got: 0x{(markerByte & 0xFF).ToString("X2")}");
                 }
             }
 
@@ -570,7 +570,7 @@ namespace Neo4j.Driver.Internal.Packstream
                         return UnpackUint16();
                     default:
                         throw new ProtocolException(
-                            $"Expected a struct, but got: {markerByte.ToString("X2")}");
+                            $"Expected a struct, but got: 0x{markerByte.ToString("X2")}");
                 }
             }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
@@ -67,7 +67,7 @@ namespace Neo4j.Driver.Internal.Packstream
                         UnpackIgnoredMessage(responseHandler);
                         break;
                     default:
-                        throw new IOException("Unknown requestMessage type: " + type);
+                        throw new ProtocolException("Unknown requestMessage type: " + type);
                 }
                 UnPackMessageTail();
             }
@@ -98,13 +98,13 @@ namespace Neo4j.Driver.Internal.Packstream
                         switch (_unpacker.UnpackStructSignature())
                         {
                             case NODE:
-                                Throw.ArgumentException.IfNotEqual(NodeFields, size, nameof(NodeFields), nameof(size));
+                                Throw.ProtocolException.IfNotEqual(NodeFields, size, nameof(NodeFields), nameof(size));
                                 return UnpackNode();
                             case RELATIONSHIP:
-                                Throw.ArgumentException.IfNotEqual(RelationshipFields, size, nameof(RelationshipFields), nameof(size));
+                                Throw.ProtocolException.IfNotEqual(RelationshipFields, size, nameof(RelationshipFields), nameof(size));
                                 return UnpackRelationship();
                             case PATH:
-                                Throw.ArgumentException.IfNotEqual(PathFields, size, nameof(PathFields), nameof(size));
+                                Throw.ProtocolException.IfNotEqual(PathFields, size, nameof(PathFields), nameof(size));
                                 return UnpackPath();
                         }
                         break;
@@ -118,8 +118,8 @@ namespace Neo4j.Driver.Internal.Packstream
                 var uniqNodes = new INode[(int) _unpacker.UnpackListHeader()];
                 for(int i = 0; i < uniqNodes.Length; i ++)
                 {
-                    Throw.ArgumentException.IfNotEqual(NodeFields, _unpacker.UnpackStructHeader(), nameof(NodeFields), $"received{nameof(NodeFields)}");
-                    Throw.ArgumentException.IfNotEqual(NODE, _unpacker.UnpackStructSignature(),nameof(NODE), $"received{nameof(NODE)}");
+                    Throw.ProtocolException.IfNotEqual(NodeFields, _unpacker.UnpackStructHeader(), nameof(NodeFields), $"received{nameof(NodeFields)}");
+                    Throw.ProtocolException.IfNotEqual(NODE, _unpacker.UnpackStructSignature(),nameof(NODE), $"received{nameof(NODE)}");
                     uniqNodes[i]=UnpackNode();
                 }
 
@@ -127,8 +127,8 @@ namespace Neo4j.Driver.Internal.Packstream
                 var uniqRels = new Relationship[(int)_unpacker.UnpackListHeader()];
                 for (int i = 0; i < uniqRels.Length; i++)
                 {
-                    Throw.ArgumentException.IfNotEqual( UnboundRelationshipFields, _unpacker.UnpackStructHeader(), nameof(UnboundRelationshipFields), $"received{nameof(UnboundRelationshipFields)}");
-                    Throw.ArgumentException.IfNotEqual(UNBOUND_RELATIONSHIP, _unpacker.UnpackStructSignature(), nameof(UNBOUND_RELATIONSHIP), $"received{nameof(UNBOUND_RELATIONSHIP)}");
+                    Throw.ProtocolException.IfNotEqual( UnboundRelationshipFields, _unpacker.UnpackStructHeader(), nameof(UnboundRelationshipFields), $"received{nameof(UnboundRelationshipFields)}");
+                    Throw.ProtocolException.IfNotEqual(UNBOUND_RELATIONSHIP, _unpacker.UnpackStructSignature(), nameof(UNBOUND_RELATIONSHIP), $"received{nameof(UNBOUND_RELATIONSHIP)}");
                     var urn = _unpacker.UnpackLong();
                     var relType = _unpacker.UnpackString();
                     var props = UnpackMap();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
@@ -29,7 +29,7 @@ namespace Neo4j.Driver.Internal.Result
 
         public Record(List<string>keys, object[] values)
         {
-            Throw.ArgumentException.IfNotEqual(keys.Count, values.Length, nameof(keys), nameof(values));
+            Throw.ProtocolException.IfNotEqual(keys.Count, values.Length, nameof(keys), nameof(values));
 
             var valueKeys = new Dictionary<string, object>();
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -238,12 +238,12 @@ namespace Neo4j.Driver.Internal.Routing
         internal class ClusterPooledConnectionErrorHandler : IConnectionErrorHandler
         {
             private Func<Exception, Exception> _onConnectionErrorFunc;
-            private readonly Func<Neo4jException, Neo4jException> _onNeo4jErrorFunc;
+            private readonly Func<Neo4jException, Neo4jException> _onServerErrorFunc;
 
-            public ClusterPooledConnectionErrorHandler(Func<Exception, Exception> onConnectionErrorFuncFunc, Func<Neo4jException, Neo4jException> onNeo4JErrorFuncFunc)
+            public ClusterPooledConnectionErrorHandler(Func<Exception, Exception> onConnectionErrorFuncFunc, Func<Neo4jException, Neo4jException> onServerErrorFuncFunc)
             {
                 _onConnectionErrorFunc = onConnectionErrorFuncFunc;
-                _onNeo4jErrorFunc = onNeo4JErrorFuncFunc;
+                _onServerErrorFunc = onServerErrorFuncFunc;
             }
 
             public Exception OnConnectionError(Exception e)
@@ -253,7 +253,7 @@ namespace Neo4j.Driver.Internal.Routing
 
             public Neo4jException OnServerError(Neo4jException e)
             {
-                return _onNeo4jErrorFunc.Invoke(e);
+                return _onServerErrorFunc.Invoke(e);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -202,17 +202,16 @@ namespace Neo4j.Driver.Internal.Routing
 
         private Exception OnConnectionError(Exception e, Uri uri)
         {
-            if (e is SecurityException || e is ProtocolException)
+            if (e is ServiceUnavailableException)
             {
-                return e;
+                _logger?.Info($"Server at {uri} is no longer available due to error: {e.Message}.");
+                Forget(uri);
+                return new SessionExpiredException($"Server at {uri} is no longer available due to error: {e.Message}.", e);
             }
-
-            _logger?.Info($"Server at {uri} is no longer available due to error: {e.Message}.");
-            Forget(uri);
-            return new SessionExpiredException($"Server at {uri} is no longer available due to error: {e.Message}.", e);
+            return e;
         }
 
-        private Neo4jException OnNeo4jError(Neo4jException error, Uri uri)
+        private Neo4jException OnServerError(Neo4jException error, Uri uri)
         {
             if (error.IsClusterNotALeaderError())
             {
@@ -233,7 +232,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         internal ClusterPooledConnectionErrorHandler CreateClusterPooledConnectionErrorHandler(Uri uri)
         {
-            return new ClusterPooledConnectionErrorHandler(x => OnConnectionError(x, uri), x => OnNeo4jError(x, uri));
+            return new ClusterPooledConnectionErrorHandler(x => OnConnectionError(x, uri), x => OnServerError(x, uri));
         }
 
         internal class ClusterPooledConnectionErrorHandler : IConnectionErrorHandler
@@ -252,7 +251,7 @@ namespace Neo4j.Driver.Internal.Routing
                 return _onConnectionErrorFunc.Invoke(e);
             }
 
-            public Neo4jException OnNeo4jError(Neo4jException e)
+            public Neo4jException OnServerError(Neo4jException e)
             {
                 return _onNeo4jErrorFunc.Invoke(e);
             }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Neo4jException.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System;
 using System.Runtime.Serialization;
+using Neo4j.Driver.Internal.Routing;
 
 namespace Neo4j.Driver.V1
 {
@@ -168,7 +169,19 @@ namespace Neo4j.Driver.V1
     [DataContract]
     public class ProtocolException : Neo4jException
     {
+        private const string ErrorCodeInvalid = "Neo.ClientError.Request.Invalid";
+        private const string ErrorCodeInvalidFormat = "Neo.ClientError.Request.InvalidFormat";
+
+        internal static bool IsProtocolError(string code)
+        {
+            return code.Equals(ErrorCodeInvalid) || code.Equals(ErrorCodeInvalidFormat);
+        }
+
         public ProtocolException(string message) : base(message)
+        {
+        }
+
+        public ProtocolException(string code, string message) : base(code, message)
         {
         }
 
@@ -204,7 +217,12 @@ namespace Neo4j.Driver.V1
     [DataContract]
     public class AuthenticationException : SecurityException
     {
-        internal const string ErrorCode = "Neo.ClientError.Security.Unauthorized";
+        private const string ErrorCode = "Neo.ClientError.Security.Unauthorized";
+
+        internal static bool IsAuthenticationError(string code)
+        {
+            return code.Equals(ErrorCode);
+        }
 
         public AuthenticationException(string message) : base(ErrorCode, message)
         {


### PR DESCRIPTION
Based on #142 

* Made `DirectDriver` throw `ServiceUnavailable` when failed to send/receive data caused by `IOException` and `SocketException`.
* Ensured connections who have connection errors always closed immediately when the error is received. Also ensure connections where `ProtocolError` is received from server will be immediately stop too. 
* Ensured connections who have connection errors always mark connections not recoverable. (A fallback to ensure the connection will be closed again when session.close)
* Changed most `ArgumentOutOfRangeException` in `PackStream` to `ProtocolException`.

* Improved the IT structure to only start corresponding neo4j services for stand alone or cluster.
* Changed the error handling logic on connections. Before each connection could register multiple error handlers, while no order among the handlers is guaranteed. Now each connection could accept only one external error hander. The external handler will only be executed after internal handler has been called.