### PR TITLE
Fix purge connections based on `AggregateException` rather the original error

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DirectDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DirectDriverIT.cs
@@ -26,7 +26,6 @@ namespace Neo4j.Driver.IntegrationTests
     [Collection(SAIntegrationCollection.CollectionName)]
     public abstract class DirectDriverIT : IDisposable
     {
-        public static readonly Config DebugConfig = Config.Builder.WithLogger(new DebugLogger {Level = LogLevel.Debug}).ToConfig();
         protected ITestOutputHelper Output { get; }
         protected StandAlone Server { get; }
         protected Uri ServerEndPoint { get; }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ExamplesAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/ExamplesAsync.cs
@@ -856,7 +856,6 @@ namespace Neo4j.Driver.ExamplesAsync
             {
                 var result = session.Run("MATCH (n) DETACH DELETE n");
                 result.Consume();
-
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/BoltkitHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/BoltkitHelper.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.IntegrationTests.Internals
     public class BoltkitHelper
     {
         public const string TestRequireBoltkit = "Boltkit required to run test not accessible";
-        public static readonly string BoltkitArgs = Environment.GetEnvironmentVariable("NeoctrlArgs") ?? "-e 3.2.1";
+        public static readonly string BoltkitArgs = Environment.GetEnvironmentVariable("NeoctrlArgs") ?? "-e 3.2.7";
         public static readonly string TargetDir = new DirectoryInfo("../../../../Target").FullName;
         private static BoltkitStatus _boltkitAvailable = BoltkitStatus.Unknown;
         private static readonly object _syncLock = new object();

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ProcessBasedCommandRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ProcessBasedCommandRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using Neo4j.Driver.Internal;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
@@ -117,7 +118,8 @@ namespace Neo4j.Driver.IntegrationTests.Internals
                 if (_process.ExitCode != 0 || _stdErr.Length > 0)
                 {
                     throw new InvalidOperationException(
-                        $"Failed to execute `{GetProcessCommandLine(_process)}` due to error:{Environment.NewLine}{_stdErr}.");
+                        $"Failed to execute `{GetProcessCommandLine(_process)}` due to error:{Environment.NewLine}{_stdErr}" +
+                        $"{Environment.NewLine}output:{Environment.NewLine}{_stdOut.ToContentString($"{Environment.NewLine}")}");
                 }
                 
                 return _stdOut.ToArray();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DelegatedConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DelegatedConnectionTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) 2002-2017 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Neo4j.Driver.Internal.Connector;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Connector
+{
+    public class DelegatedConnectionTests
+    {
+        internal class TestDelegatedConnection : DelegatedConnection
+        {
+            public IList<Exception> ErrorList { get; } = new List<Exception>();
+
+            public TestDelegatedConnection(IConnection connection) : base(connection)
+            {
+            }
+
+            public override void OnError(Exception error)
+            {
+                ErrorList.Add(error);
+                throw error;
+            }
+        }
+
+        public class TaskWithErrrorHandlingMethod
+        {
+            private static async Task FaultedTask()
+            {
+                // as it is marked with async, therefore the result will be wrapped in task
+                throw new InvalidOperationException("Molly ate too much today!");
+            }
+
+            private static Task FaultedOutsideTask()
+            {
+                // Though this method return is a task, but this error throws before return a task
+                // Therefore there is no task created in this method
+                throw new InvalidOperationException("Molly ate too much today!");
+            }
+
+            [Fact]
+            public async void ShouldHandleBaseErrorForFaultedTask()
+            {
+                var connMock = new Mock<IConnection>();
+                var conn = new TestDelegatedConnection(connMock.Object);
+
+                await Record.ExceptionAsync(()=>conn.TaskWithErrorHandling(FaultedTask));
+
+                conn.ErrorList.Count.Should().Be(1);
+                conn.ErrorList[0].Should().BeOfType<InvalidOperationException>();
+                conn.ErrorList[0].Message.Should().Be("Molly ate too much today!");
+            }
+
+            [Fact]
+            public async void ShouldHandleBaseErrorForFaultedOutsideTask()
+            {
+                var connMock = new Mock<IConnection>();
+                var conn = new TestDelegatedConnection(connMock.Object);
+
+                FaultedTask().IsFaulted.Should().BeTrue();
+                await Record.ExceptionAsync(()=>conn.TaskWithErrorHandling(FaultedOutsideTask));
+
+                conn.ErrorList.Count.Should().Be(1);
+                conn.ErrorList[0].Should().BeOfType<InvalidOperationException>();
+                conn.ErrorList[0].Message.Should().Be("Molly ate too much today!");
+            }
+
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MockedMessagingClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MockedMessagingClient.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) 2002-2017 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.Connector;
+using Neo4j.Driver.Internal.Messaging;
+using Neo4j.Driver.V1;
+
+namespace Neo4j.Driver.Tests.Routing
+{
+    /// <summary>
+    /// If you want to create a connection with full control of what messages to send and what messages to receive,
+    /// you will find this mocked client very useful.
+    /// This client provides a clear cut from encoding/decoding messages and writing/reading from a real socket.
+    /// Instead, you talk messages directly. 
+    /// When creating a mocked client, you provide what you expect this client to send and what you want the server to response.
+    /// When sending a request message via this client, it verifies that the message to send is the same as expected.
+    /// Then when the driver wants to consume a response from the server, the response message specified at the initialization will be replied in order.
+    /// </summary>
+    internal class MockedMessagingClient
+    {
+        private readonly IList<IRequestMessage> _requestMessages = new List<IRequestMessage>();
+        private int _requestCount;
+        private readonly IList<IResponseMessage> _responseMessages = new List<IResponseMessage>();
+        private int _responseCount;
+
+        public IList<IRequestMessage> SendMessages => new List<IRequestMessage>(_requestMessages);
+        public IList<IResponseMessage> ReceiveMessages => new List<IResponseMessage>(_responseMessages);
+
+        public Mock<ISocketClient> ClientMock { get; }
+        public ISocketClient Client => ClientMock.Object;
+
+        /// <summary>
+        /// Create a mocked client for testing
+        /// </summary>
+        /// <param name="requestAndResponsePairs">
+        /// The is no one-to-one mapping in the request and response pair.
+        /// Only the order of request messages (and/or response messages) that really matters.
+        /// However it is suggested to have client request message and the expected server response message matched in a pair to make it easier to read in code.
+        /// In case of no matched value for a request (or receive) message, use <c>null</c> as a place holder.
+        /// </param>
+        /// <param name="clientMock">Set this parameter if you want to pass in the mocked client yourself.</param>
+        public MockedMessagingClient(IList<Tuple<IRequestMessage, IResponseMessage>> requestAndResponsePairs,
+            Mock<ISocketClient> clientMock = null)
+        {
+            foreach (var pair in requestAndResponsePairs)
+            {
+                if (pair.Item1 != null)
+                {
+                    _requestMessages.Add(pair.Item1);
+
+                }
+                if (pair.Item2 != null)
+                {
+                    _responseMessages.Add(pair.Item2);
+                }
+            }
+
+            ClientMock = clientMock ?? new Mock<ISocketClient>();
+            ClientMock.Setup(x => x.Send(It.IsAny<IEnumerable<IRequestMessage>>()))
+                .Callback<IEnumerable<IRequestMessage>>(msg =>
+                {
+                    foreach (var m in msg)
+                    {
+                        m.ToString().Should().Be(_requestMessages[_requestCount].ToString());
+                        _requestCount++;
+                    }
+                });
+
+            ClientMock.Setup(x => x.ReceiveOne(It.IsAny<IMessageResponseHandler>()))
+                .Callback<IMessageResponseHandler>(handler =>
+                {
+                    if (_responseCount < _responseMessages.Count)
+                    {
+                        _responseMessages[_responseCount].Dispatch(handler);
+                        _responseCount++;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Not enough response message to provide");
+                    }
+
+                });
+            ClientMock.Setup(x => x.IsOpen).Returns(() => _responseCount < _responseMessages.Count);
+        }
+
+        internal static InitMessage InitMessage(IAuthToken auth = null)
+        {
+            auth = auth ?? AuthTokens.None;
+            return new InitMessage(ConnectionSettings.DefaultUserAgent, auth.AsDictionary());
+        }
+
+        internal static SuccessMessage SuccessMessage(IList<object> fileds = null)
+        {
+            return fileds == null
+                ? new SuccessMessage(new Dictionary<string, object>())
+                : new SuccessMessage(new Dictionary<string, object> {{"fields", fileds}});
+        }
+
+        internal static PullAllMessage PullAllMessage()
+        {
+            return new PullAllMessage();
+        }
+
+        internal static Tuple<IRequestMessage, IResponseMessage> MessagePair(IRequestMessage request,
+            IResponseMessage response)
+        {
+            return new Tuple<IRequestMessage, IResponseMessage>(request, response);
+        }
+
+        internal static Tuple<IRequestMessage, IResponseMessage> MessagePair(IResponseMessage response)
+        {
+            return MessagePair(null, response);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -254,11 +254,6 @@ namespace Neo4j.Driver.Tests
                     _messageHandler.EnqueueMessage(requestMessage, responseCollector);
                 }
 
-                public void Clear()
-                {
-                    throw new NotImplementedException();
-                }
-
                 public int UnhandledMessageSize => _messageHandler.UnhandledMessageSize;
                 public IMessageResponseCollector CurrentResponseCollector => _messageHandler.CurrentResponseCollector;
 
@@ -266,8 +261,8 @@ namespace Neo4j.Driver.Tests
 
                 public Neo4jException Error
                 {
-                    get { return _messageHandler.Error; }
-                    set { _messageHandler.Error = value; }
+                    get => _messageHandler.Error;
+                    set => _messageHandler.Error = value;
                 }
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -103,6 +103,8 @@
     <Compile Include="AuthTokenTests.cs" />
     <Compile Include="BookmarkTests.cs" />
     <Compile Include="ConnectionValidatorTests.cs" />
+    <Compile Include="Connector\DelegatedConnectionTests.cs" />
+    <Compile Include="Connector\MockedMessagingClient.cs" />
     <Compile Include="Connector\TcpSocketClientTests.cs" />
     <Compile Include="IO\BoltReaderTests.cs" />
     <Compile Include="IO\BoltWriterTests.cs" />

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryManagerTests.cs
@@ -28,6 +28,7 @@ using Neo4j.Driver.Internal.Result;
 using Neo4j.Driver.Internal.Routing;
 using Neo4j.Driver.V1;
 using Xunit;
+using static Neo4j.Driver.Tests.Routing.MockedMessagingClient;
 using Record = Xunit.Record;
 
 namespace Neo4j.Driver.Tests.Routing
@@ -303,35 +304,6 @@ namespace Neo4j.Driver.Tests.Routing
             }
         }
 
-        internal static InitMessage InitMessage(IAuthToken auth = null)
-        {
-            auth = auth ?? AuthTokens.None;
-            return new InitMessage(ConnectionSettings.DefaultUserAgent, auth.AsDictionary());
-        }
-
-        internal static SuccessMessage SuccessMessage(IList<object> fileds = null)
-        {
-            return fileds == null
-                ? new SuccessMessage(new Dictionary<string, object>())
-                : new SuccessMessage(new Dictionary<string, object> {{"fields", fileds}});
-        }
-
-        internal static PullAllMessage PullAllMessage()
-        {
-            return new PullAllMessage();
-        }
-
-        internal static Tuple<IRequestMessage, IResponseMessage> MessagePair(IRequestMessage request,
-            IResponseMessage response)
-        {
-            return new Tuple<IRequestMessage, IResponseMessage>(request, response);
-        }
-
-        internal static Tuple<IRequestMessage, IResponseMessage> MessagePair(IResponseMessage response)
-        {
-            return MessagePair(null, response);
-        }
-
         internal static object[] CreateGetServersResponseRecordFields(int routerCount, int writerCount, int readerCount)
         {
             return new object[]
@@ -414,83 +386,6 @@ namespace Neo4j.Driver.Tests.Routing
             var conn = SocketConnectionTests.NewSocketConnection(mock.Client);
             conn.Init();
             return conn;
-        }
-    }
-
-    /// <summary>
-    /// If you want to create a connection with full control of what messages to send and what messages to receive,
-    /// you will find this mocked client very useful.
-    /// This client provides a clear cut from encoding/decoding messages and writing/reading from a real socket.
-    /// Instead, you talk messages directly. 
-    /// When creating a mocked client, you provide what you expect this client to send and what you want the server to response.
-    /// When sending a request message via this client, it verifies that the message to send is the same as expected.
-    /// Then when the driver wants to consume a response from the server, the response message specified at the initialization will be replied in order.
-    /// </summary>
-    internal class MockedMessagingClient
-    {
-        private readonly IList<IRequestMessage> _requestMessages = new List<IRequestMessage>();
-        private int _requestCount;
-        private readonly IList<IResponseMessage> _responseMessages = new List<IResponseMessage>();
-        private int _responseCount;
-
-        public IList<IRequestMessage> SendMessages => new List<IRequestMessage>(_requestMessages);
-        public IList<IResponseMessage> ReceiveMessages => new List<IResponseMessage>(_responseMessages);
-
-        public Mock<ISocketClient> ClientMock { get; }
-        public ISocketClient Client => ClientMock.Object;
-
-        /// <summary>
-        /// Create a mocked client for testing
-        /// </summary>
-        /// <param name="requestAndResponsePairs">
-        /// The is no one-to-one mapping in the request and response pair.
-        /// Only the order of request messages (and/or response messages) that really matters.
-        /// However it is suggested to have client request message and the expected server response message matched in a pair to make it easier to read in code.
-        /// In case of no matched value for a request (or receive) message, use <c>null</c> as a place holder.
-        /// </param>
-        /// <param name="clientMock">Set this parameter if you want to pass in the mocked client yourself.</param>
-        public MockedMessagingClient(IList<Tuple<IRequestMessage, IResponseMessage>> requestAndResponsePairs,
-            Mock<ISocketClient> clientMock = null)
-        {
-            foreach (var pair in requestAndResponsePairs)
-            {
-                if (pair.Item1 != null)
-                {
-                    _requestMessages.Add(pair.Item1);
-
-                }
-                if (pair.Item2 != null)
-                {
-                    _responseMessages.Add(pair.Item2);
-                }
-            }
-
-            ClientMock = clientMock ?? new Mock<ISocketClient>();
-            ClientMock.Setup(x => x.Send(It.IsAny<IEnumerable<IRequestMessage>>()))
-                .Callback<IEnumerable<IRequestMessage>>(msg =>
-                {
-                    foreach (var m in msg)
-                    {
-                        m.ToString().Should().Be(_requestMessages[_requestCount].ToString());
-                        _requestCount++;
-                    }
-                });
-
-            ClientMock.Setup(x => x.ReceiveOne(It.IsAny<IMessageResponseHandler>()))
-                .Callback<IMessageResponseHandler>(handler =>
-                {
-                    if (_responseCount < _responseMessages.Count)
-                    {
-                        _responseMessages[_responseCount].Dispatch(handler);
-                        _responseCount++;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException("Not enough response message to provide");
-                    }
-
-                });
-            ClientMock.Setup(x => x.IsOpen).Returns(() => _responseCount < _responseMessages.Count);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
@@ -137,16 +137,7 @@ namespace Neo4j.Driver.Tests
         public static Mock<Stream> CreateWriteStreamMock(Mock<ITcpSocketClient> mock)
         {
             var mockedStream = new Mock<Stream>();
-
-            //mockedStream.Setup(x => x.Seek(It.IsAny<long>(), It.IsAny<SeekOrigin>())).CallBase();
             mockedStream.Setup(x => x.CanWrite).Returns(true);
-            //mockedStream.Setup(x => x.CanWrite).CallBase();
-            //mockedStream.Setup(x => x.Length).CallBase();
-            //mockedStream.Setup(x => x.Position).CallBase();
-            //mockedStream.Setup(x => x.NextByte()).CallBase();
-            //mockedStream.Setup(x => x.ToArray()).CallBase();
-            //mockedStream.Setup(x => x.Read(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>())).CallBase();
-
             mock.Setup(c => c.WriteStream).Returns(mockedStream.Object);
 
             return mockedStream;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/CollectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/CollectionExtensions.cs
@@ -55,10 +55,10 @@ namespace Neo4j.Driver.Internal
             return $"[{string.Join(", ", output)}]";
         }
 
-        public static string ToContentString<K>(this IEnumerable<K> enumerable)
+        public static string ToContentString<K>(this IEnumerable<K> enumerable, string separator = ", ")
         {
             var output = enumerable.Select(item => $"{item}");
-            return $"[{string.Join(", ", output)}]";
+            return $"[{string.Join(separator, output)}]";
         }
 
         public static string ValueToString(this object o)


### PR DESCRIPTION
Fix the bug where an error was handled as `AggregateException` rather than the original error in Connections

Clean up some unreached code