### PR TITLE
Do not purge inUse connections

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -1362,7 +1362,7 @@ namespace Neo4j.Driver.Tests
             }
         }
 
-        public class DeactiviateMethod
+        public class DeactivateMethod
         {
             private static List<Mock<IPooledConnection>> FillIdleConnections(
                 BlockingCollection<IPooledConnection> idleConnections, int count)
@@ -1443,7 +1443,7 @@ namespace Neo4j.Driver.Tests
             // concurrent test
             // concurrently close and deactive
             [Fact]
-            public void DeactiviateAndThenCloseShouldCloseAllConnections()
+            public void DeactivateAndThenCloseShouldCloseAllConnections()
             {
                 var idleConnections = new BlockingCollection<IPooledConnection>();
                 var idleMocks = FillIdleConnections(idleConnections, 5);
@@ -1486,7 +1486,7 @@ namespace Neo4j.Driver.Tests
                 pool.NumberOfInUseConnections.Should().Be(0);
 
                 // This is to simulate Acquire called first,
-                // but before Acquire put a new conn into inUseConn, Deactiviate get called.
+                // but before Acquire put a new conn into inUseConn, Deactivate get called.
                 openConnMock.Setup(x => x.IsOpen).Returns(true)
                     .Callback(() => pool.Deactivate());
                 idleConnections.Add(openConnMock.Object);
@@ -1511,7 +1511,7 @@ namespace Neo4j.Driver.Tests
                 pool.NumberOfInUseConnections.Should().Be(0);
 
                 // This is to simulate Acquire called first,
-                // but before Acquire put a new conn into inUseConn, Deactiviate get called.
+                // but before Acquire put a new conn into inUseConn, Deactivate get called.
                 // However here, this connection is not healthy and will be destoried directly
                 closedConnMock.Setup(x => x.IsOpen).Returns(false)
                     .Callback(() => pool.Deactivate());

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -546,7 +546,8 @@ namespace Neo4j.Driver.Tests
                     pool.Acquire();
                 }
 
-                var stopWatch = new Stopwatch(); stopWatch.Start();
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
 
                 var exception = await Record.ExceptionAsync(() => pool.AcquireAsync(AccessMode.Read));
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -1182,17 +1182,17 @@ namespace Neo4j.Driver.Tests
 
         public class PoolState
         {
-            // open
+            // active
             [Fact]
-            public void FromOpenViaAcquireToOpen()
+            public void FromActiveViaAcquireToActive()
             {
                 var pool = NewConnectionPool();
                 pool.Acquire();
-                pool.Status.Should().Be(PoolStatus.Open);
+                pool.Status.Should().Be(PoolStatus.Active);
             }
 
             [Fact]
-            public void FromOpenViaReleaseToOpen()
+            public void FromActiveViaReleaseToActive()
             {
                 var idleQueue = new BlockingCollection<IPooledConnection>();
                 var inUseConnections = new ConcurrentSet<IPooledConnection>();
@@ -1204,11 +1204,11 @@ namespace Neo4j.Driver.Tests
 
                 idleQueue.Count.Should().Be(1);
                 inUseConnections.Count.Should().Be(0);
-                pool.Status.Should().Be(PoolStatus.Open);
+                pool.Status.Should().Be(PoolStatus.Active);
             }
 
             [Fact]
-            public void FromOpenViaDisposeToClosed()
+            public void FromActiveViaDisposeToClosed()
             {
                 var pool = NewConnectionPool();
                 pool.Dispose();
@@ -1216,36 +1216,36 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void FromOpenViaActivateToOpen()
+            public void FromActiveViaActivateToActive()
             {
                 var pool = NewConnectionPool();
                 pool.Activate();
-                pool.Status.Should().Be(PoolStatus.Open);
+                pool.Status.Should().Be(PoolStatus.Active);
             }
 
             [Fact]
-            public void FromOpenViaDeactiateToZombie()
+            public void FromActiveViaDeactiateToInactive()
             {
                 var pool = NewConnectionPool();
                 pool.Deactivate();
-                pool.Status.Should().Be(PoolStatus.Zombie);
+                pool.Status.Should().Be(PoolStatus.Inactive);
             }
 
-            // zombie
+            // inactive
             [Fact]
-            public void FromZombieViaAcquireThrowsError()
+            public void FromInactiveViaAcquireThrowsError()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Zombie;
+                pool.Status = PoolStatus.Inactive;
 
                 var exception = Record.Exception(()=>pool.Acquire());
 
                 exception.Should().BeOfType<ClientException>();
-                pool.Status.Should().Be(PoolStatus.Zombie);
+                pool.Status.Should().Be(PoolStatus.Inactive);
             }
 
             [Fact]
-            public void FromZombieViaReleaseToZombie()
+            public void FromInactiveViaReleaseToInactive()
             {
                 var idleQueue = new BlockingCollection<IPooledConnection>();
                 var inUseConnections = new ConcurrentSet<IPooledConnection>();
@@ -1254,20 +1254,20 @@ namespace Neo4j.Driver.Tests
                 inUseConnections.TryAdd(conn);
 
                 var pool = NewConnectionPool(idleQueue, inUseConnections);
-                pool.Status = PoolStatus.Zombie;
+                pool.Status = PoolStatus.Inactive;
 
                 pool.Release(conn);
 
                 inUseConnections.Count.Should().Be(0);
                 idleQueue.Count.Should().Be(0);
-                pool.Status.Should().Be(PoolStatus.Zombie);
+                pool.Status.Should().Be(PoolStatus.Inactive);
             }
 
             [Fact]
-            public void FromZombieViaDisposeToClosed()
+            public void FromInactiveViaDisposeToClosed()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Zombie;
+                pool.Status = PoolStatus.Inactive;
 
                 pool.Dispose();
 
@@ -1275,25 +1275,25 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void FromZombieViaActivateToOpen()
+            public void FromInactiveViaActivateToActive()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Zombie;
+                pool.Status = PoolStatus.Inactive;
 
                 pool.Activate();
 
-                pool.Status.Should().Be(PoolStatus.Open);
+                pool.Status.Should().Be(PoolStatus.Active);
             }
 
             [Fact]
-            public void FromZombieViaDeactiateToZombie()
+            public void FromInactiveViaDeactiateToInactive()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Zombie;
+                pool.Status = PoolStatus.Inactive;
 
                 pool.Deactivate();
 
-                pool.Status.Should().Be(PoolStatus.Zombie);
+                pool.Status.Should().Be(PoolStatus.Inactive);
             }
 
             //closed

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -1475,7 +1475,7 @@ namespace Neo4j.Driver.Tests
             // cncurrent tests
             // ConcurrentlyAcquireAndDeactivate
             [Fact]
-            public void ReturnConnectionIfAcquiredValidConnectionBeforeZombified()
+            public void ReturnConnectionIfAcquiredValidConnectionBeforeInactivation()
             {
                 // Given
                 var idleConnections = new BlockingCollection<IPooledConnection>();
@@ -1500,7 +1500,7 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void ErrorIfAcquiredInvalidConnectionBeforeZombified()
+            public void ErrorIfAcquiredInvalidConnectionBeforeInactivation()
             {
                 // Given
                 var idleConnections = new BlockingCollection<IPooledConnection>();
@@ -1524,8 +1524,8 @@ namespace Neo4j.Driver.Tests
                 pool.NumberOfInUseConnections.Should().Be(0);
                 closedConnMock.Verify(x => x.IsOpen, Times.Once);
                 closedConnMock.Verify(x => x.Destroy(), Times.Once);
-                exception.Should().BeOfType<ObjectDisposedException>();
-                exception.Message.Should().StartWith("Failed to acquire a new connection");
+                exception.Should().BeOfType<ClientException>();
+                exception.Message.Should().StartWith("Failed to acquire a connection");
             }
 
             // concurrent test

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -1240,7 +1240,7 @@ namespace Neo4j.Driver.Tests
 
                 var exception = Record.Exception(()=>pool.Acquire());
 
-                exception.Should().BeOfType<ObjectDisposedException>();
+                exception.Should().BeOfType<ClientException>();
                 pool.Status.Should().Be(PoolStatus.Zombie);
             }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
@@ -180,12 +180,12 @@ namespace Neo4j.Driver.Tests.Routing
                 pool.Update(new Uri[0], new[] {ServerUri});
 
                 // Then
-                mockedConnectionPool.Verify(x => x.Deactivate(), Times.Once); // first deactiviate then remove
+                mockedConnectionPool.Verify(x => x.Deactivate(), Times.Once); // first deactivate then remove
                 connectionPoolDict.Count.Should().Be(0);
             }
 
             [Fact]
-            public void ShouldDeactiviateServerPoolIfNotPresentInNewServersButHasInUseConnections()
+            public void ShouldDeactivateServerPoolIfNotPresentInNewServersButHasInUseConnections()
             {
                 // Given
                 var mockedConnectionPool = new Mock<IConnectionPool>();
@@ -206,7 +206,7 @@ namespace Neo4j.Driver.Tests.Routing
         public class AddMethod
         {
             [Fact]
-            public void ShouldActiviateIfExist()
+            public void ShouldActivateIfExist()
             {
                 // Given
                 var mockedConnectionPool = new Mock<IConnectionPool>();
@@ -243,10 +243,10 @@ namespace Neo4j.Driver.Tests.Routing
             }
         }
 
-        public class DeactiviateMethod
+        public class DeactivateMethod
         {
             [Fact]
-            public void ShouldDeactiviateIfExist()
+            public void ShouldDeactivateIfExist()
             {
                 // Given
                 var mockedConnectionPool = new Mock<IConnectionPool>();
@@ -256,7 +256,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var pool = new ClusterConnectionPool(null, connectionPoolDict);
 
                 // When
-                pool.Deactiviate(ServerUri);
+                pool.Deactivate(ServerUri);
 
                 // Then
                 mockedConnectionPool.Verify(x => x.Deactivate(), Times.Once);
@@ -265,7 +265,7 @@ namespace Neo4j.Driver.Tests.Routing
             }
 
             [Fact]
-            public void ShouldDeactiviateNothingIfNotFound()
+            public void ShouldDeactivateNothingIfNotFound()
             {
                 // Given
                 var connectionPoolDict = new ConcurrentDictionary<Uri, IConnectionPool>();
@@ -273,7 +273,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var pool = new ClusterConnectionPool(null, connectionPoolDict);
 
                 // When
-                pool.Deactiviate(ServerUri);
+                pool.Deactivate(ServerUri);
 
                 // Then
                 connectionPoolDict.Count.Should().Be(0);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
@@ -139,7 +139,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var pool = new ClusterConnectionPool(mockedConnectionPool.Object, connectionPoolDict);
 
                 // When
-                pool.Update(new[] {ServerUri});
+                pool.Update(new[] {ServerUri}, new Uri[0]);
 
                 // Then
                 connectionPoolDict.Count.Should().Be(1);
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.Tests.Routing
             }
 
             [Fact]
-            public void ShouldRemoveNewlyCreatedPoolnIfDisposeAlreadyCalled()
+            public void ShouldRemoveNewlyCreatedPoolIfDisposeAlreadyCalled()
             {
                 // Given
                 var mockedConnectionPool = new Mock<IConnectionPool>();
@@ -157,7 +157,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // When
                 pool.Dispose();
-                var exception = Record.Exception(() => pool.Update(new[] {ServerUri}));
+                var exception = Record.Exception(() => pool.Update(new[] {ServerUri}, new Uri[0]));
 
                 // Then
                 mockedConnectionPool.Verify(x => x.Close());
@@ -176,7 +176,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var pool = new ClusterConnectionPool(mockedConnectionPool.Object, connectionPoolDict);
 
                 // When
-                pool.Update(new Uri[0]);
+                pool.Update(new Uri[0], new[] {ServerUri});
 
                 // Then
                 connectionPoolDict.Count.Should().Be(0);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
@@ -44,7 +44,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var loadBalancer = new LoadBalancer(clusterPoolMock.Object, routingTableManagerMock.Object);
 
                     loadBalancer.OnConnectionError(uri, new ClientException());
-                    clusterPoolMock.Verify(x => x.Deactiviate(uri), Times.Once);
+                    clusterPoolMock.Verify(x => x.Deactivate(uri), Times.Once);
                     routingTableMock.Verify(x => x.Remove(uri), Times.Once);
                     routingTableMock.Verify(x => x.RemoveWriter(uri), Times.Never);
                 }
@@ -63,7 +63,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var loadBalancer = new LoadBalancer(clusterPoolMock.Object, routingTableManagerMock.Object);
 
                     loadBalancer.OnWriteError(uri);
-                    clusterPoolMock.Verify(x => x.Deactiviate(uri), Times.Never);
+                    clusterPoolMock.Verify(x => x.Deactivate(uri), Times.Never);
                     routingTableMock.Verify(x => x.Remove(uri), Times.Never);
                     routingTableMock.Verify(x => x.RemoveWriter(uri), Times.Once);
                 }
@@ -141,7 +141,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // should be removed
                 routingTableMock.Verify(m => m.Remove(uri), Times.Once);
-                clusterConnPoolMock.Verify(m => m.Deactiviate(uri), Times.Once);
+                clusterConnPoolMock.Verify(m => m.Deactivate(uri), Times.Once);
             }
 
             [Theory]
@@ -170,7 +170,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // while the server is not removed
                 routingTableMock.Verify(m => m.Remove(uri), Times.Never);
-                clusterConnPoolMock.Verify(m => m.Deactiviate(uri), Times.Never);
+                clusterConnPoolMock.Verify(m => m.Deactivate(uri), Times.Never);
             }
 
             [Theory]
@@ -199,7 +199,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // while the server is not removed
                 routingTableMock.Verify(m => m.Remove(uri), Times.Never);
-                clusterConnPoolMock.Verify(m => m.Deactiviate(uri), Times.Never);
+                clusterConnPoolMock.Verify(m => m.Deactivate(uri), Times.Never);
             }
 
             [Theory]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
@@ -44,7 +44,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var loadBalancer = new LoadBalancer(clusterPoolMock.Object, routingTableManagerMock.Object);
 
                     loadBalancer.OnConnectionError(uri, new ClientException());
-                    clusterPoolMock.Verify(x => x.Purge(uri), Times.Once);
+                    clusterPoolMock.Verify(x => x.Deactiviate(uri), Times.Once);
                     routingTableMock.Verify(x => x.Remove(uri), Times.Once);
                     routingTableMock.Verify(x => x.RemoveWriter(uri), Times.Never);
                 }
@@ -63,7 +63,7 @@ namespace Neo4j.Driver.Tests.Routing
                     var loadBalancer = new LoadBalancer(clusterPoolMock.Object, routingTableManagerMock.Object);
 
                     loadBalancer.OnWriteError(uri);
-                    clusterPoolMock.Verify(x => x.Purge(uri), Times.Never);
+                    clusterPoolMock.Verify(x => x.Deactiviate(uri), Times.Never);
                     routingTableMock.Verify(x => x.Remove(uri), Times.Never);
                     routingTableMock.Verify(x => x.RemoveWriter(uri), Times.Once);
                 }
@@ -141,7 +141,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // should be removed
                 routingTableMock.Verify(m => m.Remove(uri), Times.Once);
-                clusterConnPoolMock.Verify(m => m.Purge(uri), Times.Once);
+                clusterConnPoolMock.Verify(m => m.Deactiviate(uri), Times.Once);
             }
 
             [Theory]
@@ -170,7 +170,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // while the server is not removed
                 routingTableMock.Verify(m => m.Remove(uri), Times.Never);
-                clusterConnPoolMock.Verify(m => m.Purge(uri), Times.Never);
+                clusterConnPoolMock.Verify(m => m.Deactiviate(uri), Times.Never);
             }
 
             [Theory]
@@ -199,7 +199,7 @@ namespace Neo4j.Driver.Tests.Routing
 
                 // while the server is not removed
                 routingTableMock.Verify(m => m.Remove(uri), Times.Never);
-                clusterConnPoolMock.Verify(m => m.Purge(uri), Times.Never);
+                clusterConnPoolMock.Verify(m => m.Deactiviate(uri), Times.Never);
             }
 
             [Theory]

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -24,17 +24,27 @@ using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
-using static Neo4j.Driver.Internal.Throw.DriverDisposedException;
+using static Neo4j.Driver.Internal.PoolStatus;
+using static Neo4j.Driver.Internal.Throw.ObjectDisposedException;
 
 namespace Neo4j.Driver.Internal
 {
+    internal static class PoolStatus
+    {
+        public const int Open = 0;
+        public const int Closed = 1;
+        public const int Zombie = 2;
+    }
+
     internal class ConnectionPool : LoggerBase, IConnectionPool
     {
         private const int SpinningWaitInterval = 500;
 
         private readonly Uri _uri;
 
-        private int _closedMarker = 0;
+        private int _poolStatus = Open;
+        private bool IsClosed => _poolStatus == Closed;
+        private bool IsZombieOrClosed => _poolStatus != Open;
 
         private int _poolSize = 0;
         private readonly int _maxPoolSize;
@@ -45,22 +55,27 @@ namespace Neo4j.Driver.Internal
         private readonly ConnectionSettings _connectionSettings;
         private readonly BufferSettings _bufferSettings;
 
-        private readonly BlockingCollection<IPooledConnection> _availableConnections = new BlockingCollection<IPooledConnection>();
+        private readonly BlockingCollection<IPooledConnection> _idleConnections = new BlockingCollection<IPooledConnection>();
         private readonly ConcurrentSet<IPooledConnection> _inUseConnections = new ConcurrentSet<IPooledConnection>();
-
-        // for test only
-        private readonly IConnection _fakeConnection;
 
         private IStatisticsCollector _statisticsCollector;
         private ConnectionPoolStatistics _statistics;
 
         public int NumberOfInUseConnections => _inUseConnections.Count;
-        internal int NumberOfAvailableConnections => _availableConnections.Count;
+        internal int NumberOfAvailableConnections => _idleConnections.Count;
         internal int PoolSize => _poolSize;
 
+        // for test only
+        private readonly IConnection _fakeConnection;
         internal bool DisposeCalled
         {
-            set => Interlocked.CompareExchange(ref _closedMarker, 1, 0);
+            set => Interlocked.Exchange(ref _poolStatus, Closed);
+        }
+
+        internal int Status
+        {
+            get => _poolStatus;
+            set => Interlocked.Exchange(ref _poolStatus, value);
         }
 
         public ConnectionPool(
@@ -97,13 +112,11 @@ namespace Neo4j.Driver.Internal
                   bufferSettings ?? new BufferSettings(Config.DefaultConfig), logger)
         {
             _fakeConnection = connection;
-            _availableConnections = availableConnections ?? new BlockingCollection<IPooledConnection>();
+            _idleConnections = availableConnections ?? new BlockingCollection<IPooledConnection>();
             _inUseConnections = inUseConnections ?? new ConcurrentSet<IPooledConnection>();
         }
 
-        private bool IsClosed => _closedMarker > 0;
-
-        public IPooledConnection CreateNewPooledConnection()
+        private IPooledConnection CreateNewPooledConnection()
         {
             PooledConnection conn = null;
             try
@@ -245,12 +258,12 @@ namespace Neo4j.Driver.Internal
                 {
                     while (true)
                     {
-                        if (IsClosed)
+                        if (IsZombieOrClosed)
                         {
                             ThrowObjectDisposedException();
                         }
 
-                        if (!_availableConnections.TryTake(out connection))
+                        if (!_idleConnections.TryTake(out connection))
                         {
                             do
                             {
@@ -263,7 +276,7 @@ namespace Neo4j.Driver.Internal
                                     }
                                 }
 
-                                if (_availableConnections.TryTake(out connection, SpinningWaitInterval, cancellationToken))
+                                if (_idleConnections.TryTake(out connection, SpinningWaitInterval, cancellationToken))
                                 {
                                     break;
                                 }
@@ -289,7 +302,7 @@ namespace Neo4j.Driver.Internal
                     }
 
                     _inUseConnections.TryAdd(connection);
-                    if (IsClosed)
+                    if (IsZombieOrClosed)
                     {
                         if (_inUseConnections.TryRemove(connection))
                         {
@@ -331,12 +344,12 @@ namespace Neo4j.Driver.Internal
                 {
                     while (true)
                     {
-                        if (IsClosed)
+                        if (IsZombieOrClosed)
                         {
                             ThrowObjectDisposedException();
                         }
 
-                        if (!_availableConnections.TryTake(out connection))
+                        if (!_idleConnections.TryTake(out connection))
                         {
                             do
                             {
@@ -351,7 +364,7 @@ namespace Neo4j.Driver.Internal
 
                                 await Task.Delay(SpinningWaitInterval, cancellationToken).ConfigureAwait(false);
                                 
-                                if (_availableConnections.TryTake(out connection))
+                                if (_idleConnections.TryTake(out connection))
                                 {
                                     break;
                                 }
@@ -377,7 +390,7 @@ namespace Neo4j.Driver.Internal
                     }
 
                     _inUseConnections.TryAdd(connection);
-                    if (IsClosed)
+                    if (IsZombieOrClosed)
                     {
                         if (_inUseConnections.TryRemove(connection))
                         {
@@ -403,7 +416,7 @@ namespace Neo4j.Driver.Internal
 
         private bool IsIdlePoolFull()
         {
-            return _idlePoolSize != Config.Infinite && _availableConnections.Count >= _idlePoolSize;
+            return _idlePoolSize != Config.Infinite && _idleConnections.Count >= _idlePoolSize;
         }
 
         public void Release(IPooledConnection connection)
@@ -412,7 +425,7 @@ namespace Neo4j.Driver.Internal
             {
                 if (IsClosed)
                 {
-                    // pool already disposed.
+                    // pool already disposed, and this connection is also already closed
                     return;
                 }
                 if (!_inUseConnections.TryRemove(connection))
@@ -428,11 +441,11 @@ namespace Neo4j.Driver.Internal
                     }
                     else
                     {
-                        _availableConnections.Add(connection);
+                        _idleConnections.Add(connection);
                     }
 
                     // Just dequeue any one connection and close it will ensure that all connections in the pool will finally be closed
-                    if (IsClosed && _availableConnections.TryTake(out connection))
+                    if (IsZombieOrClosed && _idleConnections.TryTake(out connection))
                     {
                         DestroyConnection(connection);
                     }
@@ -468,11 +481,11 @@ namespace Neo4j.Driver.Internal
                     }
                     else
                     {
-                        _availableConnections.Add(connection);
+                        _idleConnections.Add(connection);
                     }
 
                     // Just dequeue any one connection and close it will ensure that all connections in the pool will finally be closed
-                    if (IsClosed && _availableConnections.TryTake(out connection))
+                    if (IsZombieOrClosed && _idleConnections.TryTake(out connection))
                     {
                         await DestroyConnectionAsync(connection).ConfigureAwait(false);
                     }
@@ -502,7 +515,7 @@ namespace Neo4j.Driver.Internal
 
         public void Close()
         {
-            if (Interlocked.CompareExchange(ref _closedMarker, 1, 0) == 0)
+            if (Interlocked.Exchange(ref _poolStatus, Closed) != Closed)
             {
                 TryExecute(() =>
                 {
@@ -515,12 +528,7 @@ namespace Neo4j.Driver.Internal
                         }
                     }
 
-                    while (_availableConnections.TryTake(out var connection))
-                    {
-                        Logger?.Debug($"Disposing Available Connection {connection.Id}");
-                        DestroyConnection(connection);
-                    }
-
+                    TerminateIdleConnections();
                     DisposeStatisticsProvider();
                 });
             }
@@ -528,7 +536,7 @@ namespace Neo4j.Driver.Internal
 
         public Task CloseAsync()
         {
-            if (Interlocked.CompareExchange(ref _closedMarker, 1, 0) == 0)
+            if (Interlocked.Exchange(ref _poolStatus, Closed) != Closed)
             {
                 var allCloseTasks = new List<Task>();
 
@@ -541,12 +549,7 @@ namespace Neo4j.Driver.Internal
                     }
                 }
 
-                while (_availableConnections.TryTake(out var connection))
-                {
-                    Logger?.Debug($"Disposing Available Connection {connection.Id}");
-                    allCloseTasks.Add(DestroyConnectionAsync(connection));
-                }
-
+                allCloseTasks.AddRange(TerminateIdleConnectionsAsync());
                 DisposeStatisticsProvider();
 
                 return Task.WhenAll(allCloseTasks);
@@ -555,9 +558,51 @@ namespace Neo4j.Driver.Internal
             return TaskExtensions.GetCompletedTask();
         }
 
+        public void Deactivate()
+        {
+            if (Interlocked.CompareExchange(ref _poolStatus, Zombie, Open) == Open)
+            {
+                TerminateIdleConnections();
+            }
+        }
+
+        public Task DeactivateAsync()
+        {
+            if (Interlocked.CompareExchange(ref _poolStatus, Zombie, Open) == Open)
+            {
+                return Task.WhenAll(TerminateIdleConnectionsAsync());
+            }
+            return TaskExtensions.GetCompletedTask();
+        }
+
+        public void Active()
+        {
+            Interlocked.CompareExchange(ref _poolStatus, Open, Zombie);
+        }
+
+        private void TerminateIdleConnections()
+        {
+            while (_idleConnections.TryTake(out var connection))
+            {
+                Logger?.Debug($"Disposing Available Connection {connection.Id}");
+                DestroyConnection(connection);
+            }
+        }
+
+        private IEnumerable<Task> TerminateIdleConnectionsAsync()
+        {
+            var allCloseTasks = new List<Task>();
+            while (_idleConnections.TryTake(out var connection))
+            {
+                Logger?.Debug($"Disposing Available Connection {connection.Id}");
+                allCloseTasks.Add(DestroyConnectionAsync(connection));
+            }
+            return allCloseTasks;
+        }
+
         private void ThrowObjectDisposedException()
         {
-            FailedToCreateConnection(this);
+            FailedToAcquireConnectionDueToPoolClosed(this);
         }
 
         private void SetupStatisticsProvider(IStatisticsCollector collector)
@@ -581,7 +626,7 @@ namespace Neo4j.Driver.Internal
 
         public override string ToString()
         {
-            return $"{nameof(_availableConnections)}: {{{_availableConnections.ValueToString()}}}, " +
+            return $"{nameof(_idleConnections)}: {{{_idleConnections.ValueToString()}}}, " +
                    $"{nameof(_inUseConnections)}: {{{_inUseConnections}}}";
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -606,7 +606,7 @@ namespace Neo4j.Driver.Internal
         private void ThrowClientExceptionDueToZombified()
         {
             throw new ClientException(
-                $"Failed to obtain a connection from connection pool for server with URI `{_uri}` " +
+                $"Failed to acquire a connection from connection pool for server with URI `{_uri}` " +
                 "as this server has already been removed from routing table. " +
                 "Please retry your statement again and you should be routed with a different server from the new routing table. " +
                 "You should not see this error persistenly.");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolStatistics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolStatistics.cs
@@ -8,7 +8,7 @@ namespace Neo4j.Driver.Internal
     internal class ConnectionPoolStatistics : IStatisticsProvider, IDisposable
     {
         public int InUseConns => _pool?.NumberOfInUseConnections ?? _inUseConns;
-        public int AvailableConns => _pool?.NumberOfAvailableConnections ?? _availableConns;
+        public int AvailableConns => _pool?.NumberOfIdleConnections ?? _availableConns;
         public long ConnCreated => _connCreated;
         public long ConnClosed => _connClosed;
         public long ConnToCreate => _connToCreate;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionValidator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionValidator.cs
@@ -3,7 +3,14 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal
 {
-    internal class ConnectionValidator
+    internal interface IConnectionValidator
+    {
+        bool IsConnectionReusable(IPooledConnection connection);
+        Task<bool> IsConnectionReusableAsync(IPooledConnection connection);
+        bool IsValid(IPooledConnection connection);
+    }
+
+    internal class ConnectionValidator : IConnectionValidator
     {
         private readonly TimeSpan _connIdleTimeout;
         private readonly TimeSpan _maxConnLifetime;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/Throw.cs
@@ -20,11 +20,17 @@ namespace Neo4j.Driver.Internal
 {
     internal static class Throw
     {
-        public static class DriverDisposedException
+        public static class ObjectDisposedException
         {
-            public static void FailedToCreateConnection(object obj)
+            public static void FailedToAcquireConnectionDueToPoolClosed(object obj)
             {
-                throw new ObjectDisposedException(obj.GetType().Name, "Failed to acquire a new connection as the driver has already been disposed.");
+                throw new System.ObjectDisposedException(obj.GetType().Name, $"Failed to acquire a new connection as the driver has already been disposed.");
+            }
+
+
+            public static void FailedToAcquireConnection(object obj)
+            {
+                throw new System.ObjectDisposedException(obj.GetType().Name, $"Failed to acquire a new connection as the driver has already been disposed.");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
@@ -21,6 +21,6 @@ namespace Neo4j.Driver.Internal
     {
         int NumberOfInUseConnections { get; }
         void Deactivate();
-        void Active();
+        void Activate();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
@@ -20,5 +20,7 @@ namespace Neo4j.Driver.Internal
     internal interface IConnectionPool : IConnectionProvider, IConnectionReleaseManager
     {
         int NumberOfInUseConnections { get; }
+        void Deactivate();
+        void Active();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
@@ -15,12 +15,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading.Tasks;
+
 namespace Neo4j.Driver.Internal
 {
     internal interface IConnectionPool : IConnectionProvider, IConnectionReleaseManager
     {
         int NumberOfInUseConnections { get; }
         void Deactivate();
+        Task DeactivateAsync();
         void Activate();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -71,11 +71,6 @@ namespace Neo4j.Driver.Internal.Routing
 
         private bool IsClosed => _closedMarker > 0;
 
-        private IConnectionPool CreateNewConnectionPool(Uri uri)
-        {
-            return _fakePool ?? new ConnectionPool(uri, _connectionSettings, _poolSettings, _bufferSettings, Logger);
-        }
-
         public IConnection Acquire(Uri uri)
         {
             if (!_pools.TryGetValue(uri, out var pool))
@@ -98,31 +93,33 @@ namespace Neo4j.Driver.Internal.Routing
             return pool.AcquireAsync(ignored);
         }
 
-        // This is the ultimate method to add a pool
-        private void Add(Uri uri)
+        public void Add(IEnumerable<Uri> servers)
         {
-            _pools.GetOrAdd(uri, CreateNewConnectionPool);
+            foreach (var uri in servers)
+            {
+                _pools.AddOrUpdate(uri, CreateNewConnectionPool, ActivateConnectionPool);
+            }
             if (IsClosed)
             {
                 // Anything added after dispose should be directly cleaned.
                 Clear();
                 throw new ObjectDisposedException(GetType().Name,
-                    $"Failed to create connections with server {uri} as the driver has already started to dispose.");
+                    $"Failed to create connections with servers {servers.ToContentString()} as the driver has already started to dispose.");
             }
         }
 
-        public void Add(IEnumerable<Uri> servers)
+        public async Task AddAsync(IEnumerable<Uri> servers)
         {
             foreach (var uri in servers)
             {
-                if (_pools.ContainsKey(uri))
-                {
-                    _pools[uri].Activate();
-                }
-                else
-                {
-                    Add(uri);
-                }
+                _pools.AddOrUpdate(uri, CreateNewConnectionPool, ActivateConnectionPool);
+            }
+            if (IsClosed)
+            {
+                // Anything added after dispose should be directly cleaned.
+                await ClearAsync().ConfigureAwait(false);
+                throw new ObjectDisposedException(GetType().Name,
+                    $"Failed to create connections with servers {servers.ToContentString()} as the driver has already started to dispose.");
             }
         }
 
@@ -131,24 +128,30 @@ namespace Neo4j.Driver.Internal.Routing
             Add(added);
             foreach (var uri in removed)
             {
-                _pools[uri].Deactivate();
-                if (_pools[uri].NumberOfInUseConnections == 0)
+                if (_pools.TryGetValue(uri, out var pool))
                 {
-                    Purge(uri);
+                    pool.Deactivate();
+                    if (pool.NumberOfInUseConnections == 0)
+                    {
+                        Purge(uri);
+                    }
                 }
             }
         }
 
         public async Task UpdateAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed)
         {
-            Add(added);
+            await AddAsync(added).ConfigureAwait(false);
             // TODO chain this part and use task.waitAll
             foreach (var uri in removed)
             {
-                await _pools[uri].DeactivateAsync().ConfigureAwait(false);
-                if (_pools[uri].NumberOfInUseConnections == 0)
+                if (_pools.TryGetValue(uri, out var pool))
                 {
-                    await PurgeAsync(uri).ConfigureAwait(false);
+                    await pool.DeactivateAsync().ConfigureAwait(false);
+                    if (pool.NumberOfInUseConnections == 0)
+                    {
+                        await PurgeAsync(uri).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -170,26 +173,6 @@ namespace Neo4j.Driver.Internal.Routing
             return TaskExtensions.GetCompletedTask();
         }
 
-        private void Purge(Uri uri)
-        {
-            var removed = _pools.TryRemove(uri, out var toRemove);
-            if (removed)
-            {
-                toRemove.Close();
-            }
-        }
-
-        private Task PurgeAsync(Uri uri)
-        {
-            var removed = _pools.TryRemove(uri, out var toRemove);
-            if (removed)
-            {
-                return toRemove.CloseAsync();
-            }
-
-            return TaskExtensions.GetCompletedTask();
-        }
-
         public int NumberOfInUseConnections(Uri uri)
         {
             if (_pools.TryGetValue(uri, out var pool))
@@ -197,6 +180,24 @@ namespace Neo4j.Driver.Internal.Routing
                 return pool.NumberOfInUseConnections;
             }
             return 0;
+        }
+
+        public void Close()
+        {
+            if (Interlocked.CompareExchange(ref _closedMarker, 1, 0) == 0)
+            {
+                Clear();
+            }
+        }
+
+        public Task CloseAsync()
+        {
+            if (Interlocked.CompareExchange(ref _closedMarker, 1, 0) == 0)
+            {
+                return ClearAsync();
+            }
+
+            return TaskExtensions.GetCompletedTask();
         }
 
         private void Clear()
@@ -221,19 +222,21 @@ namespace Neo4j.Driver.Internal.Routing
             return Task.WhenAll(clearTasks);
         }
 
-        public void Close()
+        private void Purge(Uri uri)
         {
-            if (Interlocked.CompareExchange(ref _closedMarker, 1, 0) == 0)
+            var removed = _pools.TryRemove(uri, out var toRemove);
+            if (removed)
             {
-                Clear();
+                toRemove.Close();
             }
         }
 
-        public Task CloseAsync()
+        private Task PurgeAsync(Uri uri)
         {
-            if (Interlocked.CompareExchange(ref _closedMarker, 1, 0) == 0)
+            var removed = _pools.TryRemove(uri, out var toRemove);
+            if (removed)
             {
-                return ClearAsync();
+                return toRemove.CloseAsync();
             }
 
             return TaskExtensions.GetCompletedTask();
@@ -255,6 +258,17 @@ namespace Neo4j.Driver.Internal.Routing
         public override string ToString()
         {
             return _pools.ValueToString();
+        }
+
+        private IConnectionPool CreateNewConnectionPool(Uri uri)
+        {
+            return _fakePool ?? new ConnectionPool(uri, _connectionSettings, _poolSettings, _bufferSettings, Logger);
+        }
+
+        private IConnectionPool ActivateConnectionPool(Uri uri, IConnectionPool pool)
+        {
+            pool.Activate();
+            return pool;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -153,7 +153,7 @@ namespace Neo4j.Driver.Internal.Routing
             }
         }
 
-        public void Deactiviate(Uri uri)
+        public void Deactivate(Uri uri)
         {
             if (_pools.TryGetValue(uri, out var pool))
             {
@@ -161,7 +161,7 @@ namespace Neo4j.Driver.Internal.Routing
             }
         }
 
-        public Task DeactiviateAsync(Uri uri)
+        public Task DeactivateAsync(Uri uri)
         {
             if (_pools.TryGetValue(uri, out var pool))
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -120,16 +120,16 @@ namespace Neo4j.Driver.Internal.Routing
             }
         }
 
-        public void Update(IEnumerable<Uri> servers)
+        public void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed)
         {
             foreach (var uri in _pools.Keys)
             {
-                if (!servers.Contains(uri))
+                if (!added.Contains(uri))
                 {
                     Purge(uri);
                 }
             }
-            foreach (var uri in servers)
+            foreach (var uri in added)
             {
                 Add(uri);
             }
@@ -144,7 +144,7 @@ namespace Neo4j.Driver.Internal.Routing
             }
         }
 
-        public Task PurgeAsync(Uri uri)
+        private Task PurgeAsync(Uri uri)
         {
             var removed = _pools.TryRemove(uri, out var toRemove);
             if (removed)
@@ -157,8 +157,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         public int NumberOfInUseConnections(Uri uri)
         {
-            IConnectionPool pool;
-            if (_pools.TryGetValue(uri, out pool))
+            if (_pools.TryGetValue(uri, out var pool))
             {
                 return pool.NumberOfInUseConnections;
             }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -31,8 +31,9 @@ namespace Neo4j.Driver.Internal.Routing
         // Update the pool keys with the new server uris
         void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         Task UpdateAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);
-        // Remove all the connection pool with the server specified by the uri
-        void Purge(Uri uri);
+        // Deactiviate all the connection pool with the server specified by the uri
+        void Deactiviate(Uri uri);
+        Task DeactiviateAsync(Uri uri);
         // Get number of in-use connections for the uri
         int NumberOfInUseConnections(Uri uri);
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -30,6 +30,7 @@ namespace Neo4j.Driver.Internal.Routing
         void Add(IEnumerable<Uri> uris);
         // Update the pool keys with the new server uris
         void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed);
+        Task UpdateAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         // Remove all the connection pool with the server specified by the uri
         void Purge(Uri uri);
         // Get number of in-use connections for the uri

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -31,9 +31,9 @@ namespace Neo4j.Driver.Internal.Routing
         // Update the pool keys with the new server uris
         void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         Task UpdateAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);
-        // Deactiviate all the connection pool with the server specified by the uri
-        void Deactiviate(Uri uri);
-        Task DeactiviateAsync(Uri uri);
+        // Deactivate all the connection pool with the server specified by the uri
+        void Deactivate(Uri uri);
+        Task DeactivateAsync(Uri uri);
         // Get number of in-use connections for the uri
         int NumberOfInUseConnections(Uri uri);
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -28,6 +28,7 @@ namespace Neo4j.Driver.Internal.Routing
         Task<IConnection> AcquireAsync(Uri uri);
         // Add a set of uri to this pool
         void Add(IEnumerable<Uri> uris);
+        Task AddAsync(IEnumerable<Uri> uris);
         // Update the pool keys with the new server uris
         void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         Task UpdateAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -29,7 +29,7 @@ namespace Neo4j.Driver.Internal.Routing
         // Add a set of uri to this pool
         void Add(IEnumerable<Uri> uris);
         // Update the pool keys with the new server uris
-        void Update(IEnumerable<Uri> uris);
+        void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         // Remove all the connection pool with the server specified by the uri
         void Purge(Uri uri);
         // Get number of in-use connections for the uri

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.Internal.Routing
     internal interface IClusterConnectionPoolManager
     {
         void AddConnectionPool(IEnumerable<Uri> uris);
-        void UpdateConnectionPool(IEnumerable<Uri> uris);
+        void UpdateConnectionPool(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         IConnection CreateClusterConnection(Uri uri);
         Task<IConnection> CreateClusterConnectionAsync(Uri uri);
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
@@ -24,6 +24,7 @@ namespace Neo4j.Driver.Internal.Routing
     internal interface IClusterConnectionPoolManager
     {
         void AddConnectionPool(IEnumerable<Uri> uris);
+        Task AddConnectionPoolAsync(IEnumerable<Uri> uris);
         void UpdateConnectionPool(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         Task UpdateConnectionPoolAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         IConnection CreateClusterConnection(Uri uri);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
@@ -25,6 +25,7 @@ namespace Neo4j.Driver.Internal.Routing
     {
         void AddConnectionPool(IEnumerable<Uri> uris);
         void UpdateConnectionPool(IEnumerable<Uri> added, IEnumerable<Uri> removed);
+        Task UpdateConnectionPoolAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);
         IConnection CreateClusterConnection(Uri uri);
         Task<IConnection> CreateClusterConnectionAsync(Uri uri);
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterErrorHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterErrorHandler.cs
@@ -15,12 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.Routing
 {
     internal interface IClusterErrorHandler
     {
         void OnConnectionError(Uri uri, Exception e);
+        Task OnConnectionErrorAsync(Uri uri, Exception e);
         void OnWriteError(Uri uri);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -121,6 +121,11 @@ namespace Neo4j.Driver.Internal.Routing
             _clusterConnectionPool.Add(uris);
         }
 
+        public Task AddConnectionPoolAsync(IEnumerable<Uri> uris)
+        {
+            return _clusterConnectionPool.AddAsync(uris);
+        }
+
         public void UpdateConnectionPool(IEnumerable<Uri> added, IEnumerable<Uri> removed)
         {
             _clusterConnectionPool.Update(added, removed);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -21,7 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
-using static Neo4j.Driver.Internal.Throw.DriverDisposedException;
+using static Neo4j.Driver.Internal.Throw.ObjectDisposedException;
 
 namespace Neo4j.Driver.Internal.Routing
 {
@@ -114,9 +114,9 @@ namespace Neo4j.Driver.Internal.Routing
             _clusterConnectionPool.Add(uris);
         }
 
-        public void UpdateConnectionPool(IEnumerable<Uri> uris)
+        public void UpdateConnectionPool(IEnumerable<Uri> added, IEnumerable<Uri> removed)
         {
-            _clusterConnectionPool.Update(uris);
+            _clusterConnectionPool.Update(added, removed);
         }
 
         public IConnection CreateClusterConnection(Uri uri)
@@ -276,7 +276,7 @@ namespace Neo4j.Driver.Internal.Routing
 
         private void ThrowObjectDisposedException()
         {
-            FailedToCreateConnection(this);
+            FailedToAcquireConnection(this);
         }
 
         public override string ToString()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -119,6 +119,11 @@ namespace Neo4j.Driver.Internal.Routing
             _clusterConnectionPool.Update(added, removed);
         }
 
+        public Task UpdateConnectionPoolAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed)
+        {
+            return _clusterConnectionPool.UpdateAsync(added, removed);
+        }
+
         public IConnection CreateClusterConnection(Uri uri)
         {
             return CreateClusterConnection(uri, AccessMode.Write);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -101,14 +101,14 @@ namespace Neo4j.Driver.Internal.Routing
         {
             _logger?.Info($"Server at {uri} is no longer available due to error: {e.Message}.");
             _routingTableManager.RoutingTable.Remove(uri);
-            _clusterConnectionPool.Deactiviate(uri);
+            _clusterConnectionPool.Deactivate(uri);
         }
 
         public Task OnConnectionErrorAsync(Uri uri, Exception e)
         {
             _logger?.Info($"Server at {uri} is no longer available due to error: {e.Message}.");
             _routingTableManager.RoutingTable.Remove(uri);
-            return _clusterConnectionPool.DeactiviateAsync(uri);
+            return _clusterConnectionPool.DeactivateAsync(uri);
         }
 
         public void OnWriteError(Uri uri)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
@@ -126,7 +126,7 @@ namespace Neo4j.Driver.Internal.Routing
             }
         }
 
-        private void Update(IRoutingTable newTable)
+        internal void Update(IRoutingTable newTable)
         {
             var added = newTable.All();
             added.ExceptWith(_routingTable.All());
@@ -139,7 +139,7 @@ namespace Neo4j.Driver.Internal.Routing
             _logger?.Info($"Updated routingTable to be {_routingTable}");
         }
 
-        private async Task UpdateAsync(IRoutingTable newTable)
+        internal async Task UpdateAsync(IRoutingTable newTable)
         {
             var added = newTable.All();
             added.ExceptWith(_routingTable.All());
@@ -354,11 +354,6 @@ namespace Neo4j.Driver.Internal.Routing
             await discoveryManager.RediscoveryAsync().ConfigureAwait(false);
             return new RoutingTable(discoveryManager.Routers, discoveryManager.Readers,
                 discoveryManager.Writers, discoveryManager.ExpireAfterSeconds);
-        }
-
-        public void Clear()
-        {
-            _routingTable.Clear();
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
@@ -176,6 +176,12 @@ namespace Neo4j.Driver.Internal.Routing
             _poolManager.AddConnectionPool(uris);
         }
 
+        private Task PrependRoutersAsync(ISet<Uri> uris)
+        {
+            _routingTable.PrependRouters(uris);
+            return _poolManager.AddConnectionPoolAsync(uris);
+        }
+
         internal IRoutingTable UpdateRoutingTableWithInitialUriFallback(ISet<Uri> initialUriSet,
             Func<ISet<Uri>, IRoutingTable> updateRoutingTableFunc = null)
         {
@@ -224,7 +230,7 @@ namespace Neo4j.Driver.Internal.Routing
             var hasPrependedInitialRouters = false;
             if (_isReadingInAbsenceOfWriter)
             {
-                PrependRouters(initialUriSet);
+                await PrependRoutersAsync(initialUriSet).ConfigureAwait(false);
                 hasPrependedInitialRouters = true;
             }
 
@@ -241,7 +247,7 @@ namespace Neo4j.Driver.Internal.Routing
                 uris.ExceptWith(triedUris);
                 if (uris.Count != 0)
                 {
-                    PrependRouters(uris);
+                    await PrependRoutersAsync(uris).ConfigureAwait(false);
                     routingTable = await updateRoutingTableFunc(null).ConfigureAwait(false);
                     if (routingTable != null)
                     {


### PR DESCRIPTION
This PR consists of two parts:
1) When updating routing table, the pool of the servers that are removed from routing table should not be closed but be deactivated.
2) When a connection error happens towards a server, the pool of the server should not be purged but deactivated. 

TODOs (Not in this PR but comes later):
* While working on 2) we found that the `DelegatedConnection.OnError` should also provides a Async impl so that the connections could be closed synchronically. This will be left to some future work. 
* Chain async tasks if possible