### PR TITLE
Idle timer on each pooled connection to record the idle time elapsed

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolSettings.cs
@@ -15,24 +15,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal
 {
     internal class ConnectionPoolSettings
     {
-        public int MaxIdleSessionPoolSize { get; }
+        public int MaxIdleConnectionPoolSize { get; }
         public IStatisticsCollector StatisticsCollector { get; }
+        public TimeSpan ConnectionIdleTimeout { get; }
+        
 
         public ConnectionPoolSettings(Config config)
-            :this(config.MaxIdleSessionPoolSize, config.DriverStatisticsCollector)
+            :this(config.MaxIdleSessionPoolSize, config.ConnectionIdleTimeout, config.DriverStatisticsCollector)
         {
         }
 
-        public ConnectionPoolSettings(int maxIdleSessionPoolSize, IStatisticsCollector statisticsCollector=null)
+        public ConnectionPoolSettings(int maxIdleConnectionPoolSize, TimeSpan connectionIdleTimeout, IStatisticsCollector statisticsCollector=null)
         {
-            Throw.ArgumentNullException.IfNull(maxIdleSessionPoolSize, nameof(maxIdleSessionPoolSize));
-            MaxIdleSessionPoolSize = maxIdleSessionPoolSize;
+            Throw.ArgumentNullException.IfNull(maxIdleConnectionPoolSize, nameof(maxIdleConnectionPoolSize));
+            Throw.ArgumentNullException.IfNull(connectionIdleTimeout, nameof(connectionIdleTimeout));
+            MaxIdleConnectionPoolSize = maxIdleConnectionPoolSize;
+            ConnectionIdleTimeout = connectionIdleTimeout;
             StatisticsCollector = statisticsCollector;
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.Diagnostics;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Connector
@@ -27,6 +28,7 @@ namespace Neo4j.Driver.Internal.Connector
             :base (conn)
         {
             _releaseAction = releaseAction ?? (x => { });
+            IdleTimer = new StopwatchBasedTimer();
         }
         public Guid Id { get; } = Guid.NewGuid();
 
@@ -77,6 +79,28 @@ namespace Neo4j.Driver.Internal.Connector
         public override string ToString()
         {
             return Id.ToString();
+        }
+
+        public ITimer IdleTimer { get; }
+    }
+
+    internal class StopwatchBasedTimer : ITimer
+    {
+        private readonly Stopwatch _stopwatch;
+        public StopwatchBasedTimer()
+        {
+            _stopwatch = new Stopwatch();
+        }
+
+        public long ElapsedMilliseconds => _stopwatch.ElapsedMilliseconds;
+        public void Reset()
+        {
+            _stopwatch.Reset();
+        }
+
+        public void Start()
+        {
+            _stopwatch.Start();
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IPooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IPooledConnection.cs
@@ -30,5 +30,20 @@ namespace Neo4j.Driver.Internal
         /// Try to reset the connection to a clean state to prepare it for a new session.
         /// </summary>
         void ClearConnection();
+
+        ITimer IdleTimer { get; }
+    }
+
+    internal interface ITimer
+    {
+        /// <summary>Gets the total elapsed time measured by the current instance, in milliseconds.</summary>
+        /// <returns>A read-only long integer representing the total number of milliseconds measured by the current instance.</returns>
+        /// <filterpriority>1</filterpriority>
+        long ElapsedMilliseconds { get; }
+
+        /// <summary>Stops time interval measurement and resets the elapsed time to zero.</summary>
+        void Reset();
+        /// <summary>Starts, or resumes, measuring elapsed time for an interval.</summary>
+        void Start();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/LoggerBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/LoggerBase.cs
@@ -22,12 +22,12 @@ namespace Neo4j.Driver.Internal
 {
     internal abstract class LoggerBase : IDisposable
     {
+        protected ILogger Logger { get; private set; }
+
         protected LoggerBase(ILogger logger)
         {
             Logger = logger;
         }
-
-        protected ILogger Logger { get; private set; }
 
         protected void TryExecute(Action action)
         {

--- a/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
@@ -77,6 +77,7 @@ namespace Neo4j.Driver.V1
         /// <item><see cref="ConnectionTimeout"/>: <c>5s</c> </item>
         /// <item><see cref="SocketKeepAlive"/>: <c>true</c></item>
         /// <item><see cref="MaxTransactionRetryTime"/>: <c>30s</c></item>
+        /// <item><see cref="ConnectionIdleTimeout"/>: <c>Infinite(-1ms)</c></item>
         /// </list>
         /// </remarks>
         public static Config DefaultConfig { get; }
@@ -124,6 +125,16 @@ namespace Neo4j.Driver.V1
         /// Gets or sets the socket keep alive option.
         /// </summary>
         public bool SocketKeepAlive { get; set; } = true;
+
+        internal static readonly TimeSpan Infinite = TimeSpan.FromMilliseconds(-1);
+
+        /// <summary>
+        /// Gets or sets the idle timeout on pooled connecitons.
+        /// A connection that has been idled in connection pool for longer than the given timeout is stale and will be closed once it is seen.
+        /// Any negative <see cref="TimeSpan"/> value will be considered to be "Infinite",
+        /// a.k.a. pooled connections will never be stale.
+        /// </summary>
+        public TimeSpan ConnectionIdleTimeout { get; set; } = Infinite;
 
         /// <summary>
         /// Gets or sets the statistics collector to which the statistics inside the driver could be published.


### PR DESCRIPTION
By default the connection pool will not timeout any connection inside the pool. As long as the connection is still "open", then the connection is reused.
While a user could enable idle timeout on connections by setting `ConnectionIdleTimeout` to be a non-negative number.
Then when reusing connections from the pool, connections that have been idle for longer than the configured time will be closed directly.

Notes:
* The timer is implemented using `Stopwatch`, the time elapsed is loosely precise.
* The connection will not immediately be closed when idle timeout reached, instead it will be closed in the same thread that get it out of the pool.