### PR TITLE
fix the issue caused when unexpected end of stream is encountered

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
@@ -109,6 +109,19 @@ namespace Neo4j.Driver.Tests.IO
                 real.Should().Equal(correctValue);
             }
 
+            [Fact]
+            public void ShouldThrowExceptionOnEndOfStream()
+            {
+                var reader = new ChunkReader(new MemoryStream(new byte[0]));
+                var targetStream = new MemoryStream();
+
+                var exc = Record.Exception(() => reader.ReadNextMessages(targetStream));
+
+                exc.Should().NotBeNull();
+                exc.Should().BeOfType<IOException>();
+                exc.Message.Should().StartWith("Unexpected end of stream");
+            }
+
         }
 
         public class ReadNextMessagesAsyncMethod
@@ -145,6 +158,18 @@ namespace Neo4j.Driver.Tests.IO
                 ex.Should().BeOfType<InvalidOperationException>();
             }
 
+            [Fact]
+            public async void ShouldThrowExceptionOnEndOfStream()
+            {
+                var reader = new ChunkReader(new MemoryStream(new byte[0]));
+                var targetStream = new MemoryStream();
+
+                var exc = await Record.ExceptionAsync(() => reader.ReadNextMessagesAsync(targetStream));
+
+                exc.Should().NotBeNull();
+                exc.Should().BeOfType<IOException>();
+                exc.Message.Should().StartWith("Unexpected end of stream");
+            }
         }
         
     }


### PR DESCRIPTION
As one of the issues discussed in #250, `ChunkReader.ReadNextMessages` and `ChunkReader.ReadNextMessagesAsync` method implementations are changed to handle the case when `Stream.Read` & `Stream.ReadAsync` methods return `0` (unexpected end of stream).