### PR TITLE
introduce async capable methods on existing classes

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -43,7 +44,7 @@ namespace Neo4j.Driver.Tests
                 {
                     harness.SetupReadStream(new byte[] {0, 0, 0, 1});
                     await harness.Client.Start();
-                    harness.MockTcpSocketClient.Verify(t => t.ConnectAsync(FakeUri),
+                    harness.MockTcpSocketClient.Verify(t => t.ConnectAsync(FakeUri, Timeout.InfiniteTimeSpan),
                         Times.Once);
                 }
             }
@@ -212,7 +213,7 @@ namespace Neo4j.Driver.Tests
                     var ex = Record.Exception(() => harness.Client.Receive(messageHandler));
                     ex.Should().BeOfType<ProtocolException>();
 
-                    harness.MockTcpSocketClient.Verify(x => x.DisconnectAsync(), Times.Once);
+                    harness.MockTcpSocketClient.Verify(x => x.Disconnect(), Times.Once);
                     harness.MockTcpSocketClient.Verify(x => x.Dispose(), Times.Once);
                 }
             }
@@ -287,7 +288,7 @@ namespace Neo4j.Driver.Tests
                     harness.SetupReadStream("00 00 00 01");
                     await harness.Client.Start();
                     harness.Client.Dispose();
-                    harness.MockTcpSocketClient.Verify(s => s.DisconnectAsync(), Times.Once);
+                    harness.MockTcpSocketClient.Verify(s => s.Disconnect(), Times.Once);
                     harness.MockTcpSocketClient.Verify(s => s.Dispose(), Times.Once);
                     harness.Client.IsOpen.Should().BeFalse();
                 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
@@ -18,6 +18,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Neo4j.Driver.Internal;
@@ -71,7 +73,7 @@ namespace Neo4j.Driver.Tests
                         .Setup(s => s.Write(It.IsAny<byte[]>(), 0, It.IsAny<int>()))
                         .Callback<byte[], int, int>(
                             (buffer, start, size) => Received = $"{buffer.ToHexString(start, size)}");
-
+                    
                     MockTcpSocketClient
                         .Setup(t => t.WriteStream)
                         .Returns(MockStream.Object);
@@ -295,7 +297,256 @@ namespace Neo4j.Driver.Tests
                 writer.Flush();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
+            
         }
+
+        public class WriterV1TestsAsync
+        {
+            
+            private class Mocks
+            {
+                public MemoryStream MockStream { get; }
+                public Mock<ITcpSocketClient> MockTcpSocketClient { get; }
+                public Stream Stream => MockStream;
+                public ITcpSocketClient TcpSocketClient => MockTcpSocketClient.Object;
+
+                public string Received { get; set; }
+
+                public Mocks()
+                {
+                    MockTcpSocketClient = new Mock<ITcpSocketClient>();
+
+                    MockStream = new MemoryStream();
+
+                    MockTcpSocketClient
+                        .Setup(t => t.WriteStream)
+                        .Returns(MockStream);
+                }
+
+                public void VerifyWrite(byte[] bytes, int bufferSize = ChunkedOutputStream.BufferSize)
+                {
+                    byte[] expectedBytes = bytes;
+                    byte[] actualBytes = MockStream.ToArray();
+
+                    actualBytes.Should().Equal(expectedBytes, $"Received {Received}{Environment.NewLine}Expected {expectedBytes.ToHexString(0, bytes.Length)}");
+                    //MockStream.Verify(c => c.WriteAsync(expectedBytes, 0, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once,
+                        //$"Received {Received}{Environment.NewLine}Expected {expectedBytes.ToHexString(0, bytes.Length)}");
+                }
+            }
+
+            [Fact]
+            public async void PacksInitMessageCorrectly()
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                writer.Write(new InitMessage("a", new Dictionary<string, object>()));
+                await writer.FlushAsync();
+
+                mocks.VerifyWrite(new byte[] { 0x00, 0x05, 0xB1, 0x01, 0x81, 0x61, 0xA0, 0x00, 0x00 });
+            }
+
+            [Fact]
+            public async void PackRunMessageCorrectly()
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                writer.Write(new RunMessage("RETURN 1 AS num"));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(
+                    "00 13 b2 10  8f 52 45 54  55 52 4e 20  31 20 41 53 20 6e 75 6d  a0 00 00".ToByteArray());
+            }
+
+            [Theory]
+            [InlineData(1, "00 0D B2 10 80 A1 87 69 6E 74 65 67 65 72 01 00 00")]
+            [InlineData(long.MinValue, "00 15 B2 10 80 A1 87 69 6E 74 65 67 65 72 CB 80 00 00 00 00 00 00 00 00 00")]
+            [InlineData(long.MaxValue, "00 15 B2 10 80 A1 87 69 6E 74 65 67 65 72 CB 7F FF FF FF FF FF FF FF 00 00")]
+            [InlineData((long)int.MinValue - 1,
+                "00 15 B2 10 80 A1 87 69 6E 74 65 67 65 72 CB FF FF FF FF 7F FF FF FF 00 00")]
+            [InlineData((long)int.MaxValue + 1,
+                "00 15 B2 10 80 A1 87 69 6E 74 65 67 65 72 CB 00 00 00 00 80 00 00 00 00 00")]
+            [InlineData(int.MinValue, "00 11 B2 10 80 A1 87 69 6E 74 65 67 65 72 CA 80 00 00 00 00 00")]
+            [InlineData(int.MaxValue, "00 11 B2 10 80 A1 87 69 6E 74 65 67 65 72 CA 7F FF FF FF 00 00")]
+            [InlineData(short.MinValue - 1, "00 11 B2 10 80 A1 87 69 6E 74 65 67 65 72 CA FF FF 7F FF 00 00")]
+            [InlineData(short.MaxValue + 1, "00 11 B2 10 80 A1 87 69 6E 74 65 67 65 72 CA 00 00 80 00 00 00")]
+            [InlineData(short.MinValue, "00 0F B2 10 80 A1 87 69 6E 74 65 67 65 72 C9 80 00 00 00")]
+            [InlineData(short.MaxValue, "00 0F B2 10 80 A1 87 69 6E 74 65 67 65 72 C9 7F FF 00 00")]
+            [InlineData(-129, "00 0F B2 10 80 A1 87 69 6E 74 65 67 65 72 C9 FF 7F 00 00")]
+            [InlineData(128, "00 0F B2 10 80 A1 87 69 6E 74 65 67 65 72 C9 00 80 00 00")]
+            [InlineData(-128, "00 0E B2 10 80 A1 87 69 6E 74 65 67 65 72 C8 80 00 00")]
+            [InlineData(-17, "00 0E B2 10 80 A1 87 69 6E 74 65 67 65 72 C8 EF 00 00")]
+            [InlineData(-16, "00 0D B2 10 80 A1 87 69 6E 74 65 67 65 72 F0 00 00")]
+            [InlineData(127, "00 0D B2 10 80 A1 87 69 6E 74 65 67 65 72 7F 00 00")]
+            public async void PackRunMessageWithIntegerParamCorrectly(long value, string expectedBytes)
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "integer", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Theory]
+            [InlineData(true, "00 0B B2 10 80 A1 85 76 61 6C 75 65 C3 00 00")]
+            [InlineData(false, "00 0B B2 10 80 A1 85 76 61 6C 75 65 C2 00 00")]
+            public async void PackRunMessageWithBoolParamCorrectly(bool value, string expectedBytes)
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Theory]
+            [InlineData(1.00, "00 13 B2 10 80 A1 85 76 61 6C 75 65 C1 3F F0 00 00 00 00 00 00 00 00")]
+            [InlineData(double.MaxValue, "00 13 B2 10 80 A1 85 76 61 6C 75 65 C1 7F EF FF FF FF FF FF FF 00 00")]
+            [InlineData(double.MinValue, "00 13 B2 10 80 A1 85 76 61 6C 75 65 C1 FF EF FF FF FF FF FF FF 00 00")]
+            public async void PackRunMessageWithDoubleParamCorrectly(double value, string expectedBytes)
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Theory]
+            [InlineData(1.0f, "00 13 B2 10 80 A1 85 76 61 6C 75 65 C1 3F F0 00 00 00 00 00 00 00 00")]
+            [InlineData(float.MaxValue, "00 13 B2 10 80 A1 85 76 61 6C 75 65 C1 47 EF FF FF E0 00 00 00 00 00")]
+            [InlineData(float.MinValue, "00 13 B2 10 80 A1 85 76 61 6C 75 65 C1 C7 EF FF FF E0 00 00 00 00 00")]
+            public async void PackRunMessageWithFloatParamCorrectly(float value, string expectedBytes)
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Theory]
+            [InlineData("它们的语言学归属在西方语言学界存在争议",
+                "00 45 B2 10 80 A1 85 76 61 6C 75 65 D0 39 E5 AE 83 E4 BB AC E7 9A 84 E8 AF AD E8 A8 80 E5 AD A6 E5 BD 92 E5 B1 9E E5 9C A8 E8 A5 BF E6 96 B9 E8 AF AD E8 A8 80 E5 AD A6 E7 95 8C E5 AD 98 E5 9C A8 E4 BA 89 E8 AE AE 00 00"
+            )]
+            [InlineData("", "00 0B B2 10 80 A1 85 76 61 6C 75 65 80 00 00")]
+            [InlineData("kåkåkå kå",
+                "00 18 B2 10 80 A1 85 76 61 6C 75 65 8D 6B C3 A5 6B C3 A5 6B C3 A5 20 6B C3 A5 00 00")]
+            public async void PackRunMessageWithStringParamCorrectly(string value, string expectedBytes)
+            {
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Fact]
+            public async void PackRunMessageWithArrayListParamCorrectly()
+            {
+                var value = new ArrayList();
+                string expectedBytes = "00 0B B2 10 80 A1 85 76 61 6C 75 65 90 00 00";
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Fact]
+            public async void PackRunMessageWithArrayParamCorrectly()
+            {
+                var value = new int[] { 1, 2 };
+                string expectedBytes = "00 0D B2 10 80 A1 85 76 61 6C 75 65 92 01 02 00 00";
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Fact]
+            public async void PackRunMessageWithGenericListParamCorrectly()
+            {
+                var value = new List<int> { 1, 2 };
+                string expectedBytes = "00 0D B2 10 80 A1 85 76 61 6C 75 65 92 01 02 00 00";
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Fact]
+            public async void PackRunMessageWithDictionaryParamCorrectly()
+            {
+                var value = new Dictionary<string, object> { { "key1", 1 }, { "key2", 2 } };
+                string expectedBytes =
+                    "00 17 B2 10 80 A1 85 76 61 6C 75 65 A2 84 6B 65 79 31 01 84 6B 65 79 32 02 00 00";
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+            [Fact]
+            public async void PackRunMessageWithDictionaryMixedTypesParamCorrectly()
+            {
+                var value = new Dictionary<string, object> { { "key1", 1 }, { "key2", "a string value" } };
+                string expectedBytes =
+                    " 00 25 B2 10 80 A1 85 76 61 6C 75 65 A2 84 6B 65 79 31 01 84 6B 65 79 32 8E 61 20 73 74 72 69 6E 67 20 76 61 6C 75 65 00 00";
+                var mocks = new Mocks();
+
+                var writer =
+                    new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
+                var values = new Dictionary<string, object> { { "value", value } };
+
+                writer.Write(new RunMessage("", values));
+                await writer.FlushAsync();
+                mocks.VerifyWrite(expectedBytes.ToByteArray());
+            }
+
+        }
+
 
         public class ReaderBytesIncompatibleV1Tests
         {
@@ -765,6 +1016,397 @@ namespace Neo4j.Driver.Tests
                             new Relationship( 12L, TestNodes.Alice.Id,
                                 TestNodes.Bob.Id, KNOWS,
                                 new Dictionary<string, object> {{"since", 1999L}});
+
+                        public static IRelationship AliceLikesCarol =
+                            new Relationship(13L, TestNodes.Alice.Id,
+                                TestNodes.Carol.Id, LIKES,
+                                new Dictionary<string, object>());
+
+                        public static IRelationship CarolDislikesBob =
+                            new Relationship(32L, TestNodes.Carol.Id,
+                                TestNodes.Bob.Id, DISLIKES,
+                                new Dictionary<string, object>());
+
+                        public static IRelationship CarolMarriedToDave =
+                            new Relationship(34L, TestNodes.Carol.Id,
+                                TestNodes.Dave.Id, MARRIED_TO,
+                                new Dictionary<string, object>());
+
+                        public static IRelationship DaveWorksForDave =
+                            new Relationship(44L, TestNodes.Dave.Id,
+                                TestNodes.Dave.Id, WORKS_FOR,
+                                new Dictionary<string, object>());
+                    }
+                }
+
+                public class StructUnpackerAsync
+                {
+                    [Fact]
+                    public async void ShouldUnpackRelationshipCorrectly()
+                    {
+                        var bytes = "00 07 B5 52 01 02 03 80 a0 00 00".ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var real = await reader.UnpackValueAsync();
+                        IRelationship rel = real as IRelationship;
+                        rel.Should().NotBeNull();
+
+                        rel.Id.Should().Be(1);
+                        rel.StartNodeId.Should().Be(2);
+                        rel.EndNodeId.Should().Be(3);
+                        rel.Type.Should().BeEmpty();
+                        rel.Properties.Should().BeEmpty();
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackNodeCorrectly()
+                    {
+                        var bytes = "00 06 B3 4E 01 90 A0 00 00".ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var node = await reader.UnpackValueAsync();
+                        INode n = node as INode;
+                        n.Should().NotBeNull();
+
+                        n.Id.Should().Be(1);
+                        n.Properties.Should().BeEmpty();
+                        n.Labels.Should().BeEmpty();
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathCorrectly()
+                    {
+                        var bytes = "00 0A B3 50 91 B3 4E 01 90 A0 90 90 A0 00 00".ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Id.Should().Be(1);
+                        p.Start.Properties.Should().BeEmpty();
+                        p.Start.Labels.Should().BeEmpty();
+                        p.Nodes.Should().HaveCount(1);
+                        p.Relationships.Should().HaveCount(0);
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackZeroLenghPathCorrectly()
+                    {
+                        // A
+                        var bytes =
+                            "00 2C B3 50 91 B3 4E C9 03 E9    92 86 50 65 72 73 6F 6E    88 45 6D 70 6C 6F 79 65    65 A2 84 6E 61 6D 65 85 41 6C 69 63 65 83 61 67    65 21 90 90 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Alice).Should().BeTrue();
+                        p.End.Equals(TestNodes.Alice).Should().BeTrue();
+
+                        p.Nodes.Should().HaveCount(1);
+                        p.Relationships.Should().HaveCount(0);
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathWithLenghOneCorrectly()
+                    {
+                        // A->B
+                        var bytes =
+                            "00 66 B3 50 92 B3 4E C9 03 E9    92 86 50 65 72 73 6F 6E    88 45 6D 70 6C 6F 79 65    65 A2 84 6E 61 6D 65 85 41 6C 69 63 65 83 61 67    65 21 B3 4E C9 03 EA 92    86 50 65 72 73 6F 6E 88    45 6D 70 6C 6F 79 65 65 A2 84 6E 61 6D 65 83 42    6F 62 83 61 67 65 2C 91    B3 72 0C 85 4B 4E 4F 57    53 A1 85 73 69 6E 63 65 C9 07 CF 92 01 01 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Nodes.Should().HaveCount(2);
+                        p.Relationships.Should().HaveCount(1);
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Alice).Should().BeTrue();
+                        p.End.Equals(TestNodes.Bob).Should().BeTrue();
+
+                        p.Relationships[0].Equals(TestRelationships.AliceKnowsBob).Should().BeTrue();
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathWithLenghTwoCorrectly()
+                    {
+                        // A->C->D
+                        var bytes =
+                            "00 73 B35093B34EC903E99286506572736F6E88456D706C6F796565A2846E616D6585416C6963658361676521B34EC903EB9186506572736F6EA1846E616D65854361726F6CB34EC903EC90A1846E616D65844461766592B3720D854C494B4553A0B372228A4D4152524945445F544FA09401010202 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null)
+                                .Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Nodes.Should().HaveCount(3);
+                        p.Relationships.Should().HaveCount(2);
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Alice).Should().BeTrue();
+                        p.End.Equals(TestNodes.Dave).Should().BeTrue($"Got {p.End.Id}");
+
+                        List<INode> correctOrder = new List<INode> { TestNodes.Alice, TestNodes.Carol, TestNodes.Dave };
+                        p.Nodes.Should().ContainInOrder(correctOrder);
+
+                        p.Relationships[0].Equals(TestRelationships.AliceLikesCarol).Should().BeTrue();
+                        List<IRelationship> expectedRelOrder = new List<IRelationship>
+                        {
+                            TestRelationships.AliceLikesCarol,
+                            TestRelationships.CarolMarriedToDave
+                        };
+                        p.Relationships.Should().ContainInOrder(expectedRelOrder);
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathWithRelationshipTraversedAgainstItsDirectionCorrectly()
+                    {
+                        // A->B<-C->D
+                        var bytes =
+                            "00 b0 B35094B34EC903E99286506572736F6E88456D706C6F796565A2846E616D6585416C6963658361676521B34EC903EA9286506572736F6E88456D706C6F796565A2846E616D6583426F62836167652CB34EC903EB9186506572736F6EA1846E616D65854361726F6CB34EC903EC90A1846E616D65844461766593B3720C854B4E4F5753A18573696E6365C907CFB37220884449534C494B4553A0B372228A4D4152524945445F544FA0960101FE020303 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Nodes.Should().HaveCount(4);
+                        p.Relationships.Should().HaveCount(3);
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Alice).Should().BeTrue();
+                        p.End.Equals(TestNodes.Dave).Should().BeTrue($"Got {p.End.Id}");
+
+                        List<INode> correctOrder = new List<INode>
+                        {
+                            TestNodes.Alice,
+                            TestNodes.Bob,
+                            TestNodes.Carol,
+                            TestNodes.Dave
+                        };
+                        p.Nodes.Should().ContainInOrder(correctOrder);
+
+                        p.Relationships[0].Equals(TestRelationships.AliceKnowsBob).Should().BeTrue();
+                        List<IRelationship> expectedRelOrder = new List<IRelationship>
+                        {
+                            TestRelationships.AliceKnowsBob,
+                            TestRelationships.CarolDislikesBob,
+                            TestRelationships.CarolMarriedToDave
+                        };
+                        p.Relationships.Should().ContainInOrder(expectedRelOrder);
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathWithNodeVisitedMulTimesCorrectly()
+                    {
+                        // A->B<-A->C->B<-C
+                        var bytes =
+                            "00 9E B35093B34EC903E99286506572736F6E88456D706C6F796565A2846E616D6585416C6963658361676521B34EC903EA9286506572736F6E88456D706C6F796565A2846E616D6583426F62836167652CB34EC903EB9186506572736F6EA1846E616D65854361726F6C93B3720C854B4E4F5753A18573696E6365C907CFB3720D854C494B4553A0B37220884449534C494B4553A09A0101FF0002020301FD02 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Nodes.Should().HaveCount(6);
+                        p.Relationships.Should().HaveCount(5);
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Alice).Should().BeTrue();
+                        p.End.Equals(TestNodes.Carol).Should().BeTrue($"Got {p.End.Id}");
+
+                        List<INode> correctOrder = new List<INode>
+                        {
+                            TestNodes.Alice,
+                            TestNodes.Bob,
+                            TestNodes.Alice,
+                            TestNodes.Carol,
+                            TestNodes.Bob,
+                            TestNodes.Carol
+                        };
+                        p.Nodes.Should().ContainInOrder(correctOrder);
+
+                        List<IRelationship> expectedRelOrder = new List<IRelationship>
+                        {
+                            TestRelationships.AliceKnowsBob,
+                            TestRelationships.AliceKnowsBob,
+                            TestRelationships.AliceLikesCarol,
+                            TestRelationships.CarolDislikesBob,
+                            TestRelationships.CarolDislikesBob
+                        };
+                        p.Relationships.Should().ContainInOrder(expectedRelOrder);
+                        p.Relationships[0].Equals(TestRelationships.AliceKnowsBob).Should().BeTrue();
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathWithRelTraversedMulTimesInSameDirectionCorrectly()
+                    {
+                        // A->C->B<-A->C->D
+                        var bytes =
+                            "00 BE B35094B34EC903E99286506572736F6E88456D706C6F796565A2846E616D6585416C6963658361676521B34EC903EB9186506572736F6EA1846E616D65854361726F6CB34EC903EA9286506572736F6E88456D706C6F796565A2846E616D6583426F62836167652CB34EC903EC90A1846E616D65844461766594B3720D854C494B4553A0B37220884449534C494B4553A0B3720C854B4E4F5753A18573696E6365C907CFB372228A4D4152524945445F544FA09A01010202FD0001010403 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Nodes.Should().HaveCount(6);
+                        p.Relationships.Should().HaveCount(5);
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Alice).Should().BeTrue();
+                        p.End.Equals(TestNodes.Dave).Should().BeTrue($"Got {p.End.Id}");
+
+                        List<INode> correctOrder = new List<INode>
+                        {
+                            TestNodes.Alice,
+                            TestNodes.Carol,
+                            TestNodes.Bob,
+                            TestNodes.Alice,
+                            TestNodes.Carol,
+                            TestNodes.Dave
+                        };
+                        p.Nodes.Should().ContainInOrder(correctOrder);
+
+                        List<IRelationship> expectedRelOrder = new List<IRelationship>
+                        {
+                            TestRelationships.AliceLikesCarol,
+                            TestRelationships.CarolDislikesBob,
+                            TestRelationships.AliceKnowsBob,
+                            TestRelationships.AliceLikesCarol,
+                            TestRelationships.CarolMarriedToDave
+                        };
+                        p.Relationships.Should().ContainInOrder(expectedRelOrder);
+                        p.Relationships[0].Equals(TestRelationships.AliceLikesCarol).Should().BeTrue();
+                    }
+
+                    [Fact]
+                    public async void ShouldUnpackPathWithLoopCorrectly()
+                    {
+                        // C->D->D
+                        var bytes =
+                            "00 50 B35092B34EC903EB9186506572736F6EA1846E616D65854361726F6CB34EC903EC90A1846E616D65844461766592B372228A4D4152524945445F544FA0B3722C89574F524B535F464F52A09401010201 00 00"
+                                .ToByteArray();
+                        var mockTcpSocketClient = new Mock<ITcpSocketClient>();
+                        SetupClientReadStream(mockTcpSocketClient, bytes);
+
+                        PackStreamMessageFormatV1.ReaderV1 reader = (PackStreamMessageFormatV1.ReaderV1)
+                            new PackStreamMessageFormatV1(mockTcpSocketClient.Object, null).Reader;
+                        var path = await reader.UnpackValueAsync();
+                        IPath p = path as IPath;
+                        p.Should().NotBeNull();
+
+                        p.Nodes.Should().HaveCount(3);
+                        p.Relationships.Should().HaveCount(2);
+
+                        p.Start.Should().NotBeNull();
+                        p.End.Should().NotBeNull();
+                        p.Start.Equals(TestNodes.Carol).Should().BeTrue();
+                        p.End.Equals(TestNodes.Dave).Should().BeTrue($"Got {p.End.Id}");
+
+                        List<INode> correctOrder = new List<INode>
+                        {
+                            TestNodes.Carol,
+                            TestNodes.Dave,
+                            TestNodes.Dave
+                        };
+                        p.Nodes.Should().ContainInOrder(correctOrder);
+
+                        List<IRelationship> expectedRelOrder = new List<IRelationship>
+                        {
+                            TestRelationships.CarolMarriedToDave,
+                            TestRelationships.DaveWorksForDave,
+                        };
+                        p.Relationships.Should().ContainInOrder(expectedRelOrder);
+                        p.Relationships[0].Equals(TestRelationships.CarolMarriedToDave).Should().BeTrue();
+                    }
+
+                    private static class TestNodes
+                    {
+                        public static INode Alice = new Node(1001L,
+                            new List<string> { "Person", "Employee" },
+                            new Dictionary<string, object> { { "name", "Alice" }, { "age", 33L } });
+
+                        public static INode Bob = new Node(1002L,
+                            new List<string> { "Person", "Employee" },
+                            new Dictionary<string, object> { { "name", "Bob" }, { "age", 44L } });
+
+                        public static INode Carol = new Node(
+                            1003L,
+                            new List<string> { "Person" },
+                            new Dictionary<string, object> { { "name", "Carol" } });
+
+                        public static INode Dave = new Node(
+                            1004L,
+                            new List<string>(),
+                            new Dictionary<string, object> { { "name", "Dave" } });
+                    }
+
+                    private static class TestRelationships
+                    {
+                        // IRelationship types
+                        private static string KNOWS = "KNOWS";
+                        private static string LIKES = "LIKES";
+                        private static string DISLIKES = "DISLIKES";
+
+                        private static string MARRIED_TO =
+                            "MARRIED_TO";
+
+                        private static string WORKS_FOR =
+                            "WORKS_FOR";
+
+                        // IRelationships
+                        public static IRelationship AliceKnowsBob =
+                            new Relationship(12L, TestNodes.Alice.Id,
+                                TestNodes.Bob.Id, KNOWS,
+                                new Dictionary<string, object> { { "since", 1999L } });
 
                         public static IRelationship AliceLikesCarol =
                             new Relationship(13L, TestNodes.Alice.Id,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IChunkedInputStream.cs
@@ -14,10 +14,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.Threading.Tasks;
+
 namespace Neo4j.Driver.Internal.Connector
 {
     internal interface IChunkedInputStream : IInputStream
     {
         void ReadMessageTail();
+        Task ReadMessageTailAsync();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IInputStream.cs
@@ -14,6 +14,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.Threading.Tasks;
+
 namespace Neo4j.Driver.Internal.Connector
 {
     internal interface IInputStream
@@ -26,5 +29,13 @@ namespace Neo4j.Driver.Internal.Connector
         byte PeekByte();
         long ReadLong();
         double ReadDouble();
+        Task<sbyte> ReadSByteAsync();
+        Task<byte> ReadByteAsync();
+        Task<short> ReadShortAsync();
+        Task<int> ReadIntAsync();
+        Task ReadBytesAsync(byte[] buffer, int size = 0, int? length = null);
+        Task<byte> PeekByteAsync();
+        Task<long> ReadLongAsync();
+        Task<double> ReadDoubleAsync();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IOutputStream.cs
@@ -14,6 +14,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.Threading.Tasks;
+
 namespace Neo4j.Driver.Internal.Connector
 {
     internal interface IOutputStream
@@ -21,5 +24,6 @@ namespace Neo4j.Driver.Internal.Connector
         IOutputStream Write(byte b, params byte[] bytes);
         IOutputStream Write(byte[] bytes);
         IOutputStream Flush();
+        Task<IOutputStream> FlushAsync();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ITcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ITcpSocketClient.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.Internal.Connector
     {
         Stream ReadStream { get;  }
         Stream WriteStream { get;  }
-        Task DisconnectAsync();
-        Task ConnectAsync(Uri uri);
+        void Disconnect();
+        Task ConnectAsync(Uri uri, TimeSpan timeOut);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Packstream;
@@ -55,9 +56,14 @@ namespace Neo4j.Driver.Internal.Connector
             GC.SuppressFinalize(this);
         }
 
-        public async Task Start()
+        public Task Start()
         {
-            await _tcpSocketClient.ConnectAsync(_uri).ConfigureAwait(false);
+            return Start(Timeout.InfiniteTimeSpan);
+        }
+
+        public async Task Start(TimeSpan timeOut)
+        {
+            await _tcpSocketClient.ConnectAsync(_uri, timeOut).ConfigureAwait(false);
             IsOpen = true;
             _logger?.Debug($"~~ [CONNECT] {_uri}");
 
@@ -92,7 +98,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             if (IsOpen && _tcpSocketClient != null)
             {
-                await _tcpSocketClient.DisconnectAsync().ConfigureAwait(false);
+                _tcpSocketClient.Disconnect();
                 _tcpSocketClient.Dispose();
             }
             IsOpen = false;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PackStream/PackStreamMessageFormatV1.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.V1;
@@ -114,10 +115,41 @@ namespace Neo4j.Driver.Internal.Packstream
                 UnPackMessageTail();
             }
 
+            public async Task ReadAsync(IMessageResponseHandler responseHandler)
+            {
+                await _unpacker.UnpackStructHeaderAsync().ConfigureAwait(false);
+                var type = await _unpacker.UnpackStructSignatureAsync().ConfigureAwait(false);
+
+                switch (type)
+                {
+                    case MSG_RECORD:
+                        await UnpackRecordMessageAsync(responseHandler).ConfigureAwait(false);
+                        break;
+                    case MSG_SUCCESS:
+                        await UnpackSuccessMessageAsync(responseHandler).ConfigureAwait(false);
+                        break;
+                    case MSG_FAILURE:
+                        await UnpackFailureMessageAsync(responseHandler).ConfigureAwait(false);
+                        break;
+                    case MSG_IGNORED:
+                        UnpackIgnoredMessage(responseHandler);
+                        break;
+                    default:
+                        throw new ProtocolException("Unknown requestMessage type: " + type);
+                }
+                await UnPackMessageTailAsync().ConfigureAwait(false);
+            }
+
             public object UnpackValue()
             {
                 var type = _unpacker.PeekNextType();
                 return UnpackValue(type);
+            }
+
+            public async Task<object> UnpackValueAsync()
+            {
+                var type = await _unpacker.PeekNextTypeAsync().ConfigureAwait(false);
+                return await UnpackValueAsync(type).ConfigureAwait(false);
             }
 
             public virtual object UnpackValue(PackStream.PackType type)
@@ -155,6 +187,46 @@ namespace Neo4j.Driver.Internal.Packstream
                                 Throw.ProtocolException.IfNotEqual(PathFields, size, nameof(PathFields), nameof(size));
                                 return UnpackPath();
                         }
+                        break;
+                }
+                throw new ArgumentOutOfRangeException(nameof(type), type, $"Unknown value type: {type}");
+            }
+
+            public virtual async Task<object> UnpackValueAsync(PackStream.PackType type)
+            {
+                switch (type)
+                {
+                    case PackStream.PackType.Bytes:
+                        return await _unpacker.UnpackBytesAsync().ConfigureAwait(false);
+                    case PackStream.PackType.Null:
+                        return await _unpacker.UnpackNullAsync().ConfigureAwait(false);
+                    case PackStream.PackType.Boolean:
+                        return await _unpacker.UnpackBooleanAsync().ConfigureAwait(false);
+                    case PackStream.PackType.Integer:
+                        return await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+                    case PackStream.PackType.Float:
+                        return await _unpacker.UnpackDoubleAsync().ConfigureAwait(false);
+                    case PackStream.PackType.String:
+                        return await _unpacker.UnpackStringAsync().ConfigureAwait(false);
+                    case PackStream.PackType.Map:
+                        return await UnpackMapAsync().ConfigureAwait(false);
+                    case PackStream.PackType.List:
+                        return await UnpackListAsync().ConfigureAwait(false);
+                    case PackStream.PackType.Struct:
+                        long size = await _unpacker.UnpackStructHeaderAsync().ConfigureAwait(false);
+                        switch (await _unpacker.UnpackStructSignatureAsync().ConfigureAwait(false))
+                        {
+                            case NODE:
+                                Throw.ProtocolException.IfNotEqual(NodeFields, size, nameof(NodeFields), nameof(size));
+                                return await UnpackNodeAsync().ConfigureAwait(false); ;
+                            case RELATIONSHIP:
+                                Throw.ProtocolException.IfNotEqual(RelationshipFields, size, nameof(RelationshipFields),
+                                    nameof(size));
+                                return await UnpackRelationshipAsync().ConfigureAwait(false);
+                    case PATH:
+                                Throw.ProtocolException.IfNotEqual(PathFields, size, nameof(PathFields), nameof(size));
+                                return await UnpackPathAsync().ConfigureAwait(false);
+                }
                         break;
                 }
                 throw new ArgumentOutOfRangeException(nameof(type), type, $"Unknown value type: {type}");
@@ -223,6 +295,69 @@ namespace Neo4j.Driver.Internal.Packstream
                 return new Path(segments.ToList(), nodes.ToList(), rels.ToList());
             }
 
+            private async Task<IPath> UnpackPathAsync()
+            {
+                // List of unique nodes
+                var uniqNodes = new INode[(int)await _unpacker.UnpackListHeaderAsync().ConfigureAwait(false)];
+                for (int i = 0; i < uniqNodes.Length; i++)
+                {
+                    Throw.ProtocolException.IfNotEqual(NodeFields, await _unpacker.UnpackStructHeaderAsync().ConfigureAwait(false), nameof(NodeFields),
+                        $"received{nameof(NodeFields)}");
+                    Throw.ProtocolException.IfNotEqual(NODE, await _unpacker.UnpackStructSignatureAsync().ConfigureAwait(false), nameof(NODE),
+                        $"received{nameof(NODE)}");
+                    uniqNodes[i] = await UnpackNodeAsync().ConfigureAwait(false);
+                }
+
+                // List of unique relationships, without start/end information
+                var uniqRels = new Relationship[(int)await _unpacker.UnpackListHeaderAsync().ConfigureAwait(false)];
+                for (int i = 0; i < uniqRels.Length; i++)
+                {
+                    Throw.ProtocolException.IfNotEqual(UnboundRelationshipFields, await _unpacker.UnpackStructHeaderAsync().ConfigureAwait(false),
+                        nameof(UnboundRelationshipFields), $"received{nameof(UnboundRelationshipFields)}");
+                    Throw.ProtocolException.IfNotEqual(UNBOUND_RELATIONSHIP, await _unpacker.UnpackStructSignatureAsync().ConfigureAwait(false),
+                        nameof(UNBOUND_RELATIONSHIP), $"received{nameof(UNBOUND_RELATIONSHIP)}");
+                    var urn = await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+                    var relType = await _unpacker.UnpackStringAsync().ConfigureAwait(false);
+                    var props = await UnpackMapAsync().ConfigureAwait(false);
+                    uniqRels[i] = new Relationship(urn, -1, -1, relType, props);
+                }
+
+                // Path sequence
+                var length = (int)await _unpacker.UnpackListHeaderAsync().ConfigureAwait(false);
+
+                // Knowing the sequence length, we can create the arrays that will represent the nodes, rels and segments in their "path order"
+                var segments = new ISegment[length / 2];
+                var nodes = new INode[segments.Length + 1];
+                var rels = new IRelationship[segments.Length];
+
+                var prevNode = uniqNodes[0];
+                INode nextNode; // Start node is always 0, and isn't encoded in the sequence
+                Relationship rel;
+                nodes[0] = prevNode;
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    int relIdx = (int)await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+                    nextNode = uniqNodes[(int)await _unpacker.UnpackLongAsync().ConfigureAwait(false)];
+                    // Negative rel index means this rel was traversed "inversed" from its direction
+                    if (relIdx < 0)
+                    {
+                        rel = uniqRels[(-relIdx) - 1]; // -1 because rel idx are 1-indexed
+                        rel.SetStartAndEnd(nextNode.Id, prevNode.Id);
+                    }
+                    else
+                    {
+                        rel = uniqRels[relIdx - 1];
+                        rel.SetStartAndEnd(prevNode.Id, nextNode.Id);
+                    }
+
+                    nodes[i + 1] = nextNode;
+                    rels[i] = rel;
+                    segments[i] = new Segment(prevNode, rel, nextNode);
+                    prevNode = nextNode;
+                }
+                return new Path(segments.ToList(), nodes.ToList(), rels.ToList());
+            }
+
             private IRelationship UnpackRelationship()
             {
                 var urn = _unpacker.UnpackLong();
@@ -230,6 +365,17 @@ namespace Neo4j.Driver.Internal.Packstream
                 var endUrn = _unpacker.UnpackLong();
                 var relType = _unpacker.UnpackString();
                 var props = UnpackMap();
+
+                return new Relationship(urn, startUrn, endUrn, relType, props);
+            }
+
+            private async Task<IRelationship> UnpackRelationshipAsync()
+            {
+                var urn = await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+                var startUrn = await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+                var endUrn = await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+                var relType = await _unpacker.UnpackStringAsync().ConfigureAwait(false);
+                var props = await UnpackMapAsync().ConfigureAwait(false);
 
                 return new Relationship(urn, startUrn, endUrn, relType, props);
             }
@@ -255,15 +401,43 @@ namespace Neo4j.Driver.Internal.Packstream
                 return new Node(urn, labels, props);
             }
 
+            private async Task<INode> UnpackNodeAsync()
+            {
+                var urn = await _unpacker.UnpackLongAsync().ConfigureAwait(false);
+
+                var numLabels = (int) await _unpacker.UnpackListHeaderAsync().ConfigureAwait(false);
+                var labels = new List<string>(numLabels);
+                for (var i = 0; i < numLabels; i++)
+                {
+                    labels.Add(await _unpacker.UnpackStringAsync().ConfigureAwait(false));
+                }
+                var numProps = (int)await _unpacker.UnpackMapHeaderAsync().ConfigureAwait(false);
+                var props = new Dictionary<string, object>(numProps);
+                for (var j = 0; j < numProps; j++)
+                {
+                    var key = await _unpacker.UnpackStringAsync().ConfigureAwait(false);
+                    props.Add(key, await UnpackValueAsync().ConfigureAwait(false));
+                }
+
+                return new Node(urn, labels, props);
+            }
+
             private void UnpackIgnoredMessage(IMessageResponseHandler responseHandler)
             {
                 responseHandler.HandleIgnoredMessage();
             }
 
-
             private void UnpackFailureMessage(IMessageResponseHandler responseHandler)
             {
                 var values = UnpackMap();
+                var code = values["code"]?.ToString();
+                var message = values["message"]?.ToString();
+                responseHandler.HandleFailureMessage(code, message);
+            }
+
+            private async Task UnpackFailureMessageAsync(IMessageResponseHandler responseHandler)
+            {
+                var values = await UnpackMapAsync().ConfigureAwait(false);
                 var code = values["code"]?.ToString();
                 var message = values["message"]?.ToString();
                 responseHandler.HandleFailureMessage(code, message);
@@ -280,14 +454,37 @@ namespace Neo4j.Driver.Internal.Packstream
                 responseHandler.HandleRecordMessage(fields);
             }
 
+            private async Task UnpackRecordMessageAsync(IMessageResponseHandler responseHandler)
+            {
+                var fieldCount = (int) await _unpacker.UnpackListHeaderAsync().ConfigureAwait(false);
+                var fields = new object[fieldCount];
+                for (var i = 0; i < fieldCount; i++)
+                {
+                    fields[i] = await UnpackValueAsync().ConfigureAwait(false);
+                }
+                responseHandler.HandleRecordMessage(fields);
+            }
+
+
             private void UnPackMessageTail()
             {
                 _inputStream.ReadMessageTail();
             }
 
+            private Task UnPackMessageTailAsync()
+            {
+                return _inputStream.ReadMessageTailAsync();
+            }
+
             private void UnpackSuccessMessage(IMessageResponseHandler responseHandler)
             {
                 var map = UnpackMap();
+                responseHandler.HandleSuccessMessage(map);
+            }
+
+            private async Task UnpackSuccessMessageAsync(IMessageResponseHandler responseHandler)
+            {
+                var map = await UnpackMapAsync().ConfigureAwait(false);
                 responseHandler.HandleSuccessMessage(map);
             }
 
@@ -307,6 +504,22 @@ namespace Neo4j.Driver.Internal.Packstream
                 return map;
             }
 
+            private async Task<Dictionary<string, object>> UnpackMapAsync()
+            {
+                var size = (int) await _unpacker.UnpackMapHeaderAsync().ConfigureAwait(false);
+                if (size == 0)
+                {
+                    return EmptyStringValueMap;
+                }
+                var map = new Dictionary<string, object>(size);
+                for (var i = 0; i < size; i++)
+                {
+                    var key = await _unpacker.UnpackStringAsync().ConfigureAwait(false);
+                    map.Add(key, await UnpackValueAsync().ConfigureAwait(false));
+                }
+                return map;
+            }
+
             private IList<object> UnpackList()
             {
                 var size = (int) _unpacker.UnpackListHeader();
@@ -317,6 +530,18 @@ namespace Neo4j.Driver.Internal.Packstream
                 }
                 return new List<object>(vals);
             }
+
+            private async Task<IList<object>> UnpackListAsync()
+            {
+                var size = (int) await _unpacker.UnpackListHeaderAsync().ConfigureAwait(false);
+                var vals = new object[size];
+                for (var j = 0; j < size; j++)
+                {
+                    vals[j] = await UnpackValueAsync().ConfigureAwait(false);
+                }
+                return new List<object>(vals);
+            }
+
         }
 
         public class WriterV1 : IWriter, IMessageRequestHandler
@@ -379,6 +604,11 @@ namespace Neo4j.Driver.Internal.Packstream
             public void Flush()
             {
                 _outputStream.Flush();
+            }
+
+            public Task FlushAsync()
+            {
+                return _outputStream.FlushAsync();
             }
 
             private void PackMessageTail()


### PR DESCRIPTION
TcpSocketClient/SocketClient changes for async api

1. Changed ITcpSocketClient#DisconnectAsync to ITcpSocketClient#Disconnect since no async stuff inside.
2. Added timeOut parameter to ITcpSocketClient#ConnectAsync to better handle time outs across connection retries.
3. Modified TcpSocketClient / SocketClient and affected tests to honour these changes.