### PR TITLE
Async methods in ConnectionPool

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/StandAlone.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/StandAlone.cs
@@ -53,9 +53,9 @@ namespace Neo4j.Driver.IntegrationTests.Internals
         private void NewBoltDriver()
         {
             var config = Config.DefaultConfig;
-#if DEBUG
+//#if DEBUG
             config = Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Debug}).ToConfig();
-#endif
+//#endif
             Driver = GraphDatabase.Driver(BoltUri, AuthToken, config);
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -91,7 +91,7 @@ namespace Neo4j.Driver.Tests
 
                 foreach (var conn in conns)
                 {
-                    conn.Dispose();
+                    conn.Close();
                     pool.NumberOfAvailableConnections.Should().BeLessOrEqualTo(2);
                 }
 
@@ -108,7 +108,7 @@ namespace Neo4j.Driver.Tests
                 {
                     var conn = pool.Acquire();
                     pool.NumberOfAvailableConnections.Should().Be(0);
-                    conn.Dispose();
+                    conn.Close();
                     pool.NumberOfAvailableConnections.Should().Be(1);
                 }
 
@@ -134,7 +134,7 @@ namespace Neo4j.Driver.Tests
                 var pool = new ConnectionPool(mockedConnection.Object);
 
                 Record.Exception(()=>pool.Acquire());
-                mockedConnection.Verify(x=>x.Close(), Times.Once);
+                mockedConnection.Verify(x=>x.Destroy(), Times.Once);
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(0);
             }
@@ -159,7 +159,7 @@ namespace Neo4j.Driver.Tests
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(1);
                 closedMock.Verify(x => x.IsOpen, Times.Once);
-                closedMock.Verify(x => x.Close(), Times.Once);
+                closedMock.Verify(x => x.Destroy(), Times.Once);
 
                 conn.Should().NotBeNull();
                 conn.Id.Should().NotBe(closedId);
@@ -206,8 +206,8 @@ namespace Neo4j.Driver.Tests
 
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(1);
-                unhealthyMock.Verify(x => x.Close(), Times.Once);
-                healthyMock.Verify(x => x.Close(), Times.Never);
+                unhealthyMock.Verify(x => x.Destroy(), Times.Once);
+                healthyMock.Verify(x => x.Destroy(), Times.Never);
                 conn.Should().Be(healthyMock.Object);
             }
 
@@ -238,7 +238,7 @@ namespace Neo4j.Driver.Tests
                 // Then
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(1);
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
 
                 conn.Should().NotBeNull();
                 conn.Id.Should().NotBe(idleTooLongId);
@@ -383,7 +383,7 @@ namespace Neo4j.Driver.Tests
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(0);
                 healthyMock.Verify(x => x.IsOpen, Times.Once);
-                healthyMock.Verify(x => x.Close(), Times.Once);
+                healthyMock.Verify(x => x.Destroy(), Times.Once);
                 exception.Should().BeOfType<ObjectDisposedException>();
                 exception.Message.Should().StartWith("Failed to acquire a new connection");
             }
@@ -427,7 +427,7 @@ namespace Neo4j.Driver.Tests
 
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(0);
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
             }
 
             [Fact]
@@ -448,7 +448,7 @@ namespace Neo4j.Driver.Tests
 
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(0);
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
             }
 
             [Fact]
@@ -476,7 +476,7 @@ namespace Neo4j.Driver.Tests
 
                 pool.NumberOfAvailableConnections.Should().Be(10);
                 pool.NumberOfInUseConnections.Should().Be(0);
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
             }
 
             [Fact]
@@ -561,7 +561,7 @@ namespace Neo4j.Driver.Tests
                 // Then
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(0);
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
             }
         }
 
@@ -630,7 +630,7 @@ namespace Neo4j.Driver.Tests
                 pool.Release(mock.Object);
 
                 // Then
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
             }
 
             [Fact]
@@ -647,7 +647,7 @@ namespace Neo4j.Driver.Tests
                 pool.Dispose();
 
                 // Then
-                mock.Verify(x => x.Close(), Times.Once);
+                mock.Verify(x => x.Destroy(), Times.Once);
                 pool.NumberOfAvailableConnections.Should().Be(0);
                 pool.NumberOfInUseConnections.Should().Be(0);
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -43,7 +43,7 @@ namespace Neo4j.Driver.Tests
                 using (var harness = new SocketClientTestHarness(FakeUri))
                 {
                     harness.SetupReadStream(new byte[] {0, 0, 0, 1});
-                    await harness.Client.Start();
+                    await harness.Client.StartAsync();
                     harness.MockTcpSocketClient.Verify(t => t.ConnectAsync(FakeUri, Timeout.InfiniteTimeSpan),
                         Times.Once);
                 }
@@ -58,7 +58,7 @@ namespace Neo4j.Driver.Tests
                 using (var harness = new SocketClientTestHarness(FakeUri))
                 {
                     harness.SetupReadStream(response);
-                    await harness.ExpectException<NotSupportedException>(() => harness.Client.Start(), errorMessage);
+                    await harness.ExpectException<NotSupportedException>(() => harness.Client.StartAsync(), errorMessage);
                 }
             }
         }
@@ -94,7 +94,7 @@ namespace Neo4j.Driver.Tests
                                             "00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75 6d 00 00");
                     harness.SetupWriteStream();
 
-                    await harness.Client.Start();
+                    await harness.Client.StartAsync();
                     harness.ResetCalls();
 
                     // When
@@ -124,7 +124,7 @@ namespace Neo4j.Driver.Tests
 
                     harness.SetupWriteStream();
 
-                    await harness.Client.Start();
+                    await harness.Client.StartAsync();
                     harness.ResetCalls();
 
                     // When
@@ -165,7 +165,7 @@ namespace Neo4j.Driver.Tests
 
                     harness.SetupWriteStream();
 
-                    await harness.Client.Start();
+                    await harness.Client.StartAsync();
                     harness.ResetCalls();
 
                     // When
@@ -203,7 +203,7 @@ namespace Neo4j.Driver.Tests
 
                     harness.SetupWriteStream();
 
-                    await harness.Client.Start();
+                    await harness.Client.StartAsync();
 
                     // force to recive an error
                     messageHandler.Error = new ProtocolException("Neo.ClientError.Request.Invalid", "Test Message");
@@ -213,7 +213,6 @@ namespace Neo4j.Driver.Tests
                     var ex = Record.Exception(() => harness.Client.Receive(messageHandler));
                     ex.Should().BeOfType<ProtocolException>();
 
-                    harness.MockTcpSocketClient.Verify(x => x.Disconnect(), Times.Once);
                     harness.MockTcpSocketClient.Verify(x => x.Dispose(), Times.Once);
                 }
             }
@@ -286,9 +285,8 @@ namespace Neo4j.Driver.Tests
                 using (var harness = new SocketClientTestHarness(FakeUri))
                 {
                     harness.SetupReadStream("00 00 00 01");
-                    await harness.Client.Start();
+                    await harness.Client.StartAsync();
                     harness.Client.Dispose();
-                    harness.MockTcpSocketClient.Verify(s => s.Disconnect(), Times.Once);
                     harness.MockTcpSocketClient.Verify(s => s.Dispose(), Times.Once);
                     harness.Client.IsOpen.Should().BeFalse();
                 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -86,7 +86,7 @@ namespace Neo4j.Driver.Tests
                 conn.Init();
 
                 // Then
-                mockClient.Verify(c => c.Start(It.IsAny<TimeSpan>()), Times.Once);
+                mockClient.Verify(c => c.StartAsync(It.IsAny<TimeSpan>()), Times.Once);
             }
 
             [Fact]
@@ -113,7 +113,7 @@ namespace Neo4j.Driver.Tests
             {
                 // Given
                 var mockClient = new Mock<ISocketClient>();
-                mockClient.Setup(x => x.Start(It.IsAny<TimeSpan>())).Returns(Task.Delay(TimeSpan.FromMinutes(1)));
+                mockClient.Setup(x => x.StartAsync(It.IsAny<TimeSpan>())).Returns(Task.Delay(TimeSpan.FromMinutes(1)));
                 // ReSharper disable once ObjectCreationAsStatement
                 var conn = new SocketConnection(mockClient.Object, AuthToken, TimeSpan.FromSeconds(1), UserAgent, Logger, Server);
                 // When
@@ -132,7 +132,7 @@ namespace Neo4j.Driver.Tests
                 var mock = new Mock<ISocketClient>();
                 var con = NewSocketConnection(mock.Object);
 
-                con.Dispose();
+                con.Destroy();
                 mock.Verify(c => c.Dispose(), Times.Once);
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/PackStream/PackStreamMessageFormatV1Tests.cs
@@ -341,7 +341,7 @@ namespace Neo4j.Driver.Tests
 
                 var writer =
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
-                writer.Write(new InitMessage("a", new Dictionary<string, object>()));
+                await writer.WriteAsync(new InitMessage("a", new Dictionary<string, object>()));
                 await writer.FlushAsync();
 
                 mocks.VerifyWrite(new byte[] { 0x00, 0x05, 0xB1, 0x01, 0x81, 0x61, 0xA0, 0x00, 0x00 });
@@ -354,7 +354,7 @@ namespace Neo4j.Driver.Tests
 
                 var writer =
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
-                writer.Write(new RunMessage("RETURN 1 AS num"));
+                await writer.WriteAsync(new RunMessage("RETURN 1 AS num"));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(
                     "00 13 b2 10  8f 52 45 54  55 52 4e 20  31 20 41 53 20 6e 75 6d  a0 00 00".ToByteArray());
@@ -388,7 +388,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "integer", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -404,7 +404,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -421,7 +421,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -438,7 +438,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -458,7 +458,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -474,7 +474,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -490,7 +490,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -506,7 +506,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -523,7 +523,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }
@@ -540,7 +540,7 @@ namespace Neo4j.Driver.Tests
                     new PackStreamMessageFormatV1(mocks.TcpSocketClient, null).Writer;
                 var values = new Dictionary<string, object> { { "value", value } };
 
-                writer.Write(new RunMessage("", values));
+                await writer.WriteAsync(new RunMessage("", values));
                 await writer.FlushAsync();
                 mocks.VerifyWrite(expectedBytes.ToByteArray());
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
@@ -370,7 +370,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var mockedClusterPool = new Mock<IClusterConnectionPool>();
                     var balancer = new LoadBalancer(mockedClusterPool.Object, routingTable);
 
-                    var mockedConn = new Mock<IPooledConnection>();
+                    var mockedConn = new Mock<IConnection>();
                     var conn = mockedConn.Object;
                     mockedClusterPool.Setup(x => x.TryAcquire(uri, out conn)).Callback(() =>
                     {
@@ -451,7 +451,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var routingTableMock = CreateRoutingTable(mode, uri);
 
                     var clusterConnPoolMock = new Mock<IClusterConnectionPool>();
-                    IPooledConnection conn = null;
+                    IConnection conn = null;
                     clusterConnPoolMock.Setup(x => x.TryAcquire(uri, out conn))
                         .Callback(() =>
                         {
@@ -482,7 +482,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var routingTableMock = CreateRoutingTable(mode, uri);
 
                     var clusterConnPoolMock = new Mock<IClusterConnectionPool>();
-                    IPooledConnection conn = null;
+                    IConnection conn = null;
                     clusterConnPoolMock.Setup(x => x.TryAcquire(uri, out conn))
                         .Callback(() =>
                         {
@@ -513,7 +513,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var routingTableMock = CreateRoutingTable(mode, uri);
 
                     var clusterConnPoolMock = new Mock<IClusterConnectionPool>();
-                    IPooledConnection conn = null;
+                    IConnection conn = null;
                     clusterConnPoolMock.Setup(x => x.TryAcquire(uri, out conn)).Returns(false)
                         .Callback(() =>
                         {
@@ -688,7 +688,7 @@ namespace Neo4j.Driver.Tests.Routing
 
             foreach (var uri in uris)
             {
-                var mockedConn = new Mock<IPooledConnection>();
+                var mockedConn = new Mock<IConnection>();
                 mockedConn.Setup(x => x.Server.Address).Returns(uri.ToString);
                 var conn = mockedConn.Object;
                 mockedClusterPool.Setup(x => x.TryAcquire(uri, out conn)).Returns(true);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Neo4j.Driver.Internal;
@@ -154,7 +155,7 @@ namespace Neo4j.Driver.Tests
                 session.Run("lalal");
 
                 session.Run("bibib");
-                mockConn.Verify(c=>c.Dispose(), Times.Once);
+                mockConn.Verify(c=>c.Close(), Times.Once);
             }
 
             [Fact]
@@ -166,7 +167,7 @@ namespace Neo4j.Driver.Tests
                 session.Run("lala");
 
                 session.BeginTransaction();
-                mockConn.Verify(c=>c.Dispose(), Times.Once);
+                mockConn.Verify(c=>c.Close(), Times.Once);
             }
 
             [Fact]
@@ -184,7 +185,7 @@ namespace Neo4j.Driver.Tests
                 session.Run("lala");
 
                 // Then
-                mockConn.Verify(x => x.Dispose(), Times.Once);
+                mockConn.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
@@ -211,7 +212,7 @@ namespace Neo4j.Driver.Tests
                 session.BeginTransaction();
 
                 // Then
-                mockConn.Verify(x => x.Dispose(), Times.Once);
+                mockConn.Verify(x => x.Close(), Times.Once);
             }
         }
 
@@ -228,7 +229,7 @@ namespace Neo4j.Driver.Tests
                 Record.Exception(()=>session.BeginTransaction()).Should().BeOfType<IOException>();
                 session.Dispose();
 
-                mockConn.Verify(x => x.Dispose(), Times.Once);
+                mockConn.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
@@ -241,7 +242,7 @@ namespace Neo4j.Driver.Tests
                 session.Dispose();
 
                 mockConn.Verify(x => x.Run("ROLLBACK", null, null, false), Times.Once);
-                mockConn.Verify(x => x.Dispose(), Times.Once);
+                mockConn.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
@@ -254,7 +255,7 @@ namespace Neo4j.Driver.Tests
                 session.Dispose();
 
                 mockConn.Verify(x => x.Sync(), Times.Once);
-                mockConn.Verify(x => x.Dispose(), Times.Once);
+                mockConn.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
@@ -292,6 +293,11 @@ namespace Neo4j.Driver.Tests
             {
                 Mode = mode;
                 return Connection;
+            }
+
+            public Task<IConnection> AcquireAsync(AccessMode mode)
+            {
+                throw new NotSupportedException();
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ChunkedInputStream.cs
@@ -215,7 +215,7 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 return;
             }
-            var numberOfbytesRead = await _tcpSocketClient.ReadStream.ReadAsync(buffer, 0, buffer.Length);
+            var numberOfbytesRead = await _tcpSocketClient.ReadStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
             if (numberOfbytesRead != buffer.Length)
             {
                 throw new ProtocolException($"Expect {buffer.Length}, but got {numberOfbytesRead}");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
@@ -49,7 +49,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             try
             {
-                await Delegate.SyncAsync();
+                await Delegate.SyncAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -73,7 +73,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             try
             {
-                await Delegate.SendAsync();
+                await Delegate.SendAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -97,7 +97,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             try
             {
-                await Delegate.ReceiveOneAsync();
+                await Delegate.ReceiveOneAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -138,7 +138,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             try
             {
-                await Delegate.InitAsync();
+                await Delegate.InitAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
@@ -33,11 +33,6 @@ namespace Neo4j.Driver.Internal.Connector
 
         public abstract void OnError(Exception error);
 
-        public virtual void Dispose()
-        {
-            Delegate.Dispose();
-        }
-
         public void Sync()
         {
             try
@@ -122,7 +117,7 @@ namespace Neo4j.Driver.Internal.Connector
                 OnError(e);
             }
         }
-        
+
         public virtual bool IsOpen => Delegate.IsOpen;
 
         public IServerInfo Server => Delegate.Server;
@@ -175,10 +170,19 @@ namespace Neo4j.Driver.Internal.Connector
             }
         }
         
-        public void Close()
+        public void Destroy()
+        {
+            Delegate.Destroy();
+        }
+
+        public virtual void Close()
         {
             Delegate.Close();
         }
-        
+
+        public virtual Task CloseAsync()
+        {
+            return Delegate.CloseAsync();
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IChunkedOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IChunkedOutputStream.cs
@@ -14,10 +14,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.Threading.Tasks;
+
 namespace Neo4j.Driver.Internal.Connector
 {
     internal interface IChunkedOutputStream : IOutputStream
     {
         IOutputStream WriteMessageTail();
+        Task<IOutputStream> WriteMessageTailAsync();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -22,7 +22,7 @@ using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Connector
 {
-    internal interface IConnection : IDisposable
+    internal interface IConnection
     {
         void Init();
 
@@ -55,7 +55,14 @@ namespace Neo4j.Driver.Internal.Connector
         /// <summary>
         /// Close and release related resources
         /// </summary>
+        void Destroy();
+
+        /// <summary>
+        /// Close connection
+        /// </summary>
         void Close();
+
+        Task CloseAsync();
 
         /// <summary>
         /// Return true if the underlying socket connection is till open, otherwise false.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IOutputStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IOutputStream.cs
@@ -22,7 +22,9 @@ namespace Neo4j.Driver.Internal.Connector
     internal interface IOutputStream
     {
         IOutputStream Write(byte b, params byte[] bytes);
+        Task<IOutputStream> WriteAsync(byte b, params byte[] bytes);
         IOutputStream Write(byte[] bytes);
+        Task<IOutputStream> WriteAsync(byte[] bytes);
         IOutputStream Flush();
         Task<IOutputStream> FlushAsync();
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.Internal.Connector
 {
     internal interface ISocketClient : IDisposable
     {
-        Task Start(TimeSpan timeOut);
+        Task StartAsync(TimeSpan timeOut);
         void Send(IEnumerable<IRequestMessage> messages);
         Task SendAsync(IEnumerable<IRequestMessage> messages);
         void Receive(IMessageResponseHandler responseHandler);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ITcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ITcpSocketClient.cs
@@ -24,7 +24,6 @@ namespace Neo4j.Driver.Internal.Connector
     {
         Stream ReadStream { get;  }
         Stream WriteStream { get;  }
-        void Disconnect();
         Task ConnectAsync(Uri uri, TimeSpan timeOut);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -127,7 +127,7 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 foreach (var message in messages)
                 {
-                    _writer.Write(message);
+                    await _writer.WriteAsync(message).ConfigureAwait(false);
                     _logger?.Debug("C: ", message);
                 }
 
@@ -155,7 +155,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             while (responseHandler.UnhandledMessageSize > 0)
             {
-                await ReceiveOneAsync(responseHandler);
+                await ReceiveOneAsync(responseHandler).ConfigureAwait(false);
             }
         }
 
@@ -184,7 +184,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             try
             {
-                await _reader.ReadAsync(responseHandler);
+                await _reader.ReadAsync(responseHandler).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -56,12 +56,12 @@ namespace Neo4j.Driver.Internal.Connector
             GC.SuppressFinalize(this);
         }
 
-        public Task Start()
+        internal Task StartAsync()
         {
-            return Start(Timeout.InfiniteTimeSpan);
+            return StartAsync(Timeout.InfiniteTimeSpan);
         }
 
-        public async Task Start(TimeSpan timeOut)
+        public async Task StartAsync(TimeSpan timeOut)
         {
             await _tcpSocketClient.ConnectAsync(_uri, timeOut).ConfigureAwait(false);
             IsOpen = true;
@@ -93,13 +93,11 @@ namespace Neo4j.Driver.Internal.Connector
             _reader = formatV1.Reader;
         }
 
-
-        private async Task Stop()
+        private void Stop()
         {
-            if (IsOpen && _tcpSocketClient != null)
+            if (IsOpen)
             {
-                _tcpSocketClient.Disconnect();
-                _tcpSocketClient.Dispose();
+                _tcpSocketClient?.Dispose();
             }
             IsOpen = false;
         }
@@ -118,7 +116,7 @@ namespace Neo4j.Driver.Internal.Connector
             catch (Exception ex)
             {
                 _logger?.Info($"Unable to send message to server {_uri}, connection will be terminated. ", ex);
-                Task.Run(() => Stop()).Wait();
+                Stop();
                 throw;
             }
         }
@@ -138,7 +136,7 @@ namespace Neo4j.Driver.Internal.Connector
             catch (Exception ex)
             {
                 _logger?.Info($"Unable to send message to server {_uri}, connection will be terminated. ", ex);
-                Task.Run(() => Stop()).Wait();
+                Stop();
                 throw;
             }
         }
@@ -171,13 +169,13 @@ namespace Neo4j.Driver.Internal.Connector
             catch (Exception ex)
             {
                 _logger?.Info($"Unable to read message from server {_uri}, connection will be terminated.", ex);
-                Task.Run(() => Stop()).Wait();
+                Stop();
                 throw;
             }
             if (responseHandler.HasProtocolViolationError)
             {
                 _logger?.Info($"Received bolt protocol error from server {_uri}, connection will be terminated.", responseHandler.Error);
-                Task.Run(() => Stop()).Wait();
+                Stop();
                 throw responseHandler.Error;
             }
         }
@@ -191,13 +189,13 @@ namespace Neo4j.Driver.Internal.Connector
             catch (Exception ex)
             {
                 _logger?.Info($"Unable to read message from server {_uri}, connection will be terminated.", ex);
-                Task.Run(() => Stop()).Wait();
+                Stop();
                 throw;
             }
             if (responseHandler.HasProtocolViolationError)
             {
                 _logger?.Info($"Received bolt protocol error from server {_uri}, connection will be terminated.", responseHandler.Error);
-                Task.Run(() => Stop()).Wait();
+                Stop();
                 throw responseHandler.Error;
             }
         }
@@ -243,7 +241,7 @@ namespace Neo4j.Driver.Internal.Connector
             if (!isDisposing)
                 return;
 
-            Task.Run(() => Stop()).Wait();
+            Stop();
         }
 
         public void UpdatePackStream(string serverVersion)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -54,7 +54,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public async Task ConnectAsync(Uri uri, TimeSpan timeOut)
         {
-            await Connect(uri, timeOut);
+            await Connect(uri, timeOut).ConfigureAwait(false);
             if (!_encryptionManager.UseTls)
             {
                 _stream = _client.GetStream();
@@ -81,7 +81,7 @@ namespace Neo4j.Driver.Internal.Connector
         {
             using (CancellationTokenSource cancellationSource = new CancellationTokenSource(timeOut))
             {
-                var addresses = await uri.ResolveAsync(_ipv6Enabled);
+                var addresses = await uri.ResolveAsync(_ipv6Enabled).ConfigureAwait(false);
                 AggregateException innerErrors = null;
                 for (var i = 0; i < addresses.Length; i++)
                 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -52,11 +52,6 @@ namespace Neo4j.Driver.Internal.Connector
         public Stream ReadStream => _stream;
         public Stream WriteStream => _stream;
 
-        public void Disconnect()
-        {
-            Close();
-        }
-
         public async Task ConnectAsync(Uri uri, TimeSpan timeOut)
         {
             await Connect(uri, timeOut);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionProvider.cs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
 
@@ -23,5 +24,6 @@ namespace Neo4j.Driver.Internal
     internal interface IConnectionProvider : IDisposable
     {
         IConnection Acquire(AccessMode mode);
+        Task<IConnection> AcquireAsync(AccessMode mode);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/LoggerBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/LoggerBase.cs
@@ -59,7 +59,7 @@ namespace Neo4j.Driver.Internal
         {
             try
             {
-                await func();
+                await func().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -72,7 +72,7 @@ namespace Neo4j.Driver.Internal
         {
             try
             {
-                return await func();
+                return await func().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/AckFailureMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/AckFailureMessage.cs
@@ -29,6 +29,11 @@ namespace Neo4j.Driver.Internal.Messaging
             messageRequestHandler.HandleAckFailureMessage();
         }
 
+        public Task DispatchAsync(IMessageRequestHandler messageRequestHandler)
+        {
+            return messageRequestHandler.HandleAckFailureMessageAsync();
+        }
+
         public override string ToString()
         {
             return "ACK_FAILURE";

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/DiscardAllMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/DiscardAllMessage.cs
@@ -29,6 +29,11 @@ namespace Neo4j.Driver.Internal.Messaging
             messageRequestHandler.HandleDiscardAllMessage();
         }
 
+        public Task DispatchAsync(IMessageRequestHandler messageRequestHandler)
+        {
+            return messageRequestHandler.HandleDiscardAllMessageAsync();
+        }
+
         public override string ToString()
         {
             return "DISCARDALL";

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessage.cs
@@ -14,11 +14,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.Threading.Tasks;
+
 namespace Neo4j.Driver.Internal.Messaging
 {
     internal interface IRequestMessage :IMessage
     {
         void Dispatch(IMessageRequestHandler messageRequestHandler);
+        Task DispatchAsync(IMessageRequestHandler messageRequestHandler);
     }
 
     internal interface IResponseMessage : IMessage

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessageHandler.cs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Result;
 using Neo4j.Driver.V1;
 
@@ -23,11 +24,17 @@ namespace Neo4j.Driver.Internal.Messaging
     internal interface IMessageRequestHandler
     {
         void HandleInitMessage(string clientNameAndVersion, IDictionary<string, object> authToken);
+        Task HandleInitMessageAsync(string clientNameAndVersion, IDictionary<string, object> authToken);
         void HandleRunMessage(string statement, IDictionary<string, object> parameters);
+        Task HandleRunMessageAsync(string statement, IDictionary<string, object> parameters);
         void HandlePullAllMessage();
+        Task HandlePullAllMessageAsync();
         void HandleDiscardAllMessage();
+        Task HandleDiscardAllMessageAsync();
         void HandleResetMessage();
+        Task HandleResetMessageAsync();
         void HandleAckFailureMessage();
+        Task HandleAckFailureMessageAsync();
     }
 
     internal interface IMessageResponseHandler

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/InitMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/InitMessage.cs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
@@ -33,6 +34,11 @@ namespace Neo4j.Driver.Internal.Messaging
         public void Dispatch(IMessageRequestHandler messageRequestHandler)
         {
             messageRequestHandler.HandleInitMessage(ClientNameAndVersion, _authToken);
+        }
+
+        public Task DispatchAsync(IMessageRequestHandler messageRequestHandler)
+        {
+            return messageRequestHandler.HandleInitMessageAsync(ClientNameAndVersion, _authToken);
         }
 
         public override string ToString()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/PullAllMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/PullAllMessage.cs
@@ -29,6 +29,11 @@ namespace Neo4j.Driver.Internal.Messaging
             messageRequestHandler.HandlePullAllMessage();
         }
 
+        public Task DispatchAsync(IMessageRequestHandler messageRequestHandler)
+        {
+            return messageRequestHandler.HandlePullAllMessageAsync();
+        }
+
         public override string ToString()
         {
             return "PULLALL";

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/ResetMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/ResetMessage.cs
@@ -29,6 +29,11 @@ namespace Neo4j.Driver.Internal.Messaging
             messageRequestHandler.HandleResetMessage();
         }
 
+        public Task DispatchAsync(IMessageRequestHandler messageRequestHandler)
+        {
+            return messageRequestHandler.HandleResetMessageAsync();
+        }
+
         public override string ToString()
         {
             return "RESET";

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/RunMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/RunMessage.cs
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Messaging
 {
@@ -32,6 +33,11 @@ namespace Neo4j.Driver.Internal.Messaging
         public void Dispatch(IMessageRequestHandler messageRequestHandler)
         {
             messageRequestHandler.HandleRunMessage( _statement, _statementParameters );
+        }
+
+        public Task DispatchAsync(IMessageRequestHandler messageRequestHandler)
+        {
+            return messageRequestHandler.HandleRunMessageAsync(_statement, _statementParameters);
         }
 
         public override string ToString()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
 
@@ -117,7 +118,7 @@ namespace Neo4j.Driver.Internal.Routing
             }
             public void Dispose()
             {
-                _connection?.Dispose();
+                _connection?.Close();
             }
 
             public IConnection Acquire(AccessMode mode)
@@ -125,6 +126,11 @@ namespace Neo4j.Driver.Internal.Routing
                 var conn = _connection;
                 _connection = null;
                 return conn;
+            }
+
+            public Task<IConnection> AcquireAsync(AccessMode mode)
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -16,13 +16,14 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using Neo4j.Driver.Internal.Connector;
 
 namespace Neo4j.Driver.Internal.Routing
 {
     internal interface IClusterConnectionPool : IDisposable
     {
         // Try to acquire a connection with the server specified by the uri
-        bool TryAcquire(Uri uri, out IPooledConnection conn);
+        bool TryAcquire(Uri uri, out IConnection conn);
         // Add a set of uri to this pool
         void Add(IEnumerable<Uri> uris);
         // Update the pool keys with the new server uris

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
 using static Neo4j.Driver.Internal.Throw.DriverDisposedException;
@@ -92,6 +93,11 @@ namespace Neo4j.Driver.Internal.Routing
                 ThrowObjectDisposedException();
             }
             return conn;
+        }
+
+        public Task<IConnection> AcquireAsync(AccessMode mode)
+        {
+            throw new NotImplementedException();
         }
 
         public void OnConnectionError(Uri uri, Exception e)
@@ -302,7 +308,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 try
                 {
-                    IPooledConnection conn;
+                    IConnection conn;
                     if (_clusterConnectionPool.TryAcquire(uri, out conn))
                     {
                         return new ClusterConnection(conn, uri, mode, this);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -74,9 +74,9 @@ namespace Neo4j.Driver.Internal
         {
             return TryExecuteAsync(async () =>
             {
-                EnsureCanRunMoreStatements();
+                await EnsureCanRunMoreStatementsAsync().ConfigureAwait(false);
 
-                _connection = _connectionProvider.Acquire(_defaultMode);
+                _connection = await _connectionProvider.AcquireAsync(_defaultMode).ConfigureAwait(false);
                 var resultBuilder = new ResultReaderBuilder(statement.Text, statement.Parameters,
                     () => _connection.ReceiveOneAsync(), _connection.Server, this);
                 _connection.Run(statement.Text, statement.Parameters, resultBuilder);
@@ -183,6 +183,26 @@ namespace Neo4j.Driver.Internal
             base.Dispose(true);
         }
 
+        public Task CloseAsync()
+        {
+            return TryExecuteAsync(async() =>
+            {
+                if (_isOpen)
+                {
+                    // This will not protect the session being disposed concurrently
+                    // a.k.a. Session is not thread-safe!
+                    _isOpen = false;
+                }
+                else
+                {
+                    throw new ObjectDisposedException(GetType().Name, "Failed to dispose this seesion as it has already been disposed.");
+                }
+
+                await DisposeTransactionAsync().ConfigureAwait(false);
+                await DisposeSessionResultAsync().ConfigureAwait(false);
+            });
+        }
+
         /// <summary>
         ///  This method will be called back by <see cref="ResultBuilder"/> after it consumed result
         /// </summary>
@@ -239,6 +259,22 @@ namespace Neo4j.Driver.Internal
             }
         }
 
+        private async Task DisposeTransactionAsync()
+        {
+            // When there is a open transation, this method will aslo try to close the tx
+            if (_transaction != null)
+            {
+                try
+                {
+                    await _transaction.RollbackAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new ClientException($"Error when disposing unclosed transaction in session: {e.Message}", e);
+                }
+            }
+        }
+
         /// <summary>
         /// Clean any session.run result reference.
         /// If session.run result is not fully consumed, then pull full result into memory.
@@ -275,10 +311,51 @@ namespace Neo4j.Driver.Internal
             }
         }
 
+        private async Task DisposeSessionResultAsync()
+        {
+            if (_connection == null)
+            {
+                // there is no session result resources to dispose
+                return;
+            }
+
+            if (_connection.IsOpen)
+            {
+                try
+                {
+                    // this will enfore to buffer all unconsumed result
+                    await _connection.SyncAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new ClientException($"Error when pulling unconsumed session.run records into memory in session: {e.Message}", e);
+                }
+                finally
+                {
+                    // there is a possibility that when error happens e.g. ProtocolError, the resources are not closed.
+                    await DisposeConnectionAsync().ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await DisposeConnectionAsync().ConfigureAwait(false);
+            }
+        }
+
         private void DisposeConnection()
         {
             // always try to close connection used by the result too
             _connection?.Close();
+            _connection = null;
+        }
+
+        private async Task DisposeConnectionAsync()
+        {
+            // always try to close connection used by the result too
+            if (_connection != null)
+            {
+                await _connection.CloseAsync().ConfigureAwait(false);
+            }
             _connection = null;
         }
 
@@ -287,6 +364,13 @@ namespace Neo4j.Driver.Internal
             EnsureSessionIsOpen();
             EnsureNoOpenTransaction();
             DisposeSessionResult();
+        }
+
+        private Task EnsureCanRunMoreStatementsAsync()
+        {
+            EnsureSessionIsOpen();
+            EnsureNoOpenTransaction();
+            return DisposeSessionResultAsync();
         }
 
         private void EnsureNoOpenTransaction()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -189,7 +189,7 @@ namespace Neo4j.Driver.Internal
         public void OnResultComsumed()
         {
             Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
-            CleanRunResultResources();
+            DisposeConnection();
         }
 
         /// <summary>
@@ -203,9 +203,7 @@ namespace Neo4j.Driver.Internal
             UpdateBookmark(_transaction.Bookmark);
             _transaction = null;
 
-            // always dispose connection used by the transaction too
-            _connection.Dispose();
-            _connection = null;
+            DisposeConnection();
         }
 
         /// <summary>
@@ -268,19 +266,19 @@ namespace Neo4j.Driver.Internal
                 finally
                 {
                     // there is a possibility that when error happens e.g. ProtocolError, the resources are not closed.
-                    CleanRunResultResources();
+                    DisposeConnection();
                 }
             }
             else
             {
-                CleanRunResultResources();
+                DisposeConnection();
             }
         }
 
-        private void CleanRunResultResources()
+        private void DisposeConnection()
         {
             // always try to close connection used by the result too
-            _connection?.Dispose();
+            _connection?.Close();
             _connection = null;
         }
 
@@ -386,7 +384,5 @@ namespace Neo4j.Driver.Internal
         {
             return RunTransactionAsync(AccessMode.Write, work);
         }
-
-
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -111,7 +111,7 @@ namespace Neo4j.Driver.Internal
             }
             finally
             {
-                _connection.Dispose();
+                _connection.Close();
                 _resourceHandler?.OnTransactionDispose();
                 base.Dispose(true);
             }
@@ -221,11 +221,17 @@ namespace Neo4j.Driver.Internal
                 _transaction = transaction;
             }
 
-            public override void Dispose()
+            public override void Close()
             {
                 // no resouce will be closed as the resources passed in this class are managed outside this class
                 Delegate = null;
                 _transaction = null;
+            }
+
+            public override Task CloseAsync()
+            {
+                Close();
+                return Task.CompletedTask;
             }
 
             public override void OnError(Exception error)

--- a/Neo4j.Driver/Neo4j.Driver/V1/ISessionAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/ISessionAsync.cs
@@ -66,6 +66,13 @@ namespace Neo4j.Driver.V1
         /// <returns>A task representing the completion of the transactional write operation enclosing the given unit of work.</returns>
         Task WriteTransactionAsync(Func<ITransactionAsync, Task> work);
 
+        /// <summary>
+        /// Close all resources used in this Session. If any transaction is left open in this session without commit or rollback,
+        /// then this method will rollback the transaction.
+        /// </summary>
+        /// <returns>A task representing the completion of successfully closed the session.</returns>
+        Task CloseAsync();
+
     }
 
     /// <summary>


### PR DESCRIPTION
Removed ambiguous `IConnection.Dispose` method as it means differently for different `IConnection` implementation:

* `SocketConneciton` - Close network connection directly.
* PooledConnection - Reset connection and Release connection back to pool. Requires network send and receive.
* `TransactionConnection` - Release `Delegated` connection
* `ClusterConnection` - Perform `Delegated.Dispose()`

Instead `IConnection.Close` and `IConnection.CloseAsync()` are added as replacement to `IConnection.Dispose`
Renamed old`IConnection.Close` to `IConnection.Destroy` to better describe the only action in this method is to close/destroy resources only directly in this method.
Removed some unnecessary async method in `SocketClient` and `TcpClient`