### PR TITLE
Added tests for ipv6 address parsing for routing procedure responses

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using FluentAssertions;
 using Moq;
 using Neo4j.Driver.Internal;
@@ -274,15 +275,25 @@ namespace Neo4j.Driver.Tests.Routing
         public class BoltRoutingUriMethod
         {
             [Theory]
+            [InlineData("localhost", "localhost", GraphDatabase.DefaultBoltPort)]
             [InlineData("localhost:9193", "localhost", 9193)]
-            [InlineData("neo4j.com:9193", "neo4j.com", 9193)]
+            [InlineData("neo4j.com", "neo4j.com", GraphDatabase.DefaultBoltPort)]
+            [InlineData("royal-server.com.uk", "royal-server.com.uk", GraphDatabase.DefaultBoltPort)]
             [InlineData("royal-server.com.uk:4546", "royal-server.com.uk", 4546)]
-            [InlineData("127.0.0.1:8080", "127.0.0.1", 8080)]
-            [InlineData("0.0.0.0:9193", "0.0.0.0", 9193)]
+            // IPv4
+            [InlineData("127.0.0.1", "127.0.0.1", GraphDatabase.DefaultBoltPort)]
+            [InlineData("8.8.8.8:8080", "8.8.8.8", 8080)]
+            [InlineData("0.0.0.0", "0.0.0.0", GraphDatabase.DefaultBoltPort)]
             [InlineData("192.0.2.235:4329", "192.0.2.235", 4329)]
             [InlineData("172.31.255.255:255", "172.31.255.255", 255)]
-            [InlineData("[::1]:7676", "[::1]", 7676)]
-            [InlineData("[1afc:0:a33:85a3::ff2f]:5678", "[1afc:0:a33:85a3::ff2f]", 5678)]
+            // IPv6
+            [InlineData("[1afc:0:a33:85a3::ff2f]", "[1afc:0:a33:85a3::ff2f]", GraphDatabase.DefaultBoltPort)]
+            [InlineData("[::1]:1515", "[::1]", 1515)]
+            [InlineData("[ff0a::101]:8989", "[ff0a::101]", 8989)]
+            // IPv6 with zone id
+            [InlineData("[1afc:0:a33:85a3::ff2f%eth1]", "[1afc:0:a33:85a3::ff2f]", GraphDatabase.DefaultBoltPort)]
+            [InlineData("[::1%eth0]:3030", "[::1]", 3030)]
+            [InlineData("[ff0a::101%8]:4040", "[ff0a::101]", 4040)]
             public void ShouldHaveLocalhost(string input, string host, int port)
             {
                 var uri = ClusterDiscoveryManager.BoltRoutingUri(input);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
@@ -271,6 +271,27 @@ namespace Neo4j.Driver.Tests.Routing
             }
         }
 
+        public class BoltRoutingUriMethod
+        {
+            [Theory]
+            [InlineData("localhost:9193", "localhost", 9193)]
+            [InlineData("neo4j.com:9193", "neo4j.com", 9193)]
+            [InlineData("royal-server.com.uk:4546", "royal-server.com.uk", 4546)]
+            [InlineData("127.0.0.1:8080", "127.0.0.1", 8080)]
+            [InlineData("0.0.0.0:9193", "0.0.0.0", 9193)]
+            [InlineData("192.0.2.235:4329", "192.0.2.235", 4329)]
+            [InlineData("172.31.255.255:255", "172.31.255.255", 255)]
+            [InlineData("[::1]:7676", "[::1]", 7676)]
+            [InlineData("[1afc:0:a33:85a3::ff2f]:5678", "[1afc:0:a33:85a3::ff2f]", 5678)]
+            public void ShouldHaveLocalhost(string input, string host, int port)
+            {
+                var uri = ClusterDiscoveryManager.BoltRoutingUri(input);
+                uri.Scheme.Should().Be("bolt+routing");
+                uri.Host.Should().Be(host);
+                uri.Port.Should().Be(port);
+            }
+        }
+
         internal static InitMessage InitMessage(IAuthToken auth = null)
         {
             auth = auth ?? AuthTokens.None;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
@@ -155,7 +155,7 @@ namespace Neo4j.Driver.Internal.Routing
         {
             UriBuilder builder = new UriBuilder("bolt+routing://" + address);
             
-            // If scheme is not registered, then the port is -1
+            // If scheme is not registered and no port is specified, then the port is assigned as -1
             if (builder.Port == -1)
             {
                 builder.Port = GraphDatabase.DefaultBoltPort;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
@@ -153,7 +153,15 @@ namespace Neo4j.Driver.Internal.Routing
 
         public static Uri BoltRoutingUri(string address)
         {
-            return new Uri("bolt+routing://" + address);
+            UriBuilder builder = new UriBuilder("bolt+routing://" + address);
+            
+            // If scheme is not registered, then the port is -1
+            if (builder.Port == -1)
+            {
+                builder.Port = GraphDatabase.DefaultBoltPort;
+            }
+
+            return builder.Uri;
         }
 
         private class SingleConnectionBasedConnectionProvider : IConnectionProvider

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
@@ -151,7 +151,7 @@ namespace Neo4j.Driver.Internal.Routing
             ExpireAfterSeconds = record["ttl"].As<long>();
         }
 
-        private Uri BoltRoutingUri(string address)
+        public static Uri BoltRoutingUri(string address)
         {
             return new Uri("bolt+routing://" + address);
         }


### PR DESCRIPTION
The parsing of ipv6 logic was not changed for routing procedure responses as it originally could accept ipv6 addresses.

While this parsing logic depends on the assumption that the addresses in procedure replies should be in the format of `address:port`. The `port` must be included.