### PR TITLE
 Improve buffer usage across bolt & packstream classes

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -667,9 +667,10 @@ namespace Neo4j.Driver.Tests
                 var uri = new Uri("localhost:7687");
                 var connectionSettings = new ConnectionSettings(uri, AuthTokens.None, Config.DefaultConfig);
                 var poolSettings = new ConnectionPoolSettings(1, 1, TimeSpan.MaxValue, TimeSpan.MaxValue);
+                var bufferSettings = new BufferSettings(Config.DefaultConfig);
                 var logger = new Mock<ILogger>().Object;
 
-                var pool = new ConnectionPool(uri, connectionSettings, poolSettings, logger);
+                var pool = new ConnectionPool(uri, connectionSettings, poolSettings, bufferSettings, logger);
 
                 pool.NumberOfInUseConnections.Should().Be(0);
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -81,7 +81,7 @@ namespace Neo4j.Driver.Tests
                     0x61, 0x67, 0x65, 0x20, 0x31, 0xA0, 0x00, 0x00
                 };
                 var expectedLength = expectedBytes.Length;
-                expectedBytes = expectedBytes.PadRight(Constants.BufferSize);
+                expectedBytes = expectedBytes.PadRight(8 * 1024);
 
                 var messageHandler = new MessageResponseHandler();
                 messageHandler.EnqueueMessage(new InitMessage(DefaultUserAgent, new Dictionary<string, object>()));

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
@@ -90,7 +90,7 @@ namespace Neo4j.Driver.Tests.IO
 
         }
 
-        public class ReadNextChunkMethod
+        public class ReadNextMessagesMethod
         {
 
             [Theory]
@@ -101,7 +101,8 @@ namespace Neo4j.Driver.Tests.IO
                 var reader = new ChunkReader(new MemoryStream(input));
                 var targetStream = new MemoryStream();
 
-                reader.ReadNextMessage(targetStream);
+                var count = reader.ReadNextMessages(targetStream);
+                count.Should().Be(1);
 
                 var real = targetStream.ToArray();
 
@@ -110,7 +111,7 @@ namespace Neo4j.Driver.Tests.IO
 
         }
 
-        public class ReadNextChunkAsyncMethod
+        public class ReadNextMessagesAsyncMethod
         {
 
             [Theory]
@@ -121,7 +122,8 @@ namespace Neo4j.Driver.Tests.IO
                 var reader = new ChunkReader(new MemoryStream(input));
                 var targetStream = new MemoryStream();
 
-                await reader.ReadNextMessageAsync(targetStream);
+                var count = await reader.ReadNextMessagesAsync(targetStream);
+                count.Should().Be(1);
 
                 var real = targetStream.ToArray();
 
@@ -137,60 +139,10 @@ namespace Neo4j.Driver.Tests.IO
                     .Throws<InvalidOperationException>();
                 var reader = new ChunkReader(mockStream.Object);
 
-                var ex = await Record.ExceptionAsync(() => reader.ReadNextMessageAsync(new MemoryStream()));
+                var ex = await Record.ExceptionAsync(() => reader.ReadNextMessagesAsync(new MemoryStream()));
 
                 ex.Should().NotBeNull();
                 ex.Should().BeOfType<InvalidOperationException>();
-            }
-
-        }
-
-        public class Cleanup
-        {
-
-
-            [Fact]
-            public void ShouldCleanupChunkBufferIfItExceedsMaxChunkBufferSize()
-            {
-                byte[] maxSizeChunkBuffer = new byte[ushort.MaxValue + 2 + 2];
-                byte[] chunkSizeBuffer = PackStreamBitConverter.GetBytes(ushort.MaxValue);
-                for (var i = 0; i < chunkSizeBuffer.Length; i++) maxSizeChunkBuffer[i] = chunkSizeBuffer[i];
-                var chunkBuffer = new MemoryStream();
-                var targetStream = new MemoryStream();
-                var reader = new ChunkReader(new MemoryStream(maxSizeChunkBuffer), chunkBuffer, null);
-
-                reader.ReadNextMessage(targetStream);
-
-                var real = targetStream.ToArray();
-
-                real.Should().NotBeNull();
-                real.Should().HaveCount(ushort.MaxValue);
-                real.Should().Contain(0);
-
-                chunkBuffer.Length.Should().Be(0);
-                chunkBuffer.Position.Should().Be(0);
-            }
-
-            [Fact]
-            public async void ShouldCleanupChunkBufferIfItExceedsMaxChunkBufferSizeAsync()
-            {
-                byte[] maxSizeChunkBuffer = new byte[ushort.MaxValue + 2 + 2];
-                byte[] chunkSizeBuffer = PackStreamBitConverter.GetBytes(ushort.MaxValue);
-                for (var i = 0; i < chunkSizeBuffer.Length; i++) maxSizeChunkBuffer[i] = chunkSizeBuffer[i];
-                var chunkBuffer = new MemoryStream();
-                var targetStream = new MemoryStream();
-                var reader = new ChunkReader(new MemoryStream(maxSizeChunkBuffer), chunkBuffer, null);
-
-                await reader.ReadNextMessageAsync(targetStream);
-
-                var real = targetStream.ToArray();
-
-                real.Should().NotBeNull();
-                real.Should().HaveCount(ushort.MaxValue);
-                real.Should().Contain(0);
-
-                chunkBuffer.Length.Should().Be(0);
-                chunkBuffer.Position.Should().Be(0);
             }
 
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
@@ -42,8 +42,9 @@ namespace Neo4j.Driver.Tests.Routing
                 var config = Config.DefaultConfig;
                 var connSettings = new ConnectionSettings(ServerUri, new Mock<IAuthToken>().Object, config);
                 var poolSettings = new ConnectionPoolSettings(config);
+                var bufferSettings = new BufferSettings(config);
 
-                var pool = new ClusterConnectionPool(connSettings, poolSettings, uris, null);
+                var pool = new ClusterConnectionPool(connSettings, poolSettings, bufferSettings, uris, null);
 
                 pool.ToString().Should().Be(
                     "[{bolt://123:456/ : _availableConnections: {[]}, _inUseConnections: {[]}}]");

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/IOExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/IOExtensions.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Tests
             ChunkReader chunkReader = new ChunkReader(mBytesStream, logger);
 
             MemoryStream mStream = new MemoryStream();
-            chunkReader.ReadNextMessage(mStream);
+            chunkReader.ReadNextMessages(mStream);
 
             mStream.Position = 0;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Tests
         public SocketClientTestHarness(Uri uri=null)
         {
             MockTcpSocketClient = new Mock<ITcpSocketClient>();
-            Client = new SocketClient(uri, new Mock<EncryptionManager>().Object, true, false, new Mock<ILogger>().Object, MockTcpSocketClient.Object);
+            Client = new SocketClient(uri, new Mock<EncryptionManager>().Object, true, false, new Mock<ILogger>().Object, new BufferSettings(Config.DefaultConfig), MockTcpSocketClient.Object);
         }
 
         public async Task ExpectException<T>(Func<Task> func, string errorMessage=null) where T : Exception

--- a/Neo4j.Driver/Neo4j.Driver/Internal/BufferSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/BufferSettings.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Neo4j.Driver.V1;
+
+namespace Neo4j.Driver.Internal
+{
+    internal class BufferSettings
+    {
+
+        public BufferSettings(Config config)
+            : this(config.DefaultReadBufferSize, config.MaxReadBufferSize, config.DefaultWriteBufferSize, config.MaxWriteBufferSize)
+        {
+
+        }
+
+        public BufferSettings(int defaultReadBufferSize, int maxReadBufferSize, int defaultWriteBufferSize, int maxWriteBufferSize)
+        {
+            Throw.ArgumentOutOfRangeException.IfValueLessThan(defaultReadBufferSize, 0, nameof(defaultReadBufferSize));
+            Throw.ArgumentOutOfRangeException.IfValueLessThan(maxReadBufferSize, 0, nameof(maxReadBufferSize));
+            Throw.ArgumentOutOfRangeException.IfValueLessThan(defaultWriteBufferSize, 0, nameof(defaultWriteBufferSize));
+            Throw.ArgumentOutOfRangeException.IfValueLessThan(maxWriteBufferSize, 0, nameof(maxWriteBufferSize));
+
+            DefaultReadBufferSize = defaultReadBufferSize;
+            MaxReadBufferSize = maxReadBufferSize;
+            DefaultWriteBufferSize = defaultWriteBufferSize;
+            MaxWriteBufferSize = maxWriteBufferSize;
+        }
+
+        public int DefaultReadBufferSize { get; }
+
+        public int MaxReadBufferSize { get; }
+
+        public int DefaultWriteBufferSize { get; }
+
+        public int MaxWriteBufferSize { get; }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -38,13 +38,15 @@ namespace Neo4j.Driver.Internal.Connector
         private readonly Uri _uri;
         private IBoltReader _reader;
         private IBoltWriter _writer;
+        private readonly BufferSettings _bufferSettings;
 
         private readonly ILogger _logger;
 
-        public SocketClient(Uri uri, EncryptionManager encryptionManager, bool socketKeepAlive, bool ipv6Enabled, ILogger logger, ITcpSocketClient socketClient = null)
+        public SocketClient(Uri uri, EncryptionManager encryptionManager, bool socketKeepAlive, bool ipv6Enabled, ILogger logger, BufferSettings bufferSettings, ITcpSocketClient socketClient = null)
         {
             _uri = uri;
             _logger = logger;
+            _bufferSettings = bufferSettings ?? new BufferSettings(Config.DefaultConfig);
             _tcpSocketClient = socketClient ?? new TcpSocketClient(encryptionManager, socketKeepAlive, ipv6Enabled, _logger);
         }
 
@@ -129,8 +131,8 @@ namespace Neo4j.Driver.Internal.Connector
 
         private void SetupPackStreamFormatWriterAndReader(bool supportBytes = true)
         {
-            _writer = new BoltWriter(_tcpSocketClient.WriteStream, _logger, supportBytes); 
-            _reader = new BoltReader(_tcpSocketClient.ReadStream, _logger, supportBytes);
+            _writer = new BoltWriter(_tcpSocketClient.WriteStream, _bufferSettings.DefaultWriteBufferSize, _bufferSettings.MaxWriteBufferSize, _logger, supportBytes); 
+            _reader = new BoltReader(_tcpSocketClient.ReadStream, _bufferSettings.DefaultReadBufferSize, _bufferSettings.MaxReadBufferSize, _logger, supportBytes);
         }
 
         private void Stop()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -38,10 +38,13 @@ namespace Neo4j.Driver.Internal.Connector
 
         private readonly ILogger _logger;
 
-        public SocketConnection(Uri uri, ConnectionSettings connectionSettings, ILogger logger)
-            : this(new SocketClient(uri, connectionSettings.EncryptionManager, connectionSettings.SocketKeepAliveEnabled, connectionSettings.Ipv6Enabled, logger),
-                  connectionSettings.AuthToken, connectionSettings.ConnectionTimeout, connectionSettings.UserAgent,
-                  logger, new ServerInfo(uri))
+        public SocketConnection(Uri uri, ConnectionSettings connectionSettings, BufferSettings bufferSettings,
+            ILogger logger)
+            : this(
+                new SocketClient(uri, connectionSettings.EncryptionManager, connectionSettings.SocketKeepAliveEnabled,
+                    connectionSettings.Ipv6Enabled, logger, bufferSettings),
+                connectionSettings.AuthToken, connectionSettings.ConnectionTimeout, connectionSettings.UserAgent,
+                logger, new ServerInfo(uri))
         {
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/Constants.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/Constants.cs
@@ -22,9 +22,13 @@ namespace Neo4j.Driver.Internal.IO
 {
     internal static class Constants
     {
-        public const int BufferSize = 8 * 1024;
         public const int MaxChunkSize = ushort.MaxValue;
         public const int MinChunkSize = 6;
-        public const int MaxChunkBufferSize = MaxChunkSize;
+
+        public const int ChunkBufferSize = 16 * 1024;
+        public const int DefaultReadBufferSize = 32 * 1024;
+        public const int MaxReadBufferSize = 128 * 1024;
+        public const int DefaultWriteBufferSize = 16 * 1024;
+        public const int MaxWriteBufferSize = 64 * 1024;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
@@ -25,9 +25,9 @@ namespace Neo4j.Driver.Internal.IO
     internal interface IChunkReader
     {
 
-        int ReadNextMessages(Stream target);
+        int ReadNextMessages(Stream messageStream);
 
-        Task<int> ReadNextMessagesAsync(Stream target);
+        Task<int> ReadNextMessagesAsync(Stream messageStream);
 
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
@@ -25,9 +25,9 @@ namespace Neo4j.Driver.Internal.IO
     internal interface IChunkReader
     {
 
-        void ReadNextMessage(Stream target);
+        int ReadNextMessages(Stream target);
 
-        Task ReadNextMessageAsync(Stream target);
+        Task<int> ReadNextMessagesAsync(Stream target);
 
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkWriter.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -24,11 +25,15 @@ namespace Neo4j.Driver.Internal.IO
     internal interface IChunkWriter
     {
 
-        void WriteChunk(byte[] buffer, int offset, int count);
+        Stream ChunkerStream { get; }
 
-        void Flush();
+        void OpenChunk();
 
-        Task FlushAsync();
+        void CloseChunk();
+
+        void Send();
+
+        Task SendAsync();
 
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -32,6 +32,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         private readonly ConnectionSettings _connectionSettings;
         private readonly ConnectionPoolSettings _poolSettings;
+        private readonly BufferSettings _bufferSettings;
 
         // for test only
         private readonly IConnectionPool _fakePool;
@@ -41,12 +42,14 @@ namespace Neo4j.Driver.Internal.Routing
         public ClusterConnectionPool(
             ConnectionSettings connectionSettings,
             ConnectionPoolSettings poolSettings,
+            BufferSettings bufferSettings,
             IEnumerable<Uri> initUris, ILogger logger
         )
             : base(logger)
         {
             _connectionSettings = connectionSettings;
             _poolSettings = poolSettings;
+            _bufferSettings = bufferSettings;
             Add(initUris);
         }
 
@@ -55,9 +58,10 @@ namespace Neo4j.Driver.Internal.Routing
             ConcurrentDictionary<Uri, IConnectionPool> clusterPool = null,
             ConnectionSettings connSettings = null,
             ConnectionPoolSettings poolSettings = null,
+            BufferSettings bufferSettings = null,
             ILogger logger = null
         ) :
-            this(connSettings, poolSettings, Enumerable.Empty<Uri>(), logger)
+            this(connSettings, poolSettings, bufferSettings, Enumerable.Empty<Uri>(), logger)
         {
             _fakePool = connectionPool;
             _pools = clusterPool;
@@ -65,7 +69,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         private IConnectionPool CreateNewConnectionPool(Uri uri)
         {
-            return _fakePool ?? new ConnectionPool(uri, _connectionSettings, _poolSettings, Logger);
+            return _fakePool ?? new ConnectionPool(uri, _connectionSettings, _poolSettings, _bufferSettings, Logger);
         }
 
         public IConnection Acquire(Uri uri)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -37,12 +37,13 @@ namespace Neo4j.Driver.Internal.Routing
             RoutingSettings routingSettings,
             ConnectionSettings connectionSettings,
             ConnectionPoolSettings poolSettings,
+            BufferSettings bufferSettings,
             Config config)
         {
             var logger = config.Logger;
             var uris = connectionSettings.InitialServerUri.Resolve();
             _clusterConnectionPool = new ClusterConnectionPool(
-                connectionSettings, poolSettings, uris, logger);
+                connectionSettings, poolSettings, bufferSettings, uris, logger);
             _routingTableManager = new RoutingTableManager(routingSettings, this, connectionSettings.InitialServerUri,
                 uris, logger);
             _loadBalancingStrategy = CreateLoadBalancingStrategy(config, _clusterConnectionPool);

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <AssemblyName>Neo4j.Driver</AssemblyName>
     <PackageId>Neo4j.Driver</PackageId>
     <Authors>Neo4j</Authors>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.IO;
 
 namespace Neo4j.Driver.V1
 {
@@ -101,6 +102,11 @@ namespace Neo4j.Driver.V1
         /// <br></br>
         /// <item><see cref="Logger"/> : <c>DebugLogger</c> at <c><see cref="LogLevel"/> Info</c> </item>
         /// <item><see cref="MaxTransactionRetryTime"/>: <c>30s</c></item>
+        /// <br></br>
+        /// <item><see cref="DefaultReadBufferSize"/> : <c>32K</c> </item>
+        /// <item><see cref="MaxReadBufferSize"/> : <c>128K</c> </item>
+        /// <item><see cref="DefaultWriteBufferSize"/> : <c>16K</c> </item>
+        /// <item><see cref="MaxWriteBufferSize"/> : <c>64K</c> </item>
         /// </list>
         /// </remarks>
         public static Config DefaultConfig { get; }
@@ -200,6 +206,30 @@ namespace Neo4j.Driver.V1
         /// </summary>
         internal IStatisticsCollector DriverStatisticsCollector { get; set; }
 
+        /// <summary>
+        /// Gets or sets the default read buffer size which the driver allocates for its internal buffers.
+        /// </summary>
+        public int DefaultReadBufferSize { get; set; } = Constants.DefaultReadBufferSize;
+
+        /// <summary>
+        /// Gets or sets the size when internal read buffers reach, will be released for garbage collection. 
+        /// If reading large records (nodes, relationships or paths) and experiencing too much garbage collection consider increasing this size
+        /// to a reasonable amount depending on your data.
+        /// </summary>
+        public int MaxReadBufferSize { get; set; } = Constants.MaxReadBufferSize;
+
+        /// <summary>
+        /// Gets or sets the default write buffer size which the driver allocates for its internal buffers.
+        /// </summary>
+        public int DefaultWriteBufferSize { get; set; } = Constants.DefaultWriteBufferSize;
+
+        /// <summary>
+        /// Gets or sets the size when internal write buffers reach, will be released for garbage collection. 
+        /// If writing large values and experiencing too much garbage collection consider increasing this size
+        /// to a reasonable amount depending on your data.
+        /// </summary>
+        public int MaxWriteBufferSize { get; set; } = Constants.MaxWriteBufferSize;
+
         private class ConfigBuilder : IConfigBuilder
         {
             private readonly Config _config;
@@ -288,6 +318,30 @@ namespace Neo4j.Driver.V1
             public IConfigBuilder WithLoadBalancingStrategy(LoadBalancingStrategy loadBalancingStrategy)
             {
                 _config.LoadBalancingStrategy = loadBalancingStrategy;
+                return this;
+            }
+
+            public IConfigBuilder WithDefaultReadBufferSize(int defaultReadBufferSize)
+            {
+                _config.DefaultReadBufferSize = defaultReadBufferSize;
+                return this;
+            }
+
+            public IConfigBuilder WithMaxReadBufferSize(int maxReadBufferSize)
+            {
+                _config.MaxReadBufferSize = maxReadBufferSize;
+                return this;
+            }
+
+            public IConfigBuilder WithDefaultWriteBufferSize(int defaultWriteBufferSize)
+            {
+                _config.DefaultWriteBufferSize = defaultWriteBufferSize;
+                return this;
+            }
+
+            public IConfigBuilder WithMaxWriteBufferSize(int maxWriteBufferSize)
+            {
+                _config.MaxWriteBufferSize = maxWriteBufferSize;
                 return this;
             }
         }
@@ -418,5 +472,37 @@ namespace Neo4j.Driver.V1
         /// <returns>An <see cref="IConfigBuilder"/> instance for further configuration options.</returns>
         /// <remarks>We are experimenting with different strategies. This could be removed in the next minor version.</remarks>
         IConfigBuilder WithLoadBalancingStrategy(LoadBalancingStrategy loadBalancingStrategy);
+
+        /// <summary>
+        /// Specify the default read buffer size which the driver allocates for its internal buffers.
+        /// </summary>
+        /// <param name="defaultReadBufferSize">the buffer size</param>
+        /// <returns>An <see cref="IConfigBuilder"/> instance for further configuration options.</returns>
+        IConfigBuilder WithDefaultReadBufferSize(int defaultReadBufferSize);
+
+        /// <summary>
+        /// Specify the size when internal read buffers reach, will be released for garbage collection. 
+        /// </summary>
+        /// <param name="maxReadBufferSize">the buffer size</param>
+        /// <returns>An <see cref="IConfigBuilder"/> instance for further configuration options.</returns>
+        /// <remarks>If reading large records (nodes, relationships or paths) and experiencing too much garbage collection 
+        /// consider increasing this size to a reasonable amount depending on your data.</remarks>
+        IConfigBuilder WithMaxReadBufferSize(int maxReadBufferSize);
+
+        /// <summary>
+        /// Specify the default write buffer size which the driver allocates for its internal buffers.
+        /// </summary>
+        /// <param name="defaultWriteBufferSize">the buffer size</param>
+        /// <returns>An <see cref="IConfigBuilder"/> instance for further configuration options.</returns>
+        IConfigBuilder WithDefaultWriteBufferSize(int defaultWriteBufferSize);
+
+        /// <summary>
+        /// Specify the size when internal write buffers reach, will be released for garbage collection. 
+        /// </summary>
+        /// <param name="maxWriteBufferSize">the buffer size</param>
+        /// <returns>An <see cref="IConfigBuilder"/> instance for further configuration options.</returns>
+        /// <remarks>If writing large values and experiencing too much garbage collection 
+        /// consider increasing this size to a reasonable amount depending on your data.</remarks>
+        IConfigBuilder WithMaxWriteBufferSize(int maxWriteBufferSize);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/GraphDatabase.cs
@@ -206,6 +206,7 @@ namespace Neo4j.Driver.V1
             var routingSettings = new RoutingSettings(routingContext);
             var connectionSettings = new ConnectionSettings(parsedUri, authToken, config);
             var connectionPoolSettings = new ConnectionPoolSettings(config);
+            var bufferSettings = new BufferSettings(config);
 
             var logger = config.Logger;
             var retryLogic = new ExponentialBackoffRetryLogic(config.MaxTransactionRetryTime, logger);
@@ -218,10 +219,10 @@ namespace Neo4j.Driver.V1
                     {
                         throw new ArgumentException($"Routing context are not supported with scheme 'bolt'. Given URI: '{uri}'");
                     }
-                    connectionProvider = new ConnectionPool(parsedUri, connectionSettings, connectionPoolSettings, logger);
+                    connectionProvider = new ConnectionPool(parsedUri, connectionSettings, connectionPoolSettings, bufferSettings, logger);
                     break;
                 case "bolt+routing":
-                    connectionProvider = new LoadBalancer(routingSettings, connectionSettings, connectionPoolSettings, config);
+                    connectionProvider = new LoadBalancer(routingSettings, connectionSettings, connectionPoolSettings, bufferSettings, config);
                     break;
                 default:
                     throw new NotSupportedException($"Unsupported URI scheme: {parsedUri.Scheme}");


### PR DESCRIPTION
  1. Introduced Buffer related settings into the configuration,
  2. Dropped MemoryStream from ChunkReader and started to use a fix sized buffer,
  3. Dropped MemoryStream from BoltWriter,
  4. Reset MemoryStream capacity to default buffer size after consuming or sending messages in BoltReader and ChunkWriter classes.