### PR TITLE
Restore the empty parameter back

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
@@ -57,7 +57,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var discoveryManager = new ClusterDiscoveryManager(mock.Object, null, null);
                 // Then
                 discoveryManager.DiscoveryProcedure.Text.Should().Be("CALL dbms.cluster.routing.getServers");
-                discoveryManager.DiscoveryProcedure.Parameters.Should().BeNull();
+                discoveryManager.DiscoveryProcedure.Parameters.Should().BeEmpty();
             }
 
             [Theory]
@@ -368,7 +368,7 @@ namespace Neo4j.Driver.Tests.Routing
             var pairs = new List<Tuple<IRequestMessage, IResponseMessage>>
             {
                 MessagePair(InitMessage(), SuccessMessage()),
-                MessagePair(new RunMessage("CALL dbms.cluster.routing.getServers"),
+                MessagePair(new RunMessage("CALL dbms.cluster.routing.getServers", new Dictionary<string, object>()),
                     SuccessMessage(new List<object> {"ttl", "servers"}))
             };
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -50,7 +50,7 @@ namespace Neo4j.Driver.Tests
                 var session = NewSession(mockConn.Object);
                 session.Run("lalalal");
 
-                mockConn.Verify(x => x.Run("lalalal", null, It.IsAny<ResultBuilder>(), true), Times.Once);
+                mockConn.Verify(x => x.Run("lalalal", new Dictionary<string, object>(), It.IsAny<ResultBuilder>(), true), Times.Once);
                 mockConn.Verify(x => x.Send());
             }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/StatementRunnerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/StatementRunnerTests.cs
@@ -56,7 +56,7 @@ namespace Neo4j.Driver.Tests
                 var stRunner = new MyStatementRunner();
                 stRunner.Run(new Statement("lalalala"));
                 stRunner.Statement.Should().Be("lalalala");
-                stRunner.Parameters.Should().BeNull();
+                stRunner.Parameters.Should().BeEmpty();
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -74,7 +74,7 @@ namespace Neo4j.Driver.Tests
 
                 tx.Run("lalala");
 
-                mockConn.Verify(x => x.Run("lalala", null, It.IsAny<ResultBuilder>(), true), Times.Once);
+                mockConn.Verify(x => x.Run("lalala", new Dictionary<string, object>(), It.IsAny<ResultBuilder>(), true), Times.Once);
                 mockConn.Verify(x => x.Send(), Times.Once);
             }
 
@@ -86,7 +86,7 @@ namespace Neo4j.Driver.Tests
 
                 try
                 {
-                    mockConn.Setup(x => x.Run(It.IsAny<string>(), null, It.IsAny<ResultBuilder>(), true))
+                    mockConn.Setup(x => x.Run(It.IsAny<string>(), new Dictionary<string, object>(), It.IsAny<ResultBuilder>(), true))
                         .Throws<Neo4jException>();
                     tx.Run("lalala");
                 }
@@ -105,7 +105,7 @@ namespace Neo4j.Driver.Tests
                 var mockConn = new Mock<IConnection>();
                 var tx = new Transaction(mockConn.Object);
                    
-                mockConn.Setup(x => x.Run(It.IsAny<string>(), null, It.IsAny<ResultBuilder>(), true))
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), new Dictionary<string, object>(), It.IsAny<ResultBuilder>(), true))
                         .Throws<Neo4jException>();
 
                 var error = Xunit.Record.Exception(() => tx.Run("ttt"));

--- a/Neo4j.Driver/Neo4j.Driver/V1/Statement.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Statement.cs
@@ -24,6 +24,13 @@ namespace Neo4j.Driver.V1
     /// </summary>
     public class Statement
     {
+        private static IDictionary<string, object> NoParameter { get; }
+
+        static Statement()
+        {
+            NoParameter = new Dictionary<string, object>();
+        }
+         
         /// <summary>
         /// Gets the statement's text.
         /// </summary>
@@ -41,12 +48,12 @@ namespace Neo4j.Driver.V1
         public Statement(string text, IDictionary<string, object> parameters = null)
         {
             Text = text;
-            Parameters = parameters;
+            Parameters = parameters ?? NoParameter;
         }
 
         public override string ToString()
         {
-            return $"`{Text}`, {Parameters.ValueToString()}";
+            return $"`{Text}`, {Parameters.ToContentString()}";
         }
     }
 


### PR DESCRIPTION
Fix the tck failure due to the change to remove empty default parameters in statement.

