### PR TITLE
Avoiding throw AggregateException

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/SessionIT.cs
@@ -42,7 +42,7 @@ namespace Neo4j.Driver.IntegrationTests
                 exception = Record.Exception(() => session.Run("RETURN 1"));
             }
             exception.Should().BeOfType<ServiceUnavailableException>();
-            exception.Message.Should().Be("Connection with the server breaks due to AggregateException: One or more errors occurred.");
+            exception.Message.Should().Contain("Connection with the server breaks due to IOException");
             exception.GetBaseException().Should().BeOfType<SocketException>();
             exception.GetBaseException().Message.Should().Contain("No connection could be made because the target machine actively refused it");
         }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/TransactionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/TransactionIT.cs
@@ -46,11 +46,12 @@ namespace Neo4j.Driver.IntegrationTests
                 }));
                 timer.Stop();
 
-                var error = e as AggregateException;
+                var error = e.InnerException as AggregateException;
                 var innerErrors = error.Flatten().InnerExceptions;
                 foreach (var innerError in innerErrors)
                 {
                     Output.WriteLine(innerError.Message);
+                    innerError.Should().BeOfType<SessionExpiredException>();
                 }
                 innerErrors.Count.Should().BeGreaterOrEqualTo(5);
                 timer.Elapsed.TotalSeconds.Should().BeGreaterOrEqualTo(30);

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/TransactionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/TransactionIT.cs
@@ -46,6 +46,7 @@ namespace Neo4j.Driver.IntegrationTests
                 }));
                 timer.Stop();
 
+                e.Should().BeOfType<ServiceUnavailableException>();
                 var error = e.InnerException as AggregateException;
                 var innerErrors = error.Flatten().InnerExceptions;
                 foreach (var innerError in innerErrors)

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Examples.cs
@@ -533,7 +533,7 @@ namespace Neo4j.Driver.Examples
                         );
                     }
                 }
-                catch (AggregateException)
+                catch (ServiceUnavailableException)
                 {
                     return false;
                 }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ExamplesAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ExamplesAsync.cs
@@ -614,7 +614,7 @@ namespace Neo4j.Driver.ExamplesAsync
                         }
                     );
                 }
-                catch (AggregateException)
+                catch (ServiceUnavailableException)
                 {
                     return false;
                 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
@@ -62,7 +62,7 @@ namespace Neo4j.Driver.Tests
             }));
             timer.Stop();
 
-            var error = e as AggregateException;
+            var error = e.InnerException as AggregateException;
             var innerErrors = error.Flatten().InnerExceptions;
 
             innerErrors.Count.Should().BeGreaterOrEqualTo(2);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
@@ -62,6 +62,7 @@ namespace Neo4j.Driver.Tests
             }));
             timer.Stop();
 
+            e.Should().BeOfType<ServiceUnavailableException>();
             var error = e.InnerException as AggregateException;
             var innerErrors = error.Flatten().InnerExceptions;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -66,14 +66,22 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void Init()
         {
-            var connected = Task.Run(() => _client.StartAsync(_connectionTimeout)).Wait(_connectionTimeout);
-            if (!connected)
+            try
             {
-                throw new IOException(
-                    $"Failed to connect to the server {Server.Address} within connection timeout {_connectionTimeout.TotalMilliseconds}ms");
-            }
+                var connected = Task.Run(() => _client.StartAsync(_connectionTimeout)).Wait(_connectionTimeout);
+                if (!connected)
+                {
+                    throw new IOException(
+                        $"Failed to connect to the server {Server.Address} within connection timeout {_connectionTimeout.TotalMilliseconds}ms");
+                }
 
-            Init(_authToken);
+                Init(_authToken);
+            }
+            catch (AggregateException e)
+            {
+                // To remove the wrapper around the inner exception because of Task.Wait()
+                throw e.InnerException;
+            }
         }
 
         public async Task InitAsync()


### PR DESCRIPTION
Made Retry and TcpClient to not throw AggregatedException on the top level. 
But as Retry and TcpClient still try to do some work for several times, the inner errors as a list are still stored in a AggregatedException.