### PR TITLE
Changed the impl for waiting for keys to arrive

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultBuilderTests.cs
@@ -143,6 +143,8 @@ namespace Neo4j.Driver.Tests
             public void ShouldPassDefaultKeysToResultIfNoKeySet()
             {
                 var builder = new ResultBuilder(null, () => { }, null, null);
+                builder.DoneSuccess();
+
                 var result = builder.PreBuild();
 
                 result.Keys.Should().BeEmpty();
@@ -153,6 +155,7 @@ namespace Neo4j.Driver.Tests
             {
                 var builder = new ResultBuilder(null, () => { }, null, null);
                 builder.CollectFields(null);
+                builder.DoneSuccess();
 
                 var result = builder.PreBuild();
                 result.Keys.Should().BeEmpty();
@@ -167,6 +170,7 @@ namespace Neo4j.Driver.Tests
                     {"something", "here" }
                 };
                 builder.CollectFields(meta);
+                builder.DoneSuccess();
 
                 var result = builder.PreBuild();
                 result.Keys.Should().BeEmpty();
@@ -180,6 +184,7 @@ namespace Neo4j.Driver.Tests
 
                 var builder = new ResultBuilder(null, () => { }, null, null);
                 builder.CollectFields(meta);
+                builder.DoneSuccess();
                 var result = builder.PreBuild();
 
                 result.Keys.Should().ContainInOrder("fieldKey1", "fieldKey2", "fieldKey3");

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultCursorBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultCursorBuilderTests.cs
@@ -58,7 +58,7 @@ namespace Neo4j.Driver.Tests
         public class CollectRecordMethod
         {
             [Fact]
-            public void ShouldStreamResults()
+            public async void ShouldStreamResults()
             {
                 var builder = GenerateBuilder();
                 var i = 0;
@@ -67,6 +67,7 @@ namespace Neo4j.Driver.Tests
                     if (i++ >= 3)
                     {
                         builder.CollectSummary(null);
+                        builder.DoneSuccess();
                     }
                     else
                     {
@@ -75,7 +76,7 @@ namespace Neo4j.Driver.Tests
 
                     return Task.CompletedTask;
                 });
-                var result = builder.PreBuild();
+                var result = await builder.PreBuildAsync();
 
                 var t = AssertGetExpectResults(result, 3, new List<object> {124, 125, 126});
 
@@ -83,16 +84,16 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void ShouldReturnNoResultsWhenNoneRecieved()
+            public async void ShouldReturnNoResultsWhenNoneRecieved()
             {
                 var builder = GenerateBuilder();
                 builder.SetReceiveOneFunc(() =>
                 {
                     builder.CollectSummary(null);
-
+                    builder.DoneSuccess();
                     return Task.CompletedTask;
                 });
-                var result = builder.PreBuild();
+                var result = await builder.PreBuildAsync();
 
                 var t = AssertGetExpectResults(result, 0);
 
@@ -100,7 +101,7 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void ShouldReturnQueuedResultsWithExspectedValue()
+            public async void ShouldReturnQueuedResultsWithExspectedValue()
             {
                 var builder = GenerateBuilder();
                 List<object> recordValues = new List<object>
@@ -115,15 +116,16 @@ namespace Neo4j.Driver.Tests
                     builder.CollectRecord(new[] { recordValues[i] });
                 }
                 builder.CollectSummary(null);
+                builder.DoneSuccess();
 
-                var result = builder.PreBuild();
+                var result = await builder.PreBuildAsync();
 
                 var task = AssertGetExpectResults(result, recordValues.Count, recordValues);
                 task.Wait();
             }
 
             [Fact]
-            public void ShouldStopStreamingWhenResultIsInvalid()
+            public async void ShouldStopStreamingWhenResultIsInvalid()
             {
                 var builder = GenerateBuilder();
                 var i = 0;
@@ -140,7 +142,7 @@ namespace Neo4j.Driver.Tests
 
                     return Task.CompletedTask;
                 });
-                var result = builder.PreBuild();
+                var result = await builder.PreBuildAsync();
 
                 var t = AssertGetExpectResults(result, 3, new List<object> { 124, 125, 126 });
                 t.Wait();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -75,6 +75,12 @@ namespace Neo4j.Driver.Tests
             {
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lalalal");
 
@@ -87,6 +93,12 @@ namespace Neo4j.Driver.Tests
             {
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lalalal");
 
@@ -284,6 +296,13 @@ namespace Neo4j.Driver.Tests
             {
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
+
                 var session = NewSession(mockConn.Object);
                 var tx = await session.BeginTransactionAsync();
                 await tx.RollbackAsync();
@@ -295,6 +314,12 @@ namespace Neo4j.Driver.Tests
             public async void ShouldClosePreviousRunConnectionWhenRunMoreStatements()
             {
                 var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lalal");
 
@@ -307,6 +332,12 @@ namespace Neo4j.Driver.Tests
             {
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(false);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lala");
 
@@ -320,6 +351,12 @@ namespace Neo4j.Driver.Tests
                 // Given
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 mockConn.Setup(x => x.Run("BEGIN", null, null, true))
                     .Throws(new IOException("Triggered an error when beginTx"));
                 var session = NewSession(mockConn.Object);
@@ -458,6 +495,12 @@ namespace Neo4j.Driver.Tests
             {
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lalal");
                 await session.CloseAsync();
@@ -472,6 +515,12 @@ namespace Neo4j.Driver.Tests
                 // Given
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lalal");
 
@@ -492,6 +541,12 @@ namespace Neo4j.Driver.Tests
                 // Given
                 var mockConn = new Mock<IConnection>();
                 mockConn.Setup(x => x.IsOpen).Returns(true);
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var session = NewSession(mockConn.Object);
                 await session.RunAsync("lalal");
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -192,6 +192,12 @@ namespace Neo4j.Driver.Tests
             public async void ShouldRunPullAllSyncRun()
             {
                 var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var tx = new Transaction(mockConn.Object);
 
                 await tx.RunAsync("lalala");
@@ -225,6 +231,12 @@ namespace Neo4j.Driver.Tests
             public async void ShouldThrowExceptionIfFailedToRunAndFetchResult()
             {
                 var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
                 var tx = new Transaction(mockConn.Object);
 
                 mockConn.Setup(x => x.Run(It.IsAny<string>(), new Dictionary<string, object>(), It.IsAny<ResultCursorBuilder>(), true))
@@ -238,6 +250,13 @@ namespace Neo4j.Driver.Tests
             public async void ResultBuilderShouldObtainServerInfoFromConnection()
             {
                 var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.Run(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<IMessageResponseCollector>(), It.IsAny<bool>())).Callback<string, IDictionary<string, object>, IMessageResponseCollector, bool>(
+                    (s, d, c, b) =>
+                    {
+                        c?.DoneSuccess();
+                    });
+
                 var tx = new Transaction(mockConn.Object);
 
                 await tx.RunAsync("lalala");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilder.cs
@@ -43,7 +43,16 @@ namespace Neo4j.Driver.Internal.Result
         
         public StatementResult PreBuild()
         {
-            return new StatementResult(() => Keys, new RecordSet(NextRecord), Summary);
+            return new StatementResult(GetKeys, new RecordSet(NextRecord), Summary);
+        }
+
+        private List<string> GetKeys()
+        {
+            while (!StatementProcessed)
+            {
+                _receiveOneAction();
+            }
+            return Keys;
         }
 
         /// <summary>
@@ -90,11 +99,6 @@ namespace Neo4j.Driver.Internal.Result
                     _resourceHandler?.OnResultConsumed();
                 }
             };
-        }
-
-        protected override void EnsureStatementProcessed()
-        {
-            _receiveOneAction();
         }
 
         protected override void EnqueueRecord(Record record)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilderBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultBuilderBase.cs
@@ -22,26 +22,13 @@ namespace Neo4j.Driver.Internal.Result
 {
     internal abstract class ResultBuilderBase : IMessageResponseCollector
     {
-        private bool _statementProcessed = false;
-        protected List<string> _keys = new List<string>();
+        protected bool StatementProcessed { get; set; } = false;
+        protected List<string> Keys { get; } = new List<string>();
         protected SummaryCollector SummaryCollector { get; }
 
         protected ResultBuilderBase(Statement statement, IServerInfo server)
         {
             SummaryCollector = new SummaryCollector(statement, server);
-        }
-
-        protected List<string> Keys
-        {
-            get
-            {
-                if (!_statementProcessed)
-                {
-                    EnsureStatementProcessed();
-                }
-
-                return _keys;
-            }
         }
 
         public void CollectFields(IDictionary<string, object> meta)
@@ -51,7 +38,7 @@ namespace Neo4j.Driver.Internal.Result
                 return;
             }
 
-            CollectKeys(meta, "fields", _keys);
+            CollectKeys(meta, "fields", Keys);
             SummaryCollector.CollectWithFields(meta);
         }
 
@@ -63,7 +50,7 @@ namespace Neo4j.Driver.Internal.Result
 
         public void CollectRecord(object[] fields)
         {
-            var record = new Record(_keys, fields);
+            var record = new Record(Keys, fields);
             EnqueueRecord(record);
         }
 
@@ -80,22 +67,21 @@ namespace Neo4j.Driver.Internal.Result
         public void DoneSuccess()
         {
             // do nothing
-            _statementProcessed = true;
+            StatementProcessed = true;
         }
 
         public void DoneFailure()
         {
             NoMoreRecords();// an error received, so the result is broken
-            _statementProcessed = true;
+            StatementProcessed = true;
         }
 
         public void DoneIgnored()
         {
             NoMoreRecords();// the result is ignored
-            _statementProcessed = true;
+            StatementProcessed = true;
         }
 
-        protected abstract void EnsureStatementProcessed();
         protected abstract void NoMoreRecords();
         protected abstract void EnqueueRecord(Record record);
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursorBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursorBuilder.cs
@@ -45,9 +45,19 @@ namespace Neo4j.Driver.Internal.Result
         {
         }
 
-        public IStatementResultCursor PreBuild()
+        public async Task<IStatementResultCursor> PreBuildAsync()
         {
+            await GetKeys();
             return new StatementResultCursor(Keys, NextRecordAsync, SummaryAsync);
+        }
+
+        private async Task<List<string>> GetKeys()
+        {
+            while (!StatementProcessed)
+            {
+                await _receiveOneFunc().ConfigureAwait(false);
+            }
+            return Keys;
         }
 
         /// <summary>
@@ -104,11 +114,6 @@ namespace Neo4j.Driver.Internal.Result
         protected override void NoMoreRecords()
         {
             _hasMoreRecords = false;
-        }
-
-        protected override void EnsureStatementProcessed()
-        {
-            
         }
 
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursorBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursorBuilder.cs
@@ -47,7 +47,7 @@ namespace Neo4j.Driver.Internal.Result
 
         public async Task<IStatementResultCursor> PreBuildAsync()
         {
-            await GetKeys();
+            await GetKeys().ConfigureAwait(false);
             return new StatementResultCursor(Keys, NextRecordAsync, SummaryAsync);
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -80,10 +80,7 @@ namespace Neo4j.Driver.Internal
 
                 await _connection.SendAsync().ConfigureAwait(false);
 
-                // Wait for SUCCESS/FAILURE message from the server
-                await _connection.ReceiveOneAsync().ConfigureAwait(false);
-
-                return resultBuilder.PreBuild();
+                return await resultBuilder.PreBuildAsync();
             });
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -80,7 +80,7 @@ namespace Neo4j.Driver.Internal
 
                 await _connection.SendAsync().ConfigureAwait(false);
 
-                return await resultBuilder.PreBuildAsync();
+                return await resultBuilder.PreBuildAsync().ConfigureAwait(false);
             });
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Transaction.cs
@@ -224,10 +224,7 @@ namespace Neo4j.Driver.Internal
                 _connection.Run(statement.Text, statement.Parameters, resultBuilder);
                 await _connection.SendAsync().ConfigureAwait(false);
 
-                // Wait for SUCCESS/FAILURE message from the server
-                await _connection.ReceiveOneAsync().ConfigureAwait(false);
-
-                return resultBuilder.PreBuild();
+                return await resultBuilder.PreBuildAsync().ConfigureAwait(false);
             });
         }
 


### PR DESCRIPTION
For sync, the key will be received when `result.Keys` method is called. The method will block there until the key arrives via the reply of `Run` message

For async, the key will be received when a result cursor is built. While returning cursor after `Run` method, we will wait there for the reply of `Run` message