### PR TITLE
Allow the driver to serve read operations when the writer is absent.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ConcurrentRoundRobinSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ConcurrentRoundRobinSetTests.cs
@@ -101,9 +101,18 @@ namespace Neo4j.Driver.Tests.Routing
             [Fact]
             public void ShouldRemoveAdd()
             {
+                // Given
                 var set = new ConcurrentRoundRobinSet<int> { 0, 1, 2, 3 };
+                int ignored;
+                set.TryNext(out ignored);
+                set.Index.Should().Be(1);
+
+                // When
                 set.Clear();
+
+                // Then
                 set.Should().BeEmpty();
+                set.Index.Should().Be(0);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ConcurrentRoundRobinSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ConcurrentRoundRobinSetTests.cs
@@ -99,7 +99,7 @@ namespace Neo4j.Driver.Tests.Routing
         public class ClearMethod
         {
             [Fact]
-            public void ShouldRemoveAdd()
+            public void ShouldClear()
             {
                 // Given
                 var set = new ConcurrentRoundRobinSet<int> { 0, 1, 2, 3 };

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ConcurrentRoundRobinSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ConcurrentRoundRobinSet.cs
@@ -27,6 +27,8 @@ namespace Neo4j.Driver.Internal.Routing
         private readonly IList<T> _items = new List<T>();
         private int _index = 0;
 
+        internal int Index => _index;
+
         /// <summary>
         /// Add one item into this set.
         /// </summary>
@@ -103,6 +105,7 @@ namespace Neo4j.Driver.Internal.Routing
             lock (_items)
             {
                 _items.Clear();
+                _index = 0;
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IRoutingTable.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IRoutingTable.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
+using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Routing
 {
     internal interface IRoutingTable
     {
-        bool IsStale();
+        bool IsStale(AccessMode mode);
         bool TryNextRouter(out Uri uri);
         bool TryNextReader(out Uri uri);
         bool TryNextWriter(out Uri uri);
@@ -13,6 +14,6 @@ namespace Neo4j.Driver.Internal.Routing
         void RemoveWriter(Uri uri);
         ISet<Uri> All();
         void Clear();
-        void AddRouter(IEnumerable<Uri> uris);
+        void PrependRouters(IEnumerable<Uri> uris);
     }
 }


### PR DESCRIPTION
In order to do this, a few driver behaviours have been changed:
* Move the EnsureRoutingTable check inside each AcquireReader/Writer method
* Allow the driver to accept routing table wihtout a writer
* Always first try initial routers for a new routing table in next discovery call if the writer is absent