### PR TITLE
Decouple conn from session

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/AuthenticationIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/AuthenticationIT.cs
@@ -19,8 +19,9 @@ namespace Neo4j.Driver.IntegrationTests
         {
             Exception exception;
             using (var driver = GraphDatabase.Driver(ServerEndPoint, AuthTokens.Basic("fake", "fake")))
+            using (var session = driver.Session())
             {
-                exception = Record.Exception(()=>driver.Session());
+                exception = Record.Exception(() =>session.Run("Return 1"));
             }
             exception.Should().BeOfType<AuthenticationException>();
             exception.Message.Should().Contain("The client is unauthorized due to authentication failure.");

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
@@ -21,8 +21,9 @@ namespace Neo4j.Driver.IntegrationTests
         {
             Exception exception;
             using (var driver = GraphDatabase.Driver("bolt://localhost:123"))
+            using (var session = driver.Session())
             {
-               exception = Record.Exception(()=>driver.Session());
+                exception = Record.Exception(() => session.Run("RETURN 1"));
             }
             exception.Should().BeOfType<ServiceUnavailableException>();
             exception.Message.Should().Be("Connection with the server breaks due to AggregateException: One or more errors occurred.");

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
@@ -57,7 +57,7 @@ namespace Neo4j.Driver.IntegrationTests
 
             var error = Record.Exception(() => session.Run("RETURN 1"));
             error.Should().BeOfType<ObjectDisposedException>();
-            error.Message.Should().StartWith("Cannot acquire a new connection as ConnectionPool has already been disposed.");
+            error.Message.Should().StartWith("Failed to acquire a new connection as the driver has already been disposed.");
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
@@ -47,6 +47,20 @@ namespace Neo4j.Driver.IntegrationTests
         }
 
         [Fact]
+        public void DisallowRunInSessionAfterDriverDispose()
+        {
+            var driver = GraphDatabase.Driver(ServerEndPoint, AuthToken);
+            var session = driver.Session(AccessMode.Write);
+            session.Run("RETURN 1").Single()[0].ValueAs<int>().Should().Be(1);
+
+            driver.Dispose();
+
+            var error = Record.Exception(() => session.Run("RETURN 1"));
+            error.Should().BeOfType<ObjectDisposedException>();
+            error.Message.Should().StartWith("Cannot acquire a new connection as ConnectionPool has already been disposed.");
+        }
+
+        [Fact]
         public void ShouldConnectAndRun()
         {
             using (var session = Driver.Session())

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
@@ -129,7 +129,7 @@ namespace Neo4j.Driver.IntegrationTests
             driver.Dispose();
             var error = Record.Exception(() => session.Run("RETURN 1"));
             error.Should().BeOfType<ObjectDisposedException>();
-            error.Message.Should().StartWith("Cannot acquire a new connection as LoadBalancer has already been disposed.");
+            error.Message.Should().StartWith("Failed to acquire a new connection as the driver has already been disposed.");
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
@@ -46,8 +46,9 @@ namespace Neo4j.Driver.IntegrationTests
 
             Exception exception = null;
             using (var driver = GraphDatabase.Driver(RoutingServer, AuthTokens.Basic("fake", "fake")))
+            using(var session = driver.Session())
             {
-                exception = Record.Exception(() => driver.Session());
+                exception = Record.Exception(() => session.Run("RETURN 1"));
             }
             exception.Should().BeOfType<AuthenticationException>();
             exception.Message.Should().Be("The client is unauthorized due to authentication failure.");
@@ -104,11 +105,14 @@ namespace Neo4j.Driver.IntegrationTests
                 return;
             }
 
-            var driver = GraphDatabase.Driver(WrongServer, AuthToken);
-            var error = Record.Exception(()=>driver.Session());
+            Exception error = null;
+            using (var driver = GraphDatabase.Driver(RoutingServer, AuthTokens.Basic("fake", "fake")))
+            using (var session = driver.Session())
+            {
+                error = Record.Exception(() => session.Run("RETURN 1"));
+            }
             error.Should().BeOfType<ServiceUnavailableException>();
             error.Message.Should().Be("Failed to connect to any routing server. Please make sure that the cluster is up and can be accessed by the driver and retry.");
-            driver.Dispose();
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
@@ -106,7 +106,7 @@ namespace Neo4j.Driver.IntegrationTests
             }
 
             Exception error = null;
-            using (var driver = GraphDatabase.Driver(RoutingServer, AuthTokens.Basic("fake", "fake")))
+            using (var driver = GraphDatabase.Driver(WrongServer, AuthTokens.Basic("fake", "fake")))
             using (var session = driver.Session())
             {
                 error = Record.Exception(() => session.Run("RETURN 1"));
@@ -128,8 +128,8 @@ namespace Neo4j.Driver.IntegrationTests
 
             driver.Dispose();
             var error = Record.Exception(() => session.Run("RETURN 1"));
-            error.Should().BeOfType<ClientException>();
-            error.Message.Should().Contain("The current session cannot be reused as the underlying connection with the server has been closed");
+            error.Should().BeOfType<ObjectDisposedException>();
+            error.Message.Should().StartWith("Cannot acquire a new connection as LoadBalancer has already been disposed.");
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/DriverAuthSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/DriverAuthSteps.cs
@@ -59,8 +59,9 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         {
             var driver = ScenarioContext.Current.Get<IDriver>();
             using (driver)
+            using (var session = driver.Session())
             {
-                var exception = Record.Exception(() => driver.Session());
+                var exception = Record.Exception(() => session.Run("RETURN 1"));
                 exception.Should().BeOfType<AuthenticationException>();
                 exception.Message.Should().StartWith("The client is unauthorized due to authentication failure");
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/ErrorReportingSteps.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tck.Tests/Tck/ErrorReportingSteps.cs
@@ -75,8 +75,9 @@ namespace Neo4j.Driver.Tck.Tests.TCK
         public void WhenISetUpADriverToAnIncorrectPort()
         {
             using (var driver = GraphDatabase.Driver("bolt://localhost:1234"))
+            using (var session = driver.Session())
             {
-                var ex = Xunit.Record.Exception(() => driver.Session());
+                var ex = Xunit.Record.Exception(() => session.Run("RETURN 1"));
                 ex.Should().BeOfType<ServiceUnavailableException>();
                 ex = ex.GetBaseException();
                 ex.Should().BeOfType<SocketException>();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -287,7 +287,7 @@ namespace Neo4j.Driver.Tests
                 pool.Dispose();
                 var exception = Record.Exception(() => pool.Acquire());
                 exception.Should().BeOfType<ObjectDisposedException>();
-                exception.Message.Should().Contain("Cannot acquire a new connection from the connection pool");
+                exception.Message.Should().StartWith("Cannot acquire a new connection");
             }
 
             // thread-safe test
@@ -318,7 +318,7 @@ namespace Neo4j.Driver.Tests
                 healthyMock.Verify(x => x.IsOpen, Times.Once);
                 healthyMock.Verify(x => x.Close(), Times.Once);
                 exception.Should().BeOfType<ObjectDisposedException>();
-                exception.Message.Should().Contain("Cannot acquire a new connection from the connection pool");
+                exception.Message.Should().StartWith("Cannot acquire a new connection");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -287,7 +287,7 @@ namespace Neo4j.Driver.Tests
                 pool.Dispose();
                 var exception = Record.Exception(() => pool.Acquire());
                 exception.Should().BeOfType<ObjectDisposedException>();
-                exception.Message.Should().StartWith("Cannot acquire a new connection");
+                exception.Message.Should().StartWith("Failed to acquire a new connection");
             }
 
             // thread-safe test
@@ -318,7 +318,7 @@ namespace Neo4j.Driver.Tests
                 healthyMock.Verify(x => x.IsOpen, Times.Once);
                 healthyMock.Verify(x => x.Close(), Times.Once);
                 exception.Should().BeOfType<ObjectDisposedException>();
-                exception.Message.Should().StartWith("Cannot acquire a new connection");
+                exception.Message.Should().StartWith("Failed to acquire a new connection");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -60,7 +60,7 @@ namespace Neo4j.Driver.Tests
             {
                 var builder = GenerateBuilder();
                 var i = 0;
-                builder.SetReceiveOneFunc(() =>
+                builder.SetReceiveOneAction(() =>
                 {
                     if (i++ >= 3)
                     {
@@ -81,7 +81,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldReturnNoResultsWhenNoneRecieved()
             {
                 var builder = GenerateBuilder();
-                builder.SetReceiveOneFunc(() =>
+                builder.SetReceiveOneAction(() =>
                 {
                     builder.CollectSummary(null);
                 });
@@ -1003,7 +1003,7 @@ namespace Neo4j.Driver.Tests
             {
                 var builder = GenerateBuilder();
                 var i = 0;
-                builder.SetReceiveOneFunc(() =>
+                builder.SetReceiveOneAction(() =>
                 {
                     if (i++ >= 3)
                     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -119,9 +119,10 @@ namespace Neo4j.Driver.Tests
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(false);
                 var session = new Session(mockConn.Object);
+                session.Run("lala");
 
-                var error = Record.Exception(() => session.BeginTransaction());
-                error.Should().BeOfType<ClientException>();
+                session.BeginTransaction();
+                mockConn.Verify(c=>c.Dispose(), Times.Once);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Concurrent;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
+using static Neo4j.Driver.Internal.Throw.DriverDisposedException;
 
 namespace Neo4j.Driver.Internal
 {
@@ -101,7 +102,7 @@ namespace Neo4j.Driver.Internal
             {
                 if (_disposeCalled)
                 {
-                    ThrowConnectionPoolClosedException();
+                    ThrowObjectDisposedException();
                 }
                 IPooledConnection connection;
 
@@ -122,7 +123,7 @@ namespace Neo4j.Driver.Internal
                     {
                         connection.Close();
                     }
-                    ThrowConnectionPoolClosedException();
+                    ThrowObjectDisposedException();
                 }
 
                 return connection;
@@ -223,9 +224,9 @@ namespace Neo4j.Driver.Internal
             base.Dispose(true);
         }
 
-        private void ThrowConnectionPoolClosedException()
+        private void ThrowObjectDisposedException()
         {
-            throw new ObjectDisposedException(GetType().Name, $"Cannot acquire a new connection as {GetType().Name} has already been disposed.");
+            FailedToCreateConnection(this);
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -225,7 +225,7 @@ namespace Neo4j.Driver.Internal
 
         private void ThrowConnectionPoolClosedException()
         {
-            throw new ObjectDisposedException(GetType().Name, "Cannot acquire a new connection from the connection pool as the pool has already been disposed.");
+            throw new ObjectDisposedException(GetType().Name, $"Cannot acquire a new connection as {GetType().Name} has already been disposed.");
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DirectDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DirectDriver.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Internal
 
         public override ISession NewSession(AccessMode mode)
         {
-            return new Session(_connectionPool.Acquire(), _logger);
+            return new Session(()=>_connectionPool.Acquire(), _logger);
         }
 
         public override void ReleaseUnmanagedResources()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
@@ -20,6 +20,14 @@ namespace Neo4j.Driver.Internal
 {
     internal static class Throw
     {
+        public static class DriverDisposedException
+        {
+            public static void FailedToCreateConnection(object obj)
+            {
+                throw new ObjectDisposedException(obj.GetType().Name, "Failed to acquire a new connection as the driver has already been disposed.");
+            }
+        }
+
         public static class ArgumentNullException
         {
             public static void IfNull(object parameter, string paramName)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
+using static Neo4j.Driver.Internal.Throw.DriverDisposedException;
 
 namespace Neo4j.Driver.Internal.Routing
 {
@@ -58,7 +59,7 @@ namespace Neo4j.Driver.Internal.Routing
         {
             if (_disposeCalled)
             {
-                ThrowObjectClosedException();
+                ThrowObjectDisposedException();
             }
 
             EnsureRoutingTableIsFresh();
@@ -77,14 +78,14 @@ namespace Neo4j.Driver.Internal.Routing
 
             if (_disposeCalled)
             {
-                ThrowObjectClosedException();
+                ThrowObjectDisposedException();
             }
             return conn;
         }
 
-        private void ThrowObjectClosedException()
+        private void ThrowObjectDisposedException()
         {
-            throw new ObjectDisposedException(GetType().Name, $"Cannot acquire a new connection as {GetType().Name} has already been disposed.");
+            FailedToCreateConnection(this);
         }
 
         internal IConnection AcquireReadConnection()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingDriver.cs
@@ -43,7 +43,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         public override ISession NewSession(AccessMode mode)
         {
-            return new Session(_loadBalancer.AcquireConnection(mode), _logger);
+            return new Session(()=>_loadBalancer.AcquireConnection(mode), _logger);
         }
 
         public override void ReleaseUnmanagedResources()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -34,12 +34,7 @@ namespace Neo4j.Driver.Internal
         private const string Commit = "COMMIT";
         private const string Rollback = "ROLLBACK";
 
-        /* 
-         * All the blocks that modifies the state of this tx and perform certain actoin based on the current tx state should be syncronized
-         * as a reset thread and a run thread could modify this state at the same time.
-         */
         private State _state = State.Active;
-        private readonly object _syncLock = new object();
 
         public Transaction(IConnection connection, Action cleanupAction=null, ILogger logger=null, string bookmark = null) : base(logger)
         {
@@ -90,35 +85,32 @@ namespace Neo4j.Driver.Internal
             }
             try
             {
-                lock (_syncLock)
+                if (_state == State.MarkedSuccess)
                 {
-                    if (_state == State.MarkedSuccess)
+                    try
                     {
+                        _connection.Run(Commit, null, new BookmarkCollector(s => Bookmark = s));
+                        _connection.Sync();
+                        _state = State.Succeeded;
+                    }
+                    catch (Exception)
+                    {
+                        // if we ever failed to commit, then we rollback the tx
                         try
                         {
-                            _connection.Run(Commit, null, new BookmarkCollector(s => Bookmark = s));
-                            _connection.Sync();
-                            _state = State.Succeeded;
+                            RollBackTx();
                         }
-                        catch(Exception)
+                        catch (Exception)
                         {
-                            // if we ever failed to commit, then we rollback the tx
-                            try
-                            {
-                                RollBackTx();
-                            }
-                            catch (Exception)
-                            {
-                                // ignored
-                            }
-
-                            throw;
+                            // ignored
                         }
+
+                        throw;
                     }
-                    else if (_state == State.MarkedFailed || _state == State.Active)
-                    {
-                        RollBackTx();
-                    }
+                }
+                else if (_state == State.MarkedFailed || _state == State.Active)
+                {
+                    RollBackTx();
                 }
             }
             finally
@@ -139,22 +131,22 @@ namespace Neo4j.Driver.Internal
         {
             return TryExecute(() =>
             {
-                lock (_syncLock)
+
+                EnsureNotFailed();
+                try
                 {
-                    EnsureNotFailed();
-                    try
-                    {
-                        var resultBuilder = new ResultBuilder(statement, parameters, () => _connection.ReceiveOne(), _connection.Server);
-                        _connection.Run(statement, parameters, resultBuilder);
-                        _connection.Send();
-                        return resultBuilder.PreBuild();
-                    }
-                    catch (Neo4jException)
-                    {
-                        _state = State.Failed;
-                        throw;
-                    }
+                    var resultBuilder = new ResultBuilder(statement, parameters, () => _connection.ReceiveOne(),
+                        _connection.Server);
+                    _connection.Run(statement, parameters, resultBuilder);
+                    _connection.Send();
+                    return resultBuilder.PreBuild();
                 }
+                catch (Neo4jException)
+                {
+                    _state = State.Failed;
+                    throw;
+                }
+
             });
         }
 
@@ -172,32 +164,23 @@ namespace Neo4j.Driver.Internal
 
         public void Success()
         {
-            lock (_syncLock)
+            if (_state == State.Active)
             {
-                if (_state == State.Active)
-                {
-                    _state = State.MarkedSuccess;
-                }
+                _state = State.MarkedSuccess;
             }
         }
 
         public void Failure()
         {
-            lock (_syncLock)
+            if (_state == State.Active || _state == State.MarkedSuccess)
             {
-                if (_state == State.Active || _state == State.MarkedSuccess)
-                {
-                    _state = State.MarkedFailed;
-                }
+                _state = State.MarkedFailed;
             }
         }
 
         public void MarkToClose()
         {
-            lock (_syncLock)
-            {
-                _state = State.Failed;
-            }
+            _state = State.Failed;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -131,7 +131,6 @@ namespace Neo4j.Driver.Internal
         {
             return TryExecute(() =>
             {
-
                 EnsureNotFailed();
                 try
                 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.Internal
     internal class Transaction : StatementRunner, ITransaction
     {
         private readonly IConnection _connection;
-        private readonly Action _cleanupAction;
+        private readonly Action _sessionCleanupAction;
 
         internal const string BookmarkKey = "bookmark";
         internal string Bookmark { get; private set; }
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Internal
         public Transaction(IConnection connection, Action cleanupAction=null, ILogger logger=null, string bookmark = null) : base(logger)
         {
             _connection = connection;
-            _cleanupAction = cleanupAction ?? (() => { });
+            _sessionCleanupAction = cleanupAction ?? (() => { });
 
             IDictionary<string, object> paramters = new Dictionary<string, object>();
             if (bookmark != null)
@@ -115,7 +115,7 @@ namespace Neo4j.Driver.Internal
             }
             finally
             {
-                _cleanupAction.Invoke();
+                _sessionCleanupAction.Invoke();
                 base.Dispose(true);
             }
         }


### PR DESCRIPTION
based on #147 

* `Connection` used by `session.Run` and/or `transaction` should be disposed one and only once.
* `Connection` used by `session.Run`:
  - It will be disposed when the reply message (`SUCCESS/IGNORE/FAILURE`) of `PULL_ALL` is received.
  - It will also be disposed in `session.Dispose` and/or another new `session.Run` and/or a new `transaction` if no reply message of `PULL_ALL` received.

* `Connection` used by transaction will be disposed when the tx is disposed or the session is disposed.

* Ensure a connection cannot be created after `driver.Dispose`