### PR TITLE
fix an issue that causes a deadlock on async calls

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
@@ -109,6 +109,19 @@ namespace Neo4j.Driver.Tests.IO
                 real.Should().Equal(correctValue);
             }
 
+            [Fact]
+            public void ShouldThrowExceptionOnEndOfStream()
+            {
+                var reader = new ChunkReader(new MemoryStream(new byte[0]));
+                var targetStream = new MemoryStream();
+
+                var exc = Record.Exception(() => reader.ReadNextMessages(targetStream));
+
+                exc.Should().NotBeNull();
+                exc.Should().BeOfType<IOException>();
+                exc.Message.Should().StartWith("Unexpected end of stream");
+            }
+
         }
 
         public class ReadNextMessagesAsyncMethod
@@ -145,6 +158,18 @@ namespace Neo4j.Driver.Tests.IO
                 ex.Should().BeOfType<InvalidOperationException>();
             }
 
+            [Fact]
+            public async void ShouldThrowExceptionOnEndOfStream()
+            {
+                var reader = new ChunkReader(new MemoryStream(new byte[0]));
+                var targetStream = new MemoryStream();
+
+                var exc = await Record.ExceptionAsync(() => reader.ReadNextMessagesAsync(targetStream));
+
+                exc.Should().NotBeNull();
+                exc.Should().BeOfType<IOException>();
+                exc.Message.Should().StartWith("Unexpected end of stream");
+            }
         }
         
     }


### PR DESCRIPTION
`ConnectionPool` relies on `BlockingCollection` to wait for an available connection to be released when maximum connection pool size is reached. This PR removes blocking calls to `BlockingCollection.TryTake` into the fail-fast overload of it and awaits predefined units of time (500ms) yielding the thread to be released - all only applicable to async code path.

Based on #252, addressing issues discussed at #250.