### PR TITLE
Improve metrics

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DriverIT.cs
@@ -147,8 +147,8 @@ namespace Neo4j.Driver.IntegrationTests
                 }
 
                 // Then
-                var metrics = ((Internal.Driver) driver).GetDriverMetrics();
-                var m = metrics.PoolMetrics.Single().Value;
+                var metrics = ((Internal.Driver) driver).GetMetrics();
+                var m = metrics.ConnectionPoolMetrics.Single().Value;
                 Output.WriteLine(m.ToString());
                 m.Created.Should().Be(sessionCount);
                 m.Created.Should().Be(m.Closed + 1);
@@ -172,7 +172,7 @@ namespace Neo4j.Driver.IntegrationTests
             var startTime = DateTime.Now;
             Output.WriteLine($"[{startTime:HH:mm:ss.ffffff}] Started");
 
-            var metrics = ((Internal.Driver) driver).GetDriverMetrics();
+            var metrics = ((Internal.Driver) driver).GetMetrics();
             var workItem = new SoakRunWorkItem(driver, metrics, Output);
 
             var tasks = new List<Task>();
@@ -182,7 +182,7 @@ namespace Neo4j.Driver.IntegrationTests
             }
             Task.WaitAll(tasks.ToArray());
 
-            var m = metrics.PoolMetrics.Single().Value;
+            var m = metrics.ConnectionPoolMetrics.Single().Value;
             var cm = metrics.ConnectionMetrics.Single().Value;
             Output.WriteLine(m.ToString());
             Output.WriteLine(m.AcquisitionTimeHistogram.ToString());
@@ -193,8 +193,8 @@ namespace Neo4j.Driver.IntegrationTests
             Output.WriteLine($"[{endTime:HH:mm:ss.ffffff}] Finished");
             Output.WriteLine($"Total time spent: {endTime - startTime}");
 
-            m.ToCreate.Should().Be(0);
-            m.ToClose.Should().Be(0);
+            m.Creating.Should().Be(0);
+            m.Closing.Should().Be(0);
             m.InUse.Should().Be(0);
             m.Idle.Should().Be((int) (m.Created - m.Closed));
 
@@ -218,7 +218,7 @@ namespace Neo4j.Driver.IntegrationTests
             var startTime = DateTime.Now;
             Output.WriteLine($"[{startTime:HH:mm:ss.ffffff}] Started");
 
-            var metrics = ((Internal.Driver) driver).GetDriverMetrics();
+            var metrics = ((Internal.Driver) driver).GetMetrics();
             var workItem = new SoakRunWorkItem(driver, metrics, Output);
 
             var tasks = new List<Task>();
@@ -228,7 +228,7 @@ namespace Neo4j.Driver.IntegrationTests
             }
             await Task.WhenAll(tasks);
 
-            var m = metrics.PoolMetrics.Single().Value;
+            var m = metrics.ConnectionPoolMetrics.Single().Value;
             Output.WriteLine(m.ToString());
             Output.WriteLine(m.AcquisitionTimeHistogram.ToString());
 
@@ -236,8 +236,8 @@ namespace Neo4j.Driver.IntegrationTests
             Output.WriteLine($"[{endTime:HH:mm:ss.ffffff}] Finished");
             Output.WriteLine($"Total time spent: {endTime - startTime}");
 
-            m.ToCreate.Should().Be(0);
-            m.ToClose.Should().Be(0);
+            m.Creating.Should().Be(0);
+            m.Closing.Should().Be(0);
             m.InUse.Should().Be(0);
             m.Idle.Should().Be((int) (m.Created - m.Closed));
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverAsyncIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverAsyncIT.cs
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.IntegrationTests
             var startTime = DateTime.Now;
             Output.WriteLine($"[{startTime:HH:mm:ss.ffffff}] Started");
 
-            var metrics = ((Internal.Driver) driver).GetDriverMetrics();
+            var metrics = ((Internal.Driver) driver).GetMetrics();
             var workItem = new SoakRunWorkItem(driver, metrics, Output);
 
             var tasks = new List<Task>();
@@ -158,7 +158,7 @@ namespace Neo4j.Driver.IntegrationTests
             }
             await Task.WhenAll(tasks);
 
-            var poolMetrics = metrics.PoolMetrics;
+            var poolMetrics = metrics.ConnectionPoolMetrics;
             Output.WriteLine(poolMetrics.ToContentString());
             var endTime = DateTime.Now;
             Output.WriteLine($"[{endTime:HH:mm:ss.ffffff}] Finished");
@@ -168,8 +168,8 @@ namespace Neo4j.Driver.IntegrationTests
             {
                 var st = value.Value;
 
-                st.ToCreate.Should().Be(0);
-                st.ToClose.Should().Be(0);
+                st.Creating.Should().Be(0);
+                st.Closing.Should().Be(0);
                 st.InUse.Should().Be(0);
                 st.Idle.Should().Be((int) (st.Created - st.Closed));
             }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverIT.cs
@@ -140,7 +140,7 @@ namespace Neo4j.Driver.IntegrationTests
             var startTime = DateTime.Now;
             Output.WriteLine($"[{startTime:HH:mm:ss.ffffff}] Started");
 
-            var metrics = ((Internal.Driver) driver).GetDriverMetrics();
+            var metrics = ((Internal.Driver) driver).GetMetrics();
             var workItem = new SoakRunWorkItem(driver, metrics, Output);
 
             var tasks = new List<Task>();
@@ -150,7 +150,7 @@ namespace Neo4j.Driver.IntegrationTests
             }
             Task.WaitAll(tasks.ToArray());
 
-            var poolMetrics = metrics.PoolMetrics;
+            var poolMetrics = metrics.ConnectionPoolMetrics;
             Output.WriteLine(poolMetrics.ToContentString());
             var endTime = DateTime.Now;
             Output.WriteLine($"[{endTime:HH:mm:ss.ffffff}] Finished");
@@ -160,8 +160,8 @@ namespace Neo4j.Driver.IntegrationTests
             {
                 var st = value.Value;
 
-                st.ToCreate.Should().Be(0);
-                st.ToClose.Should().Be(0);
+                st.Creating.Should().Be(0);
+                st.Closing.Should().Be(0);
                 st.InUse.Should().Be(0);
                 st.Idle.Should().Be((int) (st.Created - st.Closed));
             }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverStressIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverStressIT.cs
@@ -31,7 +31,7 @@ namespace Neo4j.Driver.IntegrationTests
     public class RoutingDriverStressIT : RoutingDriverTestBase
     {
         private Internal.Driver _driver;
-        private IDriverMetrics _metrics;
+        private IMetrics _metrics;
         private ConcurrentQueue<IPooledConnection> _connections;
         private readonly CancellationTokenSource _cancellationTokenSource;
 
@@ -107,15 +107,15 @@ namespace Neo4j.Driver.IntegrationTests
 
         private void PrintStatistics()
         {
-            var poolMetrics = _metrics.PoolMetrics;
+            var poolMetrics = _metrics.ConnectionPoolMetrics;
             Output.WriteLine(poolMetrics.ToContentString());
 
             foreach (var value in poolMetrics)
             {
                 var st = value.Value;
 
-                st.ToCreate.Should().Be(0);
-                st.ToClose.Should().Be(0);
+                st.Creating.Should().Be(0);
+                st.Closing.Should().Be(0);
                 st.InUse.Should().Be(0);
                 st.Idle.Should().Be((int) (st.Created + st.FailedToCreate - st.Closed));
             }
@@ -139,7 +139,7 @@ namespace Neo4j.Driver.IntegrationTests
 
             _driver = (Internal.Driver) GraphDatabase.CreateDriver(new Uri(RoutingServer), config, connectionFactory);
             _connections = connectionFactory.Connections;
-            _metrics = _driver.GetDriverMetrics();
+            _metrics = _driver.GetMetrics();
         }
 
         private Task ConnectionTerminator()

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Shared/SoakRunWorkItem.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Shared/SoakRunWorkItem.cs
@@ -40,13 +40,13 @@ namespace Neo4j.Driver.IntegrationTests
 
         private readonly ITestOutputHelper _output;
         private readonly IDriver _driver;
-        private readonly IDriverMetrics _driverMetrics;
+        private readonly IMetrics _metrics;
         private int _counter;
 
-        public SoakRunWorkItem(IDriver driver, IDriverMetrics driverMetrics, ITestOutputHelper output)
+        public SoakRunWorkItem(IDriver driver, IMetrics metrics, ITestOutputHelper output)
         {
             this._driver = driver;
-            this._driverMetrics = driverMetrics;
+            this._metrics = metrics;
             this._output = output;
         }
 
@@ -67,7 +67,7 @@ namespace Neo4j.Driver.IntegrationTests
                             var result = session.Run(query);
                             if (currentIteration % 1000 == 0)
                             {
-                                _output.WriteLine(_driverMetrics.PoolMetrics.ToContentString());
+                                _output.WriteLine(_metrics.ConnectionPoolMetrics.ToContentString());
                             }
 
                             result.Consume();
@@ -97,7 +97,7 @@ namespace Neo4j.Driver.IntegrationTests
                 var result = await session.RunAsync(query);
                 if (currentIteration % 1000 == 0)
                 {
-                    _output.WriteLine(_driverMetrics.PoolMetrics.ToContentString());
+                    _output.WriteLine(_metrics.ConnectionPoolMetrics.ToContentString());
                 }
                 await result.SummaryAsync();
             }
@@ -141,7 +141,7 @@ namespace Neo4j.Driver.IntegrationTests
 
                             if (currentIteration % 1000 == 0)
                             {
-                                _output.WriteLine(_driverMetrics.PoolMetrics.ToContentString());
+                                _output.WriteLine(_metrics.ConnectionPoolMetrics.ToContentString());
                             }
                         }
                         catch (Exception e)
@@ -182,7 +182,7 @@ namespace Neo4j.Driver.IntegrationTests
 
                     if (currentIteration % 1000 == 0)
                     {
-                        _output.WriteLine(_driverMetrics.PoolMetrics.ToContentString());
+                        _output.WriteLine(_metrics.ConnectionPoolMetrics.ToContentString());
                     }
 
                 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -1120,7 +1120,7 @@ namespace Neo4j.Driver.Tests
             {
                 var pool = NewConnectionPool();
                 pool.Acquire();
-                pool.Status.Should().Be(PoolStatus.Active);
+                pool.Status.Should().Be(ConnectionPoolStatus.Active);
             }
 
             [Fact]
@@ -1136,7 +1136,7 @@ namespace Neo4j.Driver.Tests
 
                 idleQueue.Count.Should().Be(1);
                 inUseConnections.Count.Should().Be(0);
-                pool.Status.Should().Be(PoolStatus.Active);
+                pool.Status.Should().Be(ConnectionPoolStatus.Active);
             }
 
             [Fact]
@@ -1144,7 +1144,7 @@ namespace Neo4j.Driver.Tests
             {
                 var pool = NewConnectionPool();
                 pool.Dispose();
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
 
             [Fact]
@@ -1152,7 +1152,7 @@ namespace Neo4j.Driver.Tests
             {
                 var pool = NewConnectionPool();
                 pool.Activate();
-                pool.Status.Should().Be(PoolStatus.Active);
+                pool.Status.Should().Be(ConnectionPoolStatus.Active);
             }
 
             [Fact]
@@ -1160,7 +1160,7 @@ namespace Neo4j.Driver.Tests
             {
                 var pool = NewConnectionPool();
                 pool.Deactivate();
-                pool.Status.Should().Be(PoolStatus.Inactive);
+                pool.Status.Should().Be(ConnectionPoolStatus.Inactive);
             }
 
             // inactive
@@ -1168,12 +1168,12 @@ namespace Neo4j.Driver.Tests
             public void FromInactiveViaAcquireThrowsError()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Inactive;
+                pool.Status = ConnectionPoolStatus.Inactive;
 
                 var exception = Record.Exception(()=>pool.Acquire());
 
                 exception.Should().BeOfType<ClientException>();
-                pool.Status.Should().Be(PoolStatus.Inactive);
+                pool.Status.Should().Be(ConnectionPoolStatus.Inactive);
             }
 
             [Fact]
@@ -1186,46 +1186,46 @@ namespace Neo4j.Driver.Tests
                 inUseConnections.TryAdd(conn);
 
                 var pool = NewConnectionPool(idleQueue, inUseConnections);
-                pool.Status = PoolStatus.Inactive;
+                pool.Status = ConnectionPoolStatus.Inactive;
 
                 pool.Release(conn);
 
                 inUseConnections.Count.Should().Be(0);
                 idleQueue.Count.Should().Be(0);
-                pool.Status.Should().Be(PoolStatus.Inactive);
+                pool.Status.Should().Be(ConnectionPoolStatus.Inactive);
             }
 
             [Fact]
             public void FromInactiveViaDisposeToClosed()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Inactive;
+                pool.Status = ConnectionPoolStatus.Inactive;
 
                 pool.Dispose();
 
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
 
             [Fact]
             public void FromInactiveViaActivateToActive()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Inactive;
+                pool.Status = ConnectionPoolStatus.Inactive;
 
                 pool.Activate();
 
-                pool.Status.Should().Be(PoolStatus.Active);
+                pool.Status.Should().Be(ConnectionPoolStatus.Active);
             }
 
             [Fact]
             public void FromInactiveViaDeactiateToInactive()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Inactive;
+                pool.Status = ConnectionPoolStatus.Inactive;
 
                 pool.Deactivate();
 
-                pool.Status.Should().Be(PoolStatus.Inactive);
+                pool.Status.Should().Be(ConnectionPoolStatus.Inactive);
             }
 
             //closed
@@ -1233,12 +1233,12 @@ namespace Neo4j.Driver.Tests
             public void FromClosedViaAcquireThrowsError()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Closed;
+                pool.Status = ConnectionPoolStatus.Closed;
 
                 var exception = Record.Exception(()=>pool.Acquire());
 
                 exception.Should().BeOfType<ObjectDisposedException>();
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
 
             [Fact]
@@ -1251,46 +1251,46 @@ namespace Neo4j.Driver.Tests
                 inUseConnections.TryAdd(conn);
 
                 var pool = NewConnectionPool(idleQueue, inUseConnections);
-                pool.Status = PoolStatus.Closed;
+                pool.Status = ConnectionPoolStatus.Closed;
 
                 pool.Release(conn);
 
                 inUseConnections.Count.Should().Be(1);
                 idleQueue.Count.Should().Be(0);
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
 
             [Fact]
             public void FromClosedViaDisposeToClosed()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Closed;
+                pool.Status = ConnectionPoolStatus.Closed;
 
                 pool.Dispose();
 
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
 
             [Fact]
             public void FromClosedViaActivateToClosed()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Closed;
+                pool.Status = ConnectionPoolStatus.Closed;
 
                 pool.Activate();
 
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
 
             [Fact]
             public void FromClosedViaDeactivateToClosed()
             {
                 var pool = NewConnectionPool();
-                pool.Status = PoolStatus.Closed;
+                pool.Status = ConnectionPoolStatus.Closed;
 
                 pool.Deactivate();
 
-                pool.Status.Should().Be(PoolStatus.Closed);
+                pool.Status.Should().Be(ConnectionPoolStatus.Closed);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolSettings.cs
@@ -28,9 +28,9 @@ namespace Neo4j.Driver.Internal
         public TimeSpan ConnectionAcquisitionTimeout { get; }
         public TimeSpan ConnectionIdleTimeout { get; }
         public TimeSpan MaxConnectionLifetime { get; }
-        public DriverMetrics DriverMetrics { get; }
+        public Metrics.Metrics Metrics { get; }
 
-        public ConnectionPoolSettings(Config config, DriverMetrics metrics = null)
+        public ConnectionPoolSettings(Config config, Metrics.Metrics metrics = null)
             : this(config.MaxIdleConnectionPoolSize, config.MaxConnectionPoolSize, config.ConnectionAcquisitionTimeout,
                 config.ConnectionIdleTimeout, config.MaxConnectionLifetime, metrics)
         {
@@ -38,14 +38,14 @@ namespace Neo4j.Driver.Internal
 
         internal ConnectionPoolSettings(int maxIdleConnectionPoolSize, int maxConnectionPoolSize,
             TimeSpan connectionAcquisitionTimeout, TimeSpan connectionIdleTimeout, TimeSpan maxConnectionLifetime,
-            DriverMetrics metrics = null)
+            Metrics.Metrics metrics = null)
         {
             MaxIdleConnectionPoolSize = maxIdleConnectionPoolSize;
             MaxConnectionPoolSize = maxConnectionPoolSize;
             ConnectionAcquisitionTimeout = connectionAcquisitionTimeout;
             ConnectionIdleTimeout = connectionIdleTimeout;
             MaxConnectionLifetime = maxConnectionLifetime;
-            DriverMetrics = metrics;
+            Metrics = metrics;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -61,12 +61,12 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void OnAcquire()
         {
-            _connMetricsListener?.OnAcquire(_connEvent);
+            _connMetricsListener?.ConnectionAcquired(_connEvent);
         }
 
         public void OnRelease()
         {
-            _connMetricsListener?.OnRelease(_connEvent);
+            _connMetricsListener?.ConnectionReleased(_connEvent);
         }
 
         public override bool IsOpen => Delegate.IsOpen && !HasUnrecoverableError;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -69,12 +69,12 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void Start()
         {
-            _connMetricsListener?.BeforeConnect(_connEvent);
+            _connMetricsListener?.ConnectionConnecting(_connEvent);
             _tcpSocketClient.Connect(_uri);
 
             SetOpened();
             _logger?.Debug($"~~ [CONNECT] {_uri}");
-            _connMetricsListener?.AfterConnect(_connEvent);
+            _connMetricsListener?.ConnectionConnected(_connEvent);
 
             var version = DoHandshake();
             _boltProtocol = BoltProtocolFactory.Create(version, _tcpSocketClient, _bufferSettings, _logger);
@@ -84,11 +84,11 @@ namespace Neo4j.Driver.Internal.Connector
         {
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
 
-            _connMetricsListener?.BeforeConnect(_connEvent);
+            _connMetricsListener?.ConnectionConnecting(_connEvent);
             _tcpSocketClient.ConnectAsync(_uri)
                 .ContinueWith(t =>
                     {
-                        _connMetricsListener?.AfterConnect(_connEvent);
+
 
                         if (t.IsFaulted)
                         {
@@ -102,7 +102,7 @@ namespace Neo4j.Driver.Internal.Connector
                         {
                             SetOpened();
                             _logger?.Debug($"~~ [CONNECT] {_uri}");
-
+                            _connMetricsListener?.ConnectionConnected(_connEvent);
                             return DoHandshakeAsync();
                         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -30,14 +30,14 @@ namespace Neo4j.Driver.Internal
         private readonly IConnectionProvider _connectionProvider;
         private readonly IRetryLogic _retryLogic;
         private readonly ILogger _logger;
-        private readonly IDriverMetrics _driverMetrics;
+        private readonly IMetrics _metrics;
         public Uri Uri { get; }
 
         private const AccessMode DefaultAccessMode = AccessMode.Write;
         private const string NullBookmark = null;
 
         internal Driver(Uri uri, IConnectionProvider connectionProvider, IRetryLogic retryLogic, ILogger logger,
-            IDriverMetrics driverMetrics=null)
+            IMetrics metrics=null)
         {
             Throw.ArgumentNullException.IfNull(connectionProvider, nameof(connectionProvider));
 
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.Internal
             _logger = logger;
             _connectionProvider = connectionProvider;
             _retryLogic = retryLogic;
-            _driverMetrics = driverMetrics;
+            _metrics = metrics;
         }
 
         private bool IsClosed => _closedMarker > 0;
@@ -140,13 +140,13 @@ namespace Neo4j.Driver.Internal
             throw new ObjectDisposedException(GetType().Name, "Cannot open a new session on a driver that is already disposed.");
         }
 
-        internal IDriverMetrics GetDriverMetrics()
+        internal IMetrics GetMetrics()
         {
-            if (_driverMetrics == null)
+            if (_metrics == null)
             {
                 throw new InvalidOperationException("Cannot access driver metrics if it is not enabled when creating this driver.");
             }
-            return _driverMetrics;
+            return _metrics;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
@@ -23,7 +23,7 @@ namespace Neo4j.Driver.Internal
     {
         int NumberOfInUseConnections { get; }
         int NumberOfIdleConnections { get; }
-        PoolStatus Status { get; }
+        ConnectionPoolStatus Status { get; }
         void Deactivate();
         Task DeactivateAsync();
         void Activate();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/ConnectionMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/ConnectionMetrics.cs
@@ -35,22 +35,22 @@ namespace Neo4j.Driver.Internal.Metrics
             _inUseTimeHistogram = new Histogram();
         }
 
-        public void BeforeConnect(IListenerEvent connEvent)
+        public void ConnectionConnecting(IListenerEvent connEvent)
         {
             connEvent.Start();
         }
 
-        public void AfterConnect(IListenerEvent connEvent)
+        public void ConnectionConnected(IListenerEvent connEvent)
         {
             _connectionTimeHistogram.RecordValue(connEvent.GetElapsed());
         }
 
-        public void OnAcquire(IListenerEvent connEvent)
+        public void ConnectionAcquired(IListenerEvent connEvent)
         {
             connEvent.Start();
         }
 
-        public void OnRelease(IListenerEvent connEvent)
+        public void ConnectionReleased(IListenerEvent connEvent)
         {
             _inUseTimeHistogram.RecordValue(connEvent.GetElapsed());
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/DriverMetricsManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/DriverMetricsManager.cs
@@ -44,16 +44,16 @@ namespace Neo4j.Driver.Internal.Metrics
         public IConnectionPoolListener PoolMetricsListener => _poolMetrics;
         public IConnectionListener ConnectionMetricsListener => _connMetrics;
 
-        public DriverMetricsManager(DriverMetrics driverMetrics, Uri poolUri, ConnectionPool pool)
+        public DriverMetricsManager(Metrics metrics, Uri poolUri, ConnectionPool pool)
         {
-            Throw.ArgumentNullException.IfNull(driverMetrics, nameof(driverMetrics));
-            Throw.ArgumentNullException.IfNull(driverMetrics.ConnectionMetrics, nameof(driverMetrics.ConnectionMetrics));
-            Throw.ArgumentNullException.IfNull(driverMetrics.PoolMetrics, nameof(driverMetrics.PoolMetrics));
+            Throw.ArgumentNullException.IfNull(metrics, nameof(metrics));
+            Throw.ArgumentNullException.IfNull(metrics.ConnectionMetrics, nameof(metrics.ConnectionMetrics));
+            Throw.ArgumentNullException.IfNull(metrics.ConnectionPoolMetrics, nameof(metrics.ConnectionPoolMetrics));
             Throw.ArgumentNullException.IfNull(poolUri, nameof(poolUri));
             Throw.ArgumentNullException.IfNull(pool, nameof(pool));
 
-            _poolMetrics = driverMetrics.AddPoolMetrics(poolUri, pool);
-            _connMetrics = driverMetrics.AddConnMetrics(poolUri);
+            _poolMetrics = metrics.AddPoolMetrics(poolUri, pool);
+            _connMetrics = metrics.AddConnMetrics(poolUri);
         }
 
         public void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IConnectionListener.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IConnectionListener.cs
@@ -22,11 +22,11 @@ namespace Neo4j.Driver.Internal.Metrics
 {
     internal interface IConnectionListener
     {
-        void BeforeConnect(IListenerEvent connEvent);
-        void AfterConnect(IListenerEvent connEvent);
+        void ConnectionConnecting(IListenerEvent connEvent);
+        void ConnectionConnected(IListenerEvent connEvent);
 
-        void OnAcquire(IListenerEvent connEvent);
-        void OnRelease(IListenerEvent connEvent);
+        void ConnectionAcquired(IListenerEvent connEvent);
+        void ConnectionReleased(IListenerEvent connEvent);
     }
 
     internal interface IListenerEvent

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IConnectionPoolListener.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IConnectionPoolListener.cs
@@ -22,12 +22,14 @@ namespace Neo4j.Driver.Internal.Metrics
 {
     internal interface IConnectionPoolListener: IDisposable
     {
-        void BeforeConnectionCreated();
-        void AfterConnectionCreatedSuccessfully();
-        void AfterConnectionFailedToCreate();
-        void BeforeConnectionClosed();
-        void AfterConnectionClosed();
-        void BeforeAcquire(IListenerEvent listenerEvent);
-        void AfterAcquire(IListenerEvent listenerEvent);
+        void ConnectionCreating();
+        void ConnectionCreated();
+        void ConnectionFailedToCreate();
+        void ConnectionClosing();
+        void ConnectionClosed();
+        void PoolAcquiring(IListenerEvent listenerEvent);
+        void PoolAcquired(IListenerEvent listenerEvent);
+        void PoolFailedToAcquire();
+        void PoolTimedOutToAcquire();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IMetrics.cs
@@ -23,12 +23,12 @@ namespace Neo4j.Driver.Internal.Metrics
     /// <summary>
     /// The driver metrics
     /// </summary>
-    internal interface IDriverMetrics
+    internal interface IMetrics
     {
         /// <summary>
         /// The connection pool metrics.
         /// </summary>
-        IDictionary<string, IConnectionPoolMetrics> PoolMetrics { get; }
+        IDictionary<string, IConnectionPoolMetrics> ConnectionPoolMetrics { get; }
 
         /// <summary>
         /// The connection metrics.
@@ -68,7 +68,7 @@ namespace Neo4j.Driver.Internal.Metrics
         /// <summary>
         /// The pool status
         /// </summary>
-        string PoolStatus { get; }
+        PoolStatus PoolStatus { get; }
 
         /// <summary>
         /// The amount of the connections that are used by user's application
@@ -83,22 +83,12 @@ namespace Neo4j.Driver.Internal.Metrics
         /// <summary>
         /// The amount of connections that are waiting to be created.
         /// </summary>
-        int ToCreate { get; }
-
-        /// <summary>
-        /// The amount of connections that are waiting to be closed.
-        /// </summary>
-        int ToClose { get; }
+        int Creating { get; }
 
         /// <summary>
         /// The amount of connections that have been created by this driver
         /// </summary>
         long Created { get; }
-
-        /// <summary>
-        /// The amount of connections that have been closed by this driver.
-        /// </summary>
-        long Closed { get; }
 
         /// <summary>
         /// The amount of connections that are failed to be created.
@@ -107,10 +97,40 @@ namespace Neo4j.Driver.Internal.Metrics
         long FailedToCreate { get; }
 
         /// <summary>
+        /// The amount of connections that are waiting to be closed.
+        /// </summary>
+        int Closing { get; }
+
+        /// <summary>
+        /// The amount of connections that have been closed by this driver.
+        /// </summary>
+        long Closed { get; }
+
+        /// <summary>
+        /// The amount of requests trying to acquire a connection from the pool.
+        /// </summary>
+        int Acquiring { get; }
+
+        /// <summary>
+        /// The amount of requests that have acquired a connection out of the pool.
+        /// </summary>
+        long Acquired { get; }
+
+        /// <summary>
+        /// The amount of requests to acquire a connection from pool but failed due to acquisition timeout.
+        /// </summary>
+        long TimedOutToAcquire { get; }
+
+        /// <summary>
         /// The histgram of the delays to acquire a connection from the pool in "ticks" where a tick equals to 100 ns.
         /// The delays could either be the time to create a new connection or the time waiting for a connection available from the pool.
         /// </summary>
         IHistogram AcquisitionTimeHistogram { get; }
+    }
+
+    internal enum PoolStatus
+    {
+        Open, Closed, Inactive
     }
 
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/Metrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/Metrics.cs
@@ -18,17 +18,18 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Metrics
 {
-    internal class DriverMetrics : IDriverMetrics
+    internal class Metrics : IMetrics
     {
         private readonly ConcurrentDictionary<string, IConnectionPoolMetrics> _poolMetrics;
         private readonly ConcurrentDictionary<string, IConnectionMetrics> _connMetrics;
         private readonly Config _config;
 
-        public DriverMetrics(Config config)
+        public Metrics(Config config)
         {
             _config = config;
             _poolMetrics = new ConcurrentDictionary<string, IConnectionPoolMetrics>();
@@ -55,7 +56,7 @@ namespace Neo4j.Driver.Internal.Metrics
             return connMetrics;
         }
 
-        public IDictionary<string, IConnectionPoolMetrics> PoolMetrics => _poolMetrics;
-        public IDictionary<string, IConnectionMetrics> ConnectionMetrics => _connMetrics;
+        public IDictionary<string, IConnectionPoolMetrics> ConnectionPoolMetrics => new ReadOnlyDictionary<string, IConnectionPoolMetrics>(_poolMetrics);
+        public IDictionary<string, IConnectionMetrics> ConnectionMetrics => new ReadOnlyDictionary<string, IConnectionMetrics>(_connMetrics);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/GraphDatabase.cs
@@ -217,12 +217,12 @@ namespace Neo4j.Driver.V1
             var routingContext = uri.ParseRoutingContext();
             var routingSettings = new RoutingSettings(parsedUri, routingContext, config);
 
-            DriverMetrics driverMetrics = null;
+            Metrics metrics = null;
             if (config.DriverMetricsEnabled)
             {
-                driverMetrics = new DriverMetrics(config);
+                metrics = new Metrics(config);
             }
-            var connectionPoolSettings = new ConnectionPoolSettings(config, driverMetrics);
+            var connectionPoolSettings = new ConnectionPoolSettings(config, metrics);
 
             var retryLogic = new ExponentialBackoffRetryLogic(config.MaxTransactionRetryTime, logger);
 
@@ -240,7 +240,7 @@ namespace Neo4j.Driver.V1
                     throw new NotSupportedException($"Unsupported URI scheme: {parsedUri.Scheme}");
             }
 
-            return new Internal.Driver(parsedUri, connectionProvider, retryLogic, logger, driverMetrics);
+            return new Internal.Driver(parsedUri, connectionProvider, retryLogic, logger, metrics);
         }
 
         private static void EnsureNoRoutingContext(Uri uri, IDictionary<string, string> routingContext)


### PR DESCRIPTION
Renamed some interface methods to be the same as Java driver, such as `DriverMetrics` -> `Metrics`, `PoolStatus` string -> enum.
Added a few new counter `acquiring`, `acquired`, `timedOutToAcquire`.
Changed to return a readonly dictionary so that a user cannot add/remove items in the returned dictionary.
Changed the ConnectionTimeHistogram to only record success connection time.
Changed the Acquisition Histogram to only record success acquisition time.