### PR TITLE
Compact buffer when writable bytes drop below a set low watermark

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Shared/SoakRunWorkItem.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Shared/SoakRunWorkItem.cs
@@ -15,7 +15,37 @@ namespace Neo4j.Driver.IntegrationTests
         private static readonly string[] queries = new[]
         {
             "RETURN 1295 + 42",
-            "UNWIND range(1,10000) AS x CREATE (n {prop:x}) DELETE n RETURN sum(x)"
+            "UNWIND range(1,10000) AS x CREATE (n {prop:x}) DELETE n RETURN sum(x)",
+            @"UNWIND RANGE(1,500) AS N RETURN N, null, true, false, -2147483650, -32770, -130, -18, 126, 32765, 2147483645, 2147483650, 1.1, -1.1, """", ""1"", ""1234567890"", 
+                ""ppkXUYYqy9ENl9caIvQyRsO19jXy4LhZHHVZMyUBQjbHJXlkv2vvUfeowOOujxTxJxXufzzGLFjn35w4zFpR4pRnlM3a1AkwV0L6jCj0pWic7bPBwiiasjJTieiynvE9CIHBwdyfGAUW4YMrGR5mBZwkMWIZlDQ9
+                    hmLD3ohSlzoYp8ilj4pDreho83L5eSobYOGOKMn3ytLIKawzjO21eCIVAAXT5DmESMfoTixDLQbi9HGrNEzm56NLQjeTEsKxEKPHFDkHUWBscBIJyJsdYbObe1DgxOhWoxYz3i4cft5iL3IpsaELdo5ES3LVJP
+                    0kKh0FyFI2HTqRjNPWBWgQZyKX2uh0zoOhVApNdhQBl3mXZmaSuETsMzwdvewHOLOKp1tB1gCgvRXNf4OQ4XLOnSk6ksYW7Pd0NXEwhmFpgXTtQuJdDYXUwQD73oqq56ug6yX44MuscfdtDwJvuioBgkeItWcR
+                    FygHmLkHFNeIloqMU0nxTeUoaoA4yzyPybiQTjSU0e9CgCxkODc1ynQGIFCzo6XUws5mz31LIDmGssFT4tqxgeDH9aCjHnWTcIMB46i2JEOonXfqOsCKrvvoJBlslQvilNPitcwOIgbmRUv0iOfWXb7EOmutFA
+                    ZSs3Oeo5DGB1lkxRdZgidkV5fyfabYhR1Rd7jZsK7Sr4nzSSpnwuHjGRzqNd4Nwvi2Y94q6OuA17PVtwvordaJraTbCtOdkbCZPU7UsJfwlSOCCJM5XFmvIvquDTlyeNcaFypnADkEKcspqIqfxmECH9uH6H9I
+                    CfQ5xeOzf1Cl1TqsDnWWQWmyrerFAu5IAaCmILWUaZwQTMHkI2vteeh9eigYjWEak23vD9DkGCB8KBfzVzHsIN0fidBEsGqE7wXg1CZWfLhRqu50WD676dKP61mVBeeyHRPyhtuZ7KLnETp0B9tYztzCe65pc9
+                    lXyy1jjLGdMIrJfKPiSLC4q9C2O5qyxJMscO8D2ZgEpZve144x"", RANGE(0,100), {{KEY_1: 1, KEY_2: 2, KEY_3: 3, KEY_4: 4, KEY_5: 5, KEY_6: 6, KEY_7: 7, KEY_8: 8, KEY_9: 9, 
+                    KEY_10: 10, KEY_11: 11, KEY_12: 12, KEY_13: 13, KEY_14: 14, KEY_15: 15, KEY_16: 16, KEY_17: 17, KEY_18: 18, KEY_19: 19, KEY_20: 20, KEY_21: 21, KEY_22: 22, 
+                    KEY_23: 23, KEY_24: 24, KEY_25: 25, KEY_26: 26, KEY_27: 27, KEY_28: 28, KEY_29: 29, KEY_30: 30, KEY_31: 31, KEY_32: 32, KEY_33: 33, KEY_34: 34, KEY_35: 35, 
+                    KEY_36: 36, KEY_37: 37, KEY_38: 38, KEY_39: 39, KEY_40: 40, KEY_41: 41, KEY_42: 42, KEY_43: 43, KEY_44: 44, KEY_45: 45, KEY_46: 46, KEY_47: 47, KEY_48: 48, 
+                    KEY_49: 49, KEY_50: 50, KEY_51: 51, KEY_52: 52, KEY_53: 53, KEY_54: 54, KEY_55: 55, KEY_56: 56, KEY_57: 57, KEY_58: 58, KEY_59: 59, KEY_60: 60, KEY_61: 61, 
+                    KEY_62: 62, KEY_63: 63, KEY_64: 64, KEY_65: 65, KEY_66: 66, KEY_67: 67, KEY_68: 68, KEY_69: 69, KEY_70: 70, KEY_71: 71, KEY_72: 72, KEY_73: 73, KEY_74: 74, 
+                    KEY_75: 75, KEY_76: 76, KEY_77: 77, KEY_78: 78, KEY_79: 79, KEY_80: 80, KEY_81: 81, KEY_82: 82, KEY_83: 83, KEY_84: 84, KEY_85: 85, KEY_86: 86, KEY_87: 87, 
+                    KEY_88: 88, KEY_89: 89, KEY_90: 90, KEY_91: 91, KEY_92: 92, KEY_93: 93, KEY_94: 94, KEY_95: 95, KEY_96: 96, KEY_97: 97, KEY_98: 98, KEY_99: 99, KEY_100: 100}}",
+            @"UNWIND RANGE(1,5000) AS N RETURN N, null, true, false, -2147483650, -32770, -130, -18, 126, 32765, 2147483645, 2147483650, 1.1, -1.1, """", ""1"", ""1234567890"", 
+                ""ppkXUYYqy9ENl9caIvQyRsO19jXy4LhZHHVZMyUBQjbHJXlkv2vvUfeowOOujxTxJxXufzzGLFjn35w4zFpR4pRnlM3a1AkwV0L6jCj0pWic7bPBwiiasjJTieiynvE9CIHBwdyfGAUW4YMrGR5mBZwkMWIZlDQ9
+                    hmLD3ohSlzoYp8ilj4pDreho83L5eSobYOGOKMn3ytLIKawzjO21eCIVAAXT5DmESMfoTixDLQbi9HGrNEzm56NLQjeTEsKxEKPHFDkHUWBscBIJyJsdYbObe1DgxOhWoxYz3i4cft5iL3IpsaELdo5ES3LVJP
+                    0kKh0FyFI2HTqRjNPWBWgQZyKX2uh0zoOhVApNdhQBl3mXZmaSuETsMzwdvewHOLOKp1tB1gCgvRXNf4OQ4XLOnSk6ksYW7Pd0NXEwhmFpgXTtQuJdDYXUwQD73oqq56ug6yX44MuscfdtDwJvuioBgkeItWcR
+                    FygHmLkHFNeIloqMU0nxTeUoaoA4yzyPybiQTjSU0e9CgCxkODc1ynQGIFCzo6XUws5mz31LIDmGssFT4tqxgeDH9aCjHnWTcIMB46i2JEOonXfqOsCKrvvoJBlslQvilNPitcwOIgbmRUv0iOfWXb7EOmutFA
+                    ZSs3Oeo5DGB1lkxRdZgidkV5fyfabYhR1Rd7jZsK7Sr4nzSSpnwuHjGRzqNd4Nwvi2Y94q6OuA17PVtwvordaJraTbCtOdkbCZPU7UsJfwlSOCCJM5XFmvIvquDTlyeNcaFypnADkEKcspqIqfxmECH9uH6H9I
+                    CfQ5xeOzf1Cl1TqsDnWWQWmyrerFAu5IAaCmILWUaZwQTMHkI2vteeh9eigYjWEak23vD9DkGCB8KBfzVzHsIN0fidBEsGqE7wXg1CZWfLhRqu50WD676dKP61mVBeeyHRPyhtuZ7KLnETp0B9tYztzCe65pc9
+                    lXyy1jjLGdMIrJfKPiSLC4q9C2O5qyxJMscO8D2ZgEpZve144x"", RANGE(0,100), {{KEY_1: 1, KEY_2: 2, KEY_3: 3, KEY_4: 4, KEY_5: 5, KEY_6: 6, KEY_7: 7, KEY_8: 8, KEY_9: 9, 
+                    KEY_10: 10, KEY_11: 11, KEY_12: 12, KEY_13: 13, KEY_14: 14, KEY_15: 15, KEY_16: 16, KEY_17: 17, KEY_18: 18, KEY_19: 19, KEY_20: 20, KEY_21: 21, KEY_22: 22, 
+                    KEY_23: 23, KEY_24: 24, KEY_25: 25, KEY_26: 26, KEY_27: 27, KEY_28: 28, KEY_29: 29, KEY_30: 30, KEY_31: 31, KEY_32: 32, KEY_33: 33, KEY_34: 34, KEY_35: 35, 
+                    KEY_36: 36, KEY_37: 37, KEY_38: 38, KEY_39: 39, KEY_40: 40, KEY_41: 41, KEY_42: 42, KEY_43: 43, KEY_44: 44, KEY_45: 45, KEY_46: 46, KEY_47: 47, KEY_48: 48, 
+                    KEY_49: 49, KEY_50: 50, KEY_51: 51, KEY_52: 52, KEY_53: 53, KEY_54: 54, KEY_55: 55, KEY_56: 56, KEY_57: 57, KEY_58: 58, KEY_59: 59, KEY_60: 60, KEY_61: 61, 
+                    KEY_62: 62, KEY_63: 63, KEY_64: 64, KEY_65: 65, KEY_66: 66, KEY_67: 67, KEY_68: 68, KEY_69: 69, KEY_70: 70, KEY_71: 71, KEY_72: 72, KEY_73: 73, KEY_74: 74, 
+                    KEY_75: 75, KEY_76: 76, KEY_77: 77, KEY_78: 78, KEY_79: 79, KEY_80: 80, KEY_81: 81, KEY_82: 82, KEY_83: 83, KEY_84: 84, KEY_85: 85, KEY_86: 86, KEY_87: 87, 
+                    KEY_88: 88, KEY_89: 89, KEY_90: 90, KEY_91: 91, KEY_92: 92, KEY_93: 93, KEY_94: 94, KEY_95: 95, KEY_96: 96, KEY_97: 97, KEY_98: 98, KEY_99: 99, KEY_100: 100}}",
         };
 
         private static readonly AccessMode[] accessModes = new[]
@@ -41,8 +71,8 @@ namespace Neo4j.Driver.IntegrationTests
             return Task.Run(() =>
             {
                 var currentIteration = Interlocked.Increment(ref _counter);
-                var query = queries[currentIteration % 2];
-                var accessMode = accessModes[currentIteration % 2];
+                var query = queries[currentIteration % queries.Length];
+                var accessMode = accessModes[currentIteration % accessModes.Length];
 
                 using (var session = _driver.Session(accessMode))
                 {
@@ -68,8 +98,8 @@ namespace Neo4j.Driver.IntegrationTests
         public async Task RunAsync()
         {
             var currentIteration = Interlocked.Increment(ref _counter);
-            var query = queries[currentIteration % 2];
-            var accessMode = accessModes[currentIteration % 2];
+            var query = queries[currentIteration % queries.Length];
+            var accessMode = accessModes[currentIteration % accessModes.Length];
 
             var session = _driver.Session(accessMode);
             try

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
@@ -15,13 +15,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using Moq;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.IO;
+using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.V1;
 using Xunit;
 using Xunit.Abstractions;
@@ -122,6 +125,83 @@ namespace Neo4j.Driver.Tests.IO
                 exc.Message.Should().StartWith("Unexpected end of stream");
             }
 
+            [Fact]
+            public void ShouldNotResetInternalBufferPositionsAfterSmallMessageIsRead()
+            {
+                var size = Constants.ChunkBufferSize - (2 * Constants.ChunkBufferResetPositionsWatermark);
+                var data = IOExtensions.GenerateBoltMessage(size);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = reader.ReadNextMessages(new MemoryStream());
+
+                count.Should().Be(1);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Never);
+            }
+
+            [Fact]
+            public void ShouldResetInternalBufferPositionsAfterOneLargeMessageIsRead()
+            {
+                var size = Constants.ChunkBufferSize - Constants.ChunkBufferResetPositionsWatermark;
+                var data = IOExtensions.GenerateBoltMessage(size);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = reader.ReadNextMessages(new MemoryStream());
+
+                count.Should().Be(1);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Once);
+            }
+
+            [Fact]
+            public void ShouldNotResetInternalBufferPositionsAfterConsecutiveSmallMessagesAreRead()
+            {
+                var size = 1000;
+                var limit = Constants.ChunkBufferSize - (2 * Constants.ChunkBufferResetPositionsWatermark);
+                var data = IOExtensions.GenerateBoltMessages(size, limit);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = reader.ReadNextMessages(new MemoryStream());
+
+                count.Should().BeGreaterOrEqualTo(limit / size);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Never);
+            }
+
+            [Fact]
+            public void ShouldResetInternalBufferPositionsAfterConsecutiveSmallMessagesAreRead()
+            {
+                var size = 1000;
+                var limit = Constants.ChunkBufferSize - Constants.ChunkBufferResetPositionsWatermark;
+                var data = IOExtensions.GenerateBoltMessages(size, limit);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = reader.ReadNextMessages(new MemoryStream());
+
+                count.Should().BeGreaterOrEqualTo(limit / size);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Once);
+            }
+
+            [Fact]
+            public void ShouldResetInternalBufferPositionsAfterOneChunkSpanningMessageIsRead()
+            {
+                var size = Constants.MaxChunkSize * 3;
+                var data = IOExtensions.GenerateBoltMessage(size);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = reader.ReadNextMessages(new MemoryStream());
+
+                count.Should().Be(1);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.AtLeast(size / Constants.ChunkBufferSize));
+            }
+            
         }
 
         public class ReadNextMessagesAsyncMethod
@@ -170,7 +250,85 @@ namespace Neo4j.Driver.Tests.IO
                 exc.Should().BeOfType<IOException>();
                 exc.Message.Should().StartWith("Unexpected end of stream");
             }
+
+            [Fact]
+            public async void ShouldNotResetInternalBufferPositionsAfterSmallMessageIsRead()
+            {
+                var size = Constants.ChunkBufferSize - (2 * Constants.ChunkBufferResetPositionsWatermark);
+                var data = IOExtensions.GenerateBoltMessage(size);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = await reader.ReadNextMessagesAsync(new MemoryStream());
+
+                count.Should().Be(1);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Never);
+            }
+
+            [Fact]
+            public async void ShouldResetInternalBufferPositionsAfterOneLargeMessageIsRead()
+            {
+                var size = Constants.ChunkBufferSize - Constants.ChunkBufferResetPositionsWatermark;
+                var data = IOExtensions.GenerateBoltMessage(size);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = await reader.ReadNextMessagesAsync(new MemoryStream());
+
+                count.Should().Be(1);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Once);
+            }
+
+            [Fact]
+            public async void ShouldNotResetInternalBufferPositionsAfterConsecutiveSmallMessagesAreRead()
+            {
+                var size = 1000;
+                var limit = Constants.ChunkBufferSize - (2 * Constants.ChunkBufferResetPositionsWatermark);
+                var data = IOExtensions.GenerateBoltMessages(size, limit);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = await reader.ReadNextMessagesAsync(new MemoryStream());
+
+                count.Should().BeGreaterOrEqualTo(limit / size);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Never);
+            }
+
+            [Fact]
+            public async void ShouldResetInternalBufferPositionsAfterConsecutiveSmallMessagesAreRead()
+            {
+                var size = 1000;
+                var limit = Constants.ChunkBufferSize - Constants.ChunkBufferResetPositionsWatermark;
+                var data = IOExtensions.GenerateBoltMessages(size, limit);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = await reader.ReadNextMessagesAsync(new MemoryStream());
+
+                count.Should().BeGreaterOrEqualTo(limit / size);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.Once);
+            }
+
+            [Fact]
+            public async void ShouldResetInternalBufferPositionsAfterOneChunkSpanningMessageIsRead()
+            {
+                var size = Constants.MaxChunkSize * 3;
+                var data = IOExtensions.GenerateBoltMessage(size);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var count = await reader.ReadNextMessagesAsync(new MemoryStream());
+
+                count.Should().Be(1);
+                logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.AtLeast(size / Constants.ChunkBufferSize));
+            }
+
         }
-        
+
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/IOExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/IOExtensions.cs
@@ -24,12 +24,47 @@ using System.Threading.Tasks;
 using Moq;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.IO;
+using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Tests
 {
     internal static class IOExtensions
     {
+
+        public static byte[] GenerateBoltMessage(int paramBytesLength)
+        {
+            using (var data = new MemoryStream())
+            {
+                var boltWriter = new BoltWriter(data);
+                boltWriter.Write(new RunMessage("RETUN {a}", new Dictionary<string, object>
+                {
+                    {"a", Enumerable.Repeat((byte) 0, paramBytesLength).ToArray()}
+                }));
+                boltWriter.Flush();
+
+                return data.ToArray();
+            }
+        }
+
+        public static byte[] GenerateBoltMessages(int paramBytesLength, int limit)
+        {
+            using (var data = new MemoryStream())
+            {
+                var boltWriter = new BoltWriter(data);
+
+                while (data.Length < limit)
+                {
+                    boltWriter.Write(new RunMessage("RETUN {a}", new Dictionary<string, object>
+                    {
+                        {"a", Enumerable.Repeat((byte) 0, paramBytesLength).ToArray()}
+                    }));
+                    boltWriter.Flush();
+                }
+
+                return data.ToArray();
+            }
+        }
 
         public static PackStreamReader CreateChunkedPackStreamReaderFromBytes(byte[] bytes, ILogger logger = null)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -208,7 +208,7 @@ namespace Neo4j.Driver.Internal.Connector
             }
             catch (Exception ex)
             {
-                _logger?.Info($"Unable to read message from server {_uri}, connection will be terminated.", ex);
+                _logger?.Error($"Unable to read message from server {_uri}, connection will be terminated.", ex);
                 Stop();
                 throw;
             }
@@ -228,7 +228,7 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 if (t.IsFaulted)
                 {
-                    _logger?.Info($"Unable to read message from server {_uri}, connection will be terminated.", t.Exception);
+                    _logger?.Error($"Unable to read message from server {_uri}, connection will be terminated.", t.Exception);
                     Stop();
 
                     tcs.SetException(t.Exception.GetBaseException());

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/Constants.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/Constants.cs
@@ -26,6 +26,7 @@ namespace Neo4j.Driver.Internal.IO
         public const int MinChunkSize = 6;
 
         public const int ChunkBufferSize = 16 * 1024;
+        public const int ChunkBufferResetPositionsWatermark = 1024;
         public const int DefaultReadBufferSize = 32 * 1024;
         public const int MaxReadBufferSize = 128 * 1024;
         public const int DefaultWriteBufferSize = 16 * 1024;


### PR DESCRIPTION
Internal buffer used by `ChunkedReader` was not being reset  (its recorded positions) under edge cases, where `Read` operation on `NetworkStream` was given a `count` of `0` which was conceived as an `Unexpected end of stream`.

This PR addresses this problem by checking the number of writable bytes left in the buffer against a pre-defined constant value of `1024` and when drops under this value, the buffer positions are reset and leftover bytes are copied to the beginning of the buffer.

Related with the discussion on [Introduce network level write throttling #10433](https://github.com/neo4j/neo4j/pull/10433) and might be related to #250.