### PR TITLE
Forget CC members on DatabaseUnavailable

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ErrorExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ErrorExtensions.cs
@@ -81,6 +81,11 @@ namespace Neo4j.Driver.Internal
                 error.GetBaseException() is IOException || error.GetBaseException() is SocketException;
         }
 
+        public static bool IsDatabaseUnavailableError(this Exception error)
+        {
+            return error.HasErrorCode("Neo.TransientError.General.DatabaseUnavailable");
+        }
+
         public static bool IsClusterError(this Exception error)
         {
             return IsClusterNotALeaderError(error)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnection.cs
@@ -43,6 +43,10 @@ namespace Neo4j.Driver.Internal.Routing
                 throw new SessionExpiredException(
                     $"Server at {_uri} is no longer available due to error: {error.Message}.", error);
             }
+            else if (error.IsDatabaseUnavailableError())
+            {
+                _errorHandler.OnConnectionError(_uri, error);
+            }
             else if (error.IsClusterError())
             {
                 switch (_mode)


### PR DESCRIPTION
This PR makes routing driver forget Causal Cluster members when they fail with `Neo.TransientError.General.DatabaseUnavailable` error code. It means database is either shutting down or doing store copy. Generally we should not hammer database in such state with new requests and give it some time to either recover (in case of store copy) or just stop using it.