### PR TITLE
Adding transaction timeout on transaction

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -109,6 +109,26 @@ namespace Neo4j.Driver.Tests
         public class BeginTransactionMethod
         {
             [Fact]
+            public void NullDefaultTimeout()
+            {
+                var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.IsOpen).Returns(true);
+                var session = NewSession(mockConn.Object);
+                session.BeginTransaction();
+                mockConn.Verify(x=>x.Run("BEGIN", null, null, true));
+            }
+
+            [Fact]
+            public void ShouldSendTimeout()
+            {
+                var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.IsOpen).Returns(true);
+                var session = NewSession(mockConn.Object);
+                session.BeginTransaction(TimeSpan.FromSeconds(10));
+                mockConn.Verify(x=>x.Run("BEGIN", new Dictionary<string, object>{{"txTimeout", 10000L}}, null, true));
+            }
+
+            [Fact]
             public void NullDefaultBookmark()
             {
                 var mockConn = new Mock<IConnection>();
@@ -257,6 +277,26 @@ namespace Neo4j.Driver.Tests
 
         public class BeginTransactionAsyncMethod
         {
+            [Fact]
+            public async void NullDefaultTimeout()
+            {
+                var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.IsOpen).Returns(true);
+                var session = NewSession(mockConn.Object);
+                await session.BeginTransactionAsync();
+                mockConn.Verify(x=>x.Run("BEGIN", null, null, true));
+            }
+
+            [Fact]
+            public async void ShouldSendTimeout()
+            {
+                var mockConn = new Mock<IConnection>();
+                mockConn.Setup(x => x.IsOpen).Returns(true);
+                var session = NewSession(mockConn.Object);
+                await session.BeginTransactionAsync(TimeSpan.FromSeconds(10));
+                mockConn.Verify(x=>x.Run("BEGIN", new Dictionary<string, object>{{"txTimeout", 10000L}}, null, true));
+            }
+
             [Fact]
             public async void ShouldNotAllowNewTxWhileOneIsRunning()
             {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -44,7 +44,7 @@ namespace Neo4j.Driver.Tests
         public class Constructor
         {
             [Fact]
-            public void ShouldRunWithoutBookmarkIfNoBookmarkGiven()
+            public void ShouldRunWithoutParameterIfParameterGiven()
             {
                 var mockConn = new Mock<IConnection>();
                 var tx = new Transaction(mockConn.Object);
@@ -53,6 +53,7 @@ namespace Neo4j.Driver.Tests
                 mockConn.Verify(x => x.Sync(), Times.Never);
             }
 
+            [Fact]
             public void ShouldRunWithoutBookmarkIfInvalidBookmarkGiven()
             {
                 var mockConn = new Mock<IConnection>();
@@ -83,6 +84,17 @@ namespace Neo4j.Driver.Tests
                 var tx = new Transaction(mockConn.Object, null, null, bookmark);
 
                 tx.Bookmark.Should().BeNull();
+            }
+
+            [Fact]
+            public void ShouldRunWithTxTimeoutIfProvided()
+            {
+                var mockConn = new Mock<IConnection>();
+                var tx = new Transaction(mockConn.Object, null, null, null, TimeSpan.FromMinutes(1));
+
+                IDictionary<string, object> paramters = new Dictionary<string, object>{{"txTimeout", 60000L}};
+                mockConn.Verify(RunBegin(paramters), Times.Once);
+                mockConn.Verify(x => x.Sync(), Times.Never);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -96,6 +96,19 @@ namespace Neo4j.Driver.Tests
                 mockConn.Verify(RunBegin(paramters), Times.Once);
                 mockConn.Verify(x => x.Sync(), Times.Never);
             }
+
+            [Fact]
+            public void ShouldRunWithParameters()
+            {
+                var mockConn = new Mock<IConnection>();
+                var bookmark = Bookmark.From(FakeABookmark(234));
+                var tx = new Transaction(mockConn.Object, null, null, bookmark, TimeSpan.FromMinutes(1));
+
+                IDictionary<string, object> paramters = bookmark.AsBeginTransactionParameters();
+                paramters.Add("txTimeout", 60000L);
+                mockConn.Verify(RunBegin(paramters), Times.Once);
+                mockConn.Verify(x => x.Sync(), Times.Never);
+            }
         }
 
         public class SyncBoomarkMethod

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Session.cs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Result;
@@ -23,7 +22,7 @@ using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal
 {
-    internal class Session : StatementRunner, ISession, IResultResourceHandler, ITransactionResourceHandler
+    internal partial class Session : StatementRunner, ISession
     {
         // If the connection is ever successfully created, 
         // then it is session's responsibility to dispose them properly
@@ -112,294 +111,14 @@ namespace Neo4j.Driver.Internal
             return _transaction;
         }
 
-        public T ReadTransaction<T>(Func<ITransaction, T> work)
+        public Task<ITransaction> BeginTransactionAsync()
         {
-            return RunTransaction(AccessMode.Read, work);
+            return TryExecuteAsync(() => BeginTransactionWithoutLoggingAsync(_defaultMode));
         }
 
-        public void ReadTransaction(Action<ITransaction> work)
+        public Task<ITransaction> BeginTransactionAsync(TimeSpan timeout)
         {
-            RunTransaction(AccessMode.Read, work);
-        }
-
-        public T WriteTransaction<T>(Func<ITransaction, T> work)
-        {
-            return RunTransaction(AccessMode.Write, work);
-        }
-
-        public void WriteTransaction(Action<ITransaction> work)
-        {
-            RunTransaction(AccessMode.Write, work);
-        }
-
-        private void RunTransaction(AccessMode mode, Action<ITransaction> work)
-        {
-            RunTransaction<object>(mode, tx =>
-            {
-                work(tx);
-                return null;
-            });
-        }
-
-        private T RunTransaction<T>(AccessMode mode, Func<ITransaction, T> work)
-        {
-            return TryExecute(() => _retryLogic.Retry(() =>
-            {
-                using (var tx = BeginTransactionWithoutLogging(mode))
-                {
-                    try
-                    {
-                        var result = work(tx);
-                        tx.Success();
-                        return result;
-                    }
-                    catch
-                    {
-                        tx.Failure();
-                        throw;
-                    }
-                }
-            }));
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            if (!isDisposing)
-            {
-                return;
-            }
-
-            TryExecute(() =>
-            {
-                if (_isOpen)
-                {
-                    // This will protect the session being disposed twice
-                    _isOpen = false;
-                    DisposeTransaction();
-                    DisposeSessionResult();
-                }
-            });
-            base.Dispose(true);
-        }
-
-        public Task CloseAsync()
-        {
-            return TryExecuteAsync(async () =>
-            {
-                if (_isOpen)
-                {
-                    // This will protect the session being disposed twice
-                    _isOpen = false;
-                    await DisposeTransactionAsync().ConfigureAwait(false);
-                    await DisposeSessionResultAsync().ConfigureAwait(false);
-                }
-            });
-        }
-
-        /// <summary>
-        ///  This method will be called back by <see cref="ResultBuilder"/> after it consumed result
-        /// </summary>
-        public void OnResultConsumed()
-        {
-            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
-            DisposeConnection();
-        }
-
-        public Task OnResultConsumedAsync()
-        {
-            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
-            return DisposeConnectionAsync();
-        }
-
-        /// <summary>
-        /// Called back in <see cref="Transaction.Dispose"/>
-        /// </summary>
-        public void OnTransactionDispose()
-        {
-            Throw.ArgumentNullException.IfNull(_transaction, nameof(_transaction));
-            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
-
-            UpdateBookmark(_transaction.Bookmark);
-            _transaction = null;
-
-            DisposeConnection();
-        }
-
-        public Task OnTransactionDisposeAsync()
-        {
-            Throw.ArgumentNullException.IfNull(_transaction, nameof(_transaction));
-            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
-
-            UpdateBookmark(_transaction.Bookmark);
-            _transaction = null;
-
-            return DisposeConnectionAsync();
-        }
-
-        /// <summary>
-        /// Only set the bookmark to a new value if the new value is not null
-        /// </summary>
-        /// <param name="bookmark">The new bookmark</param>
-        private void UpdateBookmark(Bookmark bookmark)
-        {
-            if (bookmark != null && !bookmark.IsEmpty())
-            {
-                _bookmark = bookmark;
-            }
-        }
-
-        /// <summary>
-        /// Clean any transaction reference.
-        /// If transaction result is not commited, then rollback the transaction.
-        /// </summary>
-        /// <exception cref="ClientException">If error when rollback the transaction</exception>
-        private void DisposeTransaction()
-        {
-            // When there is a open transation, this method will aslo try to close the tx
-            if (_transaction != null)
-            {
-                try
-                {
-                    _transaction.Dispose();
-                }
-                catch (Exception e)
-                {
-                    throw new ClientException($"Error when disposing unclosed transaction in session: {e.Message}", e);
-                }
-            }
-        }
-
-        private async Task DisposeTransactionAsync()
-        {
-            // When there is a open transation, this method will aslo try to close the tx
-            if (_transaction != null)
-            {
-                try
-                {
-                    await _transaction.RollbackAsync().ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    throw new ClientException($"Error when disposing unclosed transaction in session: {e.Message}", e);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Clean any session.run result reference.
-        /// If session.run result is not fully consumed, then pull full result into memory.
-        /// </summary>
-        /// <exception cref="ClientException">If error when pulling result into memory</exception>
-        private void DisposeSessionResult()
-        {
-            if (_connection == null)
-            {
-                // there is no session result resources to dispose
-                return;
-            }
-
-            if (_connection.IsOpen)
-            {
-                try
-                {
-                    // this will enfore to buffer all unconsumed result
-                    _connection.Sync();
-                }
-                catch (Exception e)
-                {
-                    throw new ClientException($"Error when pulling unconsumed session.run records into memory in session: {e.Message}", e);
-                }
-                finally
-                {
-                    // there is a possibility that when error happens e.g. ProtocolError, the resources are not closed.
-                    DisposeConnection();
-                }
-            }
-            else
-            {
-                DisposeConnection();
-            }
-        }
-
-        private async Task DisposeSessionResultAsync()
-        {
-            if (_connection == null)
-            {
-                // there is no session result resources to dispose
-                return;
-            }
-
-            if (_connection.IsOpen)
-            {
-                try
-                {
-                    // this will enfore to buffer all unconsumed result
-                    await _connection.SyncAsync().ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    throw new ClientException($"Error when pulling unconsumed session.run records into memory in session: {e.Message}", e);
-                }
-                finally
-                {
-                    // there is a possibility that when error happens e.g. ProtocolError, the resources are not closed.
-                    await DisposeConnectionAsync().ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                await DisposeConnectionAsync().ConfigureAwait(false);
-            }
-        }
-
-        private void DisposeConnection()
-        {
-            // always try to close connection used by the result too
-            _connection?.Close();
-            _connection = null;
-        }
-
-        private async Task DisposeConnectionAsync()
-        {
-            // always try to close connection used by the result too
-            if (_connection != null)
-            {
-                await _connection.CloseAsync().ConfigureAwait(false);
-            }
-            _connection = null;
-        }
-
-        private void EnsureCanRunMoreStatements()
-        {
-            EnsureSessionIsOpen();
-            EnsureNoOpenTransaction();
-            DisposeSessionResult();
-        }
-
-        private Task EnsureCanRunMoreStatementsAsync()
-        {
-            EnsureSessionIsOpen();
-            EnsureNoOpenTransaction();
-            return DisposeSessionResultAsync();
-        }
-
-        private void EnsureNoOpenTransaction()
-        {
-            if (_transaction != null)
-            {
-                throw new ClientException("Please close the currently open transaction object before running " +
-                                          "more statements/transactions in the current session.");
-            }
-        }
-
-        private void EnsureSessionIsOpen()
-        {
-            if (!_isOpen)
-            {
-                throw new ClientException("Cannot running more statements in the current session as it has already been disposed." +
-                                          "Make sure that you do not have a bad reference to a disposed session " +
-                                          "and retry your statement in another new session.");
-            }
+            return TryExecuteAsync(() => BeginTransactionWithoutLoggingAsync(_defaultMode, timeout));
         }
 
         private async Task<ITransaction> BeginTransactionWithoutLoggingAsync(AccessMode mode, TimeSpan? timeout = null)
@@ -413,65 +132,16 @@ namespace Neo4j.Driver.Internal
             return _transaction;
         }
 
-        public Task<ITransaction> BeginTransactionAsync()
+        /// <summary>
+        /// Only set the bookmark to a new value if the new value is not null
+        /// </summary>
+        /// <param name="bookmark">The new bookmark</param>
+        private void UpdateBookmark(Bookmark bookmark)
         {
-            return TryExecuteAsync(() => BeginTransactionWithoutLoggingAsync(_defaultMode));
-        }
-
-        public Task<ITransaction> BeginTransactionAsync(TimeSpan timeout)
-        {
-            return TryExecuteAsync(() => BeginTransactionWithoutLoggingAsync(_defaultMode, timeout));
-        }
-
-        private Task RunTransactionAsync(AccessMode mode, Func<ITransaction, Task> work)
-        {
-            return RunTransactionAsync(mode, async tx =>
+            if (bookmark != null && !bookmark.IsEmpty())
             {
-                await work(tx).ConfigureAwait(false);
-                var ignored = 1;
-                return ignored;
-            });
-        }
-
-        private Task<T> RunTransactionAsync<T>(AccessMode mode, Func<ITransaction, Task<T>> work)
-        {
-            return TryExecuteAsync(async () => await _retryLogic.RetryAsync(async () =>
-            {
-                var tx = await BeginTransactionWithoutLoggingAsync(mode).ConfigureAwait(false);
-                {
-                    try
-                    {
-                        var result = await work(tx).ConfigureAwait(false);
-                        await tx.CommitAsync().ConfigureAwait(false);
-                        return result;
-                    }
-                    catch
-                    {
-                        await tx.RollbackAsync().ConfigureAwait(false);
-                        throw;
-                    }
-                }
-            }).ConfigureAwait(false));
-        }
-
-        public Task<T> ReadTransactionAsync<T>(Func<ITransaction, Task<T>> work)
-        {
-            return RunTransactionAsync(AccessMode.Read, work);
-        }
-
-        public Task ReadTransactionAsync(Func<ITransaction, Task> work)
-        {
-            return RunTransactionAsync(AccessMode.Read, work);
-        }
-
-        public Task<T> WriteTransactionAsync<T>(Func<ITransaction, Task<T>> work)
-        {
-            return RunTransactionAsync(AccessMode.Write, work);
-        }
-
-        public Task WriteTransactionAsync(Func<ITransaction, Task> work)
-        {
-            return RunTransactionAsync(AccessMode.Write, work);
+                _bookmark = bookmark;
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/SessionResourceManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/SessionResourceManager.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) 2002-2017 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Neo4j.Driver.Internal.Result;
+using Neo4j.Driver.V1;
+
+namespace Neo4j.Driver.Internal
+{
+    internal partial class Session : IResultResourceHandler, ITransactionResourceHandler
+    {
+        protected override void Dispose(bool isDisposing)
+        {
+            if (!isDisposing)
+            {
+                return;
+            }
+
+            TryExecute(() =>
+            {
+                if (_isOpen)
+                {
+                    // This will protect the session being disposed twice
+                    _isOpen = false;
+                    DisposeTransaction();
+                    DisposeSessionResult();
+                }
+            });
+            base.Dispose(true);
+        }
+
+        public Task CloseAsync()
+        {
+            return TryExecuteAsync(async () =>
+            {
+                if (_isOpen)
+                {
+                    // This will protect the session being disposed twice
+                    _isOpen = false;
+                    await DisposeTransactionAsync().ConfigureAwait(false);
+                    await DisposeSessionResultAsync().ConfigureAwait(false);
+                }
+            });
+        }
+
+        /// <summary>
+        ///  This method will be called back by <see cref="ResultBuilder"/> after it consumed result
+        /// </summary>
+        public void OnResultConsumed()
+        {
+            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
+            DisposeConnection();
+        }
+
+        public Task OnResultConsumedAsync()
+        {
+            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
+            return DisposeConnectionAsync();
+        }
+
+        /// <summary>
+        /// Called back in <see cref="Transaction.Dispose"/>
+        /// </summary>
+        public void OnTransactionDispose()
+        {
+            Throw.ArgumentNullException.IfNull(_transaction, nameof(_transaction));
+            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
+
+            UpdateBookmark(_transaction.Bookmark);
+            _transaction = null;
+
+            DisposeConnection();
+        }
+
+        public Task OnTransactionDisposeAsync()
+        {
+            Throw.ArgumentNullException.IfNull(_transaction, nameof(_transaction));
+            Throw.ArgumentNullException.IfNull(_connection, nameof(_connection));
+
+            UpdateBookmark(_transaction.Bookmark);
+            _transaction = null;
+
+            return DisposeConnectionAsync();
+        }
+
+        private void DisposeConnection()
+        {
+            // always try to close connection used by the result too
+            _connection?.Close();
+            _connection = null;
+        }
+
+        private async Task DisposeConnectionAsync()
+        {
+            // always try to close connection used by the result too
+            if (_connection != null)
+            {
+                await _connection.CloseAsync().ConfigureAwait(false);
+            }
+            _connection = null;
+        }
+
+        private void EnsureCanRunMoreStatements()
+        {
+            EnsureSessionIsOpen();
+            EnsureNoOpenTransaction();
+            DisposeSessionResult();
+        }
+
+        private Task EnsureCanRunMoreStatementsAsync()
+        {
+            EnsureSessionIsOpen();
+            EnsureNoOpenTransaction();
+            return DisposeSessionResultAsync();
+        }
+
+        private void EnsureNoOpenTransaction()
+        {
+            if (_transaction != null)
+            {
+                throw new ClientException("Please close the currently open transaction object before running " +
+                                          "more statements/transactions in the current session.");
+            }
+        }
+
+        private void EnsureSessionIsOpen()
+        {
+            if (!_isOpen)
+            {
+                throw new ClientException("Cannot running more statements in the current session as it has already been disposed." +
+                                          "Make sure that you do not have a bad reference to a disposed session " +
+                                          "and retry your statement in another new session.");
+            }
+        }
+
+        /// <summary>
+        /// Clean any session.run result reference.
+        /// If session.run result is not fully consumed, then pull full result into memory.
+        /// </summary>
+        /// <exception cref="ClientException">If error when pulling result into memory</exception>
+        private void DisposeSessionResult()
+        {
+            if (_connection == null)
+            {
+                // there is no session result resources to dispose
+                return;
+            }
+
+            if (_connection.IsOpen)
+            {
+                try
+                {
+                    // this will enfore to buffer all unconsumed result
+                    _connection.Sync();
+                }
+                catch (Exception e)
+                {
+                    throw new ClientException($"Error when pulling unconsumed session.run records into memory in session: {e.Message}", e);
+                }
+                finally
+                {
+                    // there is a possibility that when error happens e.g. ProtocolError, the resources are not closed.
+                    DisposeConnection();
+                }
+            }
+            else
+            {
+                DisposeConnection();
+            }
+        }
+
+        private async Task DisposeSessionResultAsync()
+        {
+            if (_connection == null)
+            {
+                // there is no session result resources to dispose
+                return;
+            }
+
+            if (_connection.IsOpen)
+            {
+                try
+                {
+                    // this will enfore to buffer all unconsumed result
+                    await _connection.SyncAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new ClientException($"Error when pulling unconsumed session.run records into memory in session: {e.Message}", e);
+                }
+                finally
+                {
+                    // there is a possibility that when error happens e.g. ProtocolError, the resources are not closed.
+                    await DisposeConnectionAsync().ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await DisposeConnectionAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Clean any transaction reference.
+        /// If transaction result is not commited, then rollback the transaction.
+        /// </summary>
+        /// <exception cref="ClientException">If error when rollback the transaction</exception>
+        private void DisposeTransaction()
+        {
+            // When there is a open transation, this method will aslo try to close the tx
+            if (_transaction != null)
+            {
+                try
+                {
+                    _transaction.Dispose();
+                }
+                catch (Exception e)
+                {
+                    throw new ClientException($"Error when disposing unclosed transaction in session: {e.Message}", e);
+                }
+            }
+        }
+
+        private async Task DisposeTransactionAsync()
+        {
+            // When there is a open transation, this method will aslo try to close the tx
+            if (_transaction != null)
+            {
+                try
+                {
+                    await _transaction.RollbackAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new ClientException($"Error when disposing unclosed transaction in session: {e.Message}", e);
+                }
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/SessionWithRetries.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/SessionWithRetries.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2002-2017 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Threading.Tasks;
+using Neo4j.Driver.V1;
+
+namespace Neo4j.Driver.Internal
+{
+    internal partial class Session
+    {
+        public T ReadTransaction<T>(Func<ITransaction, T> work)
+        {
+            return RunTransaction(AccessMode.Read, work);
+        }
+
+        public T ReadTransaction<T>(Func<ITransaction, T> work, TimeSpan timeout)
+        {
+            return RunTransaction(AccessMode.Read, work, timeout);
+        }
+
+        public void ReadTransaction(Action<ITransaction> work)
+        {
+            RunTransaction(AccessMode.Read, work);
+        }
+
+        public void ReadTransaction(Action<ITransaction> work, TimeSpan timeout)
+        {
+            RunTransaction(AccessMode.Read, work, timeout);
+        }
+
+        public T WriteTransaction<T>(Func<ITransaction, T> work)
+        {
+            return RunTransaction(AccessMode.Write, work);
+        }
+
+        public T WriteTransaction<T>(Func<ITransaction, T> work, TimeSpan timeout)
+        {
+            return RunTransaction(AccessMode.Write, work, timeout);
+        }
+
+        public void WriteTransaction(Action<ITransaction> work)
+        {
+            RunTransaction(AccessMode.Write, work);
+        }
+
+        public void WriteTransaction(Action<ITransaction> work, TimeSpan timeout)
+        {
+            RunTransaction(AccessMode.Write, work, timeout);
+        }
+
+        private void RunTransaction(AccessMode mode, Action<ITransaction> work, TimeSpan? timeout = null)
+        {
+            RunTransaction<object>(mode, tx=>
+            {
+                work(tx);
+                return null;
+            }, timeout);
+        }
+
+        private T RunTransaction<T>(AccessMode mode, Func<ITransaction, T> work, TimeSpan? timeout = null)
+        {
+            return TryExecute(() => _retryLogic.Retry(() =>
+            {
+                using (var tx = BeginTransactionWithoutLogging(mode, timeout))
+                {
+                    try
+                    {
+                        var result = work(tx);
+                        tx.Success();
+                        return result;
+                    }
+                    catch
+                    {
+                        tx.Failure();
+                        throw;
+                    }
+                }
+            }));
+        }
+
+        // Async
+        public Task<T> ReadTransactionAsync<T>(Func<ITransaction, Task<T>> work)
+        {
+            return RunTransactionAsync(AccessMode.Read, work);
+        }
+
+        public Task ReadTransactionAsync(Func<ITransaction, Task> work, TimeSpan timeout)
+        {
+            return RunTransactionAsync(AccessMode.Read, work, timeout);
+        }
+
+        public Task ReadTransactionAsync(Func<ITransaction, Task> work)
+        {
+            return RunTransactionAsync(AccessMode.Read, work);
+        }
+
+        public Task<T> ReadTransactionAsync<T>(Func<ITransaction, Task<T>> work, TimeSpan timeout)
+        {
+            return RunTransactionAsync(AccessMode.Read, work, timeout);
+        }
+
+        public Task<T> WriteTransactionAsync<T>(Func<ITransaction, Task<T>> work)
+        {
+            return RunTransactionAsync(AccessMode.Write, work);
+        }
+
+        public Task<T> WriteTransactionAsync<T>(Func<ITransaction, Task<T>> work, TimeSpan timeout)
+        {
+            return RunTransactionAsync(AccessMode.Write, work, timeout);
+        }
+
+        public Task WriteTransactionAsync(Func<ITransaction, Task> work)
+        {
+            return RunTransactionAsync(AccessMode.Write, work);
+        }
+
+        public Task WriteTransactionAsync(Func<ITransaction, Task> work, TimeSpan timeout)
+        {
+            return RunTransactionAsync(AccessMode.Write, work, timeout);
+        }
+
+        private Task RunTransactionAsync(AccessMode mode, Func<ITransaction, Task> work, TimeSpan? timeout = null)
+        {
+            return RunTransactionAsync(mode, async tx =>
+            {
+                await work(tx).ConfigureAwait(false);
+                var ignored = 1;
+                return ignored;
+            }, timeout);
+        }
+
+        private Task<T> RunTransactionAsync<T>(AccessMode mode, Func<ITransaction, Task<T>> work, TimeSpan? timeout = null)
+        {
+            return TryExecuteAsync(async () => await _retryLogic.RetryAsync(async () =>
+            {
+                var tx = await BeginTransactionWithoutLoggingAsync(mode, timeout).ConfigureAwait(false);
+                {
+                    try
+                    {
+                        var result = await work(tx).ConfigureAwait(false);
+                        await tx.CommitAsync().ConfigureAwait(false);
+                        return result;
+                    }
+                    catch
+                    {
+                        await tx.RollbackAsync().ConfigureAwait(false);
+                        throw;
+                    }
+                }
+            }).ConfigureAwait(false));
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/SessionWithRetries.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/SessionWithRetries.cs
@@ -98,7 +98,7 @@ namespace Neo4j.Driver.Internal
             return RunTransactionAsync(AccessMode.Read, work);
         }
 
-        public Task ReadTransactionAsync(Func<ITransaction, Task> work, TimeSpan timeout)
+        public Task<T> ReadTransactionAsync<T>(Func<ITransaction, Task<T>> work, TimeSpan timeout)
         {
             return RunTransactionAsync(AccessMode.Read, work, timeout);
         }
@@ -108,7 +108,7 @@ namespace Neo4j.Driver.Internal
             return RunTransactionAsync(AccessMode.Read, work);
         }
 
-        public Task<T> ReadTransactionAsync<T>(Func<ITransaction, Task<T>> work, TimeSpan timeout)
+        public Task ReadTransactionAsync(Func<ITransaction, Task> work, TimeSpan timeout)
         {
             return RunTransactionAsync(AccessMode.Read, work, timeout);
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
@@ -51,6 +51,23 @@ namespace Neo4j.Driver.V1
         ITransaction BeginTransaction();
 
         /// <summary>
+        /// Begin a new transaction with transaction timeout in this session.
+        /// The transaction running longger than the specified timeout on the server side will be cancelled and rolled back.
+        /// A session can have at most one transaction running at a time, if you
+        /// want to run multiple concurrent transactions, you should use multiple concurrent sessions.
+        ///
+        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.Run(Statement)"/>
+        /// method directly on this session interface as well. When you use that method, your statement automatically gets
+        /// wrapped in a transaction.
+        ///
+        /// If you want to run multiple statements in the same transaction, you should wrap them in a transaction using this
+        /// method.
+        /// </summary>
+        /// <param name="timeout">Transaction timeout</param>
+        /// <returns>A new transaction.</returns>
+        ITransaction BeginTransaction(TimeSpan timeout);
+
+        /// <summary>
         /// This method is deprecated.
         /// </summary>
         /// <param name="bookmark"></param>
@@ -72,7 +89,23 @@ namespace Neo4j.Driver.V1
         /// </summary>
         /// <returns>A task of a new transaction.</returns>
         Task<ITransaction> BeginTransactionAsync();
-        
+
+        /// <summary>
+        /// Asynchronously begin a new transaction with transaction timeout in this session.
+        /// The transaction running longger than the specified timeout on the server side will be cancelled and rolled back.
+        /// A session can have at most one transaction running at a time, if you
+        /// want to run multiple concurrent transactions, you should use multiple concurrent sessions.
+        ///
+        /// All data operations in Neo4j are transactional. However, for convenience we provide a <see cref="IStatementRunner.RunAsync(Statement)"/>
+        /// method directly on this session interface as well. When you use that method, your statement automatically gets
+        /// wrapped in a transaction.
+        ///
+        /// If you want to run multiple statements in the same transaction, you should wrap them in a transaction using this
+        /// method.
+        /// </summary>
+        /// <param name="timeout">Transaction timeout</param>
+        /// <returns>A task of new transaction</returns>
+        Task<ITransaction> BeginTransactionAsync(TimeSpan timeout);
         /// <summary>
         /// Execute given unit of work in a  <see cref="AccessMode.Read"/> transaction.
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
@@ -106,6 +106,7 @@ namespace Neo4j.Driver.V1
         /// <param name="timeout">Transaction timeout</param>
         /// <returns>A task of new transaction</returns>
         Task<ITransaction> BeginTransactionAsync(TimeSpan timeout);
+
         /// <summary>
         /// Execute given unit of work in a  <see cref="AccessMode.Read"/> transaction.
         /// </summary>
@@ -134,7 +135,44 @@ namespace Neo4j.Driver.V1
         /// <param name="work">The <see cref="Func{ITransactionAsync, Task}"/> to be applied to a new read transaction.</param>
         /// <returns>A task representing the completion of the transactional read operation enclosing the given unit of work.</returns>
         Task ReadTransactionAsync(Func<ITransaction, Task> work);
-        
+
+        /// <summary>
+        /// Execute given unit of work in a  <see cref="AccessMode.Read"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <typeparam name="T">The return type of the given unit of work.</typeparam>
+        /// <param name="work">The <see cref="Func{TResult}"/> to be applied to a new read transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        /// <returns>A result as returned by the given unit of work.</returns>
+        T ReadTransaction<T>(Func<ITransaction, T> work, TimeSpan timeout);
+
+        /// <summary>
+        /// Asynchronously execute given unit of work in a <see cref="AccessMode.Read"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <typeparam name="T">The return type of the given unit of work.</typeparam>
+        /// <param name="work">The <see cref="Func{ITransactionAsync, T}"/> to be applied to a new read transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        /// <returns>A task of a result as returned by the given unit of work.</returns>
+        Task<T> ReadTransactionAsync<T>(Func<ITransaction, Task<T>> work, TimeSpan timeout);
+
+        /// <summary>
+        /// Execute given unit of work in a  <see cref="AccessMode.Read"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <param name="work">The <see cref="Action{T}"/> to be applied to a new read transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        void ReadTransaction(Action<ITransaction> work, TimeSpan timeout);
+
+        /// <summary>
+        /// Asynchronously execute given unit of work in a <see cref="AccessMode.Read"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <param name="work">The <see cref="Func{ITransactionAsync, Task}"/> to be applied to a new read transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        /// <returns>A task representing the completion of the transactional read operation enclosing the given unit of work.</returns>
+        Task ReadTransactionAsync(Func<ITransaction, Task> work, TimeSpan timeout);
+
         /// <summary>
         ///  Execute given unit of work in a  <see cref="AccessMode.Write"/> transaction.
         /// </summary>
@@ -163,6 +201,43 @@ namespace Neo4j.Driver.V1
         /// <param name="work">The <see cref="Func{ITransactionAsync, Task}"/> to be applied to a new write transaction.</param>
         /// <returns>A task representing the completion of the transactional write operation enclosing the given unit of work.</returns>
         Task WriteTransactionAsync(Func<ITransaction, Task> work);
+
+        /// <summary>
+        ///  Execute given unit of work in a  <see cref="AccessMode.Write"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <typeparam name="T">The return type of the given unit of work.</typeparam>
+        /// <param name="work">The <see cref="Func{TResult}"/> to be applied to a new write transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        /// <returns>A result as returned by the given unit of work.</returns>
+        T WriteTransaction<T>(Func<ITransaction, T> work, TimeSpan timeout);
+
+        /// <summary>
+        ///  Asynchronously execute given unit of work in a <see cref="AccessMode.Write"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <typeparam name="T">The return type of the given unit of work.</typeparam>
+        /// <param name="work">The <see cref="Func{ITransactionAsync, T}"/> to be applied to a new write transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        /// <returns>A task of a result as returned by the given unit of work.</returns>
+        Task<T> WriteTransactionAsync<T>(Func<ITransaction, Task<T>> work, TimeSpan timeout);
+
+        /// <summary>
+        ///  Execute given unit of work in a  <see cref="AccessMode.Write"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <param name="work">The <see cref="Action{T}"/> to be applied to a new write transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        void WriteTransaction(Action<ITransaction> work, TimeSpan timeout);
+
+        /// <summary>
+        ///  Asynchronously execute given unit of work in a <see cref="AccessMode.Write"/> transaction.
+        /// If the work is not finished within specified transaction timeout, the transaction will be cancelled and rolled back.
+        /// </summary>
+        /// <param name="work">The <see cref="Func{ITransactionAsync, Task}"/> to be applied to a new write transaction.</param>
+        /// <param name="timeout">Transaction timeout.</param>
+        /// <returns>A task representing the completion of the transactional write operation enclosing the given unit of work.</returns>
+        Task WriteTransactionAsync(Func<ITransaction, Task> work, TimeSpan timeout);
 
         /// <summary>
         /// Close all resources used in this Session. If any transaction is left open in this session without commit or rollback,


### PR DESCRIPTION
Experimenting on the transaction timeout

Added timeout for `Session.BeginTx`.
Added timeout for `Session.ReadTransaction` and `Session.WriteTransaction`.

Requires server to also recognize timeout https://github.com/neo4j/neo4j/pull/10563