### PR TITLE
Remove UTC normalization logic when interacting with server

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeWithOffsetHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeWithOffsetHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(3);
             reader.ReadStructSignature().Should().Be((byte) 'F');
-            reader.Read().Should().Be(dateTime.EpochSecondsUtc);
+            reader.Read().Should().Be(dateTime.EpochSeconds);
             reader.Read().Should().Be((long) dateTime.NanosOfSecond);
             reader.Read().Should().Be((long) dateTime.OffsetSeconds);
         }
@@ -71,7 +71,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.EpochSecondsUtc.Should().Be(1520919278);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.EpochSeconds.Should().Be(1520919278);
             value.Should().BeOfType<CypherDateTimeWithOffset>().Which.NanosOfSecond.Should().Be(128000987);
             value.Should().BeOfType<CypherDateTimeWithOffset>().Which.OffsetSeconds.Should().Be((int)TimeSpan.FromMinutes(-150).TotalSeconds);
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithOffsetTests.cs
@@ -77,8 +77,8 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldCreateDateWithRawValues()
         {
             var dateTime = new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945);
-            var cypherDateTime = new CypherDateTimeWithOffset(TemporalHelpers.SecondsSinceEpoch(dateTime.AddSeconds(-1500).Ticks),
-                TemporalHelpers.NanosOfSecond(dateTime.AddSeconds(-1500).Ticks), 1500);
+            var cypherDateTime = new CypherDateTimeWithOffset(TemporalHelpers.SecondsSinceEpoch(dateTime.Ticks),
+                TemporalHelpers.NanosOfSecond(dateTime.Ticks), 1500);
 
             cypherDateTime.DateTime.Should().Be(dateTime);
             cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
@@ -100,7 +100,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 17, 15, 12, 01, 789000000, 1800);
             var dateTime2 = new CypherDateTimeWithOffset(new DateTime(1947, 12, 17, 15, 12, 01, 789), 1800);
-            var dateTime3 = new CypherDateTimeWithOffset(-695553479, 789000000, 1800);
+            var dateTime3 = new CypherDateTimeWithOffset(-695551679, 789000000, 1800);
 
             dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode()).And.Be(dateTime3.GetHashCode());
         }
@@ -120,10 +120,10 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 17, 15, 12, 01, 789000000, 1800);
             var dateTime2 = new CypherDateTimeWithOffset(new DateTime(1947, 12, 17, 15, 12, 01, 789), 1800);
-            var dateTime3 = new CypherDateTimeWithOffset(-695553479, 789000000, 1800);
+            var dateTime3 = new CypherDateTimeWithOffset(-695551679, 789000000, 1800);
 
-            dateTime1.Equals(dateTime2).Should().BeTrue();
-            dateTime1.Equals(dateTime3).Should().BeTrue();
+            dateTime1.Should().Be(dateTime2);
+            dateTime1.Should().Be(dateTime3);
         }
 
         [Fact]
@@ -133,8 +133,8 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime2 = new CypherDateTimeWithOffset(new DateTime(1947, 12, 17, 15, 12, 01, 790), 1800);
             var dateTime3 = new CypherDateTimeWithOffset(-695553479, 789005000, 1800);
 
-            dateTime1.Equals(dateTime2).Should().BeFalse();
-            dateTime1.Equals(dateTime3).Should().BeFalse();
+            dateTime1.Should().NotBe(dateTime2);
+            dateTime1.Should().NotBe(dateTime3);
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
@@ -26,46 +26,48 @@ namespace Neo4j.Driver.Tests.Types
     public class CypherDateTimeWithZoneIdTests
     {
 
-//        Uncomment when server enforced UTC normalization is reverted.
-//        [Fact]
-//        public void ShouldCreateDateTimeWithZoneIdWithDateTimeComponents()
-//        {
-//            var cypherDateTime = new CypherDateTimeWithZoneId(1947, 12, 17, 23, 49, 54, "Europe/Rome");
-//
-//            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
-//            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(60));
-//            cypherDateTime.ZoneId.Should().Be("Europe/Rome");
-//        }
-//
-//        [Fact]
-//        public void ShouldCreateDateTimeWithZoneIdWithDateTimeComponentsWithNanoseconds()
-//        {
-//            var cypherDateTime = new CypherDateTimeWithZoneId(1947, 12, 17, 23, 49, 54, 192794500, "Europe/Rome");
-//
-//            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
-//            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
-//        }
-//
-//        [Fact]
-//        public void ShouldCreateDateTimeWithZoneIdWithDateTime()
-//        {
-//            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120);
-//            var cypherDateTime = new CypherDateTimeWithZoneId(dateTime, "Europe/Rome");
-//
-//            cypherDateTime.DateTime.Should().Be(dateTime);
-//            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
-//        }
-//
-//        [Fact]
-//        public void ShouldCreateDateWithRawValues()
-//        {
-//            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945);
-//            var cypherDateTime = new CypherDateTimeWithZoneId(TemporalHelpers.ComputeSecondsSinceEpoch(dateTime.AddSeconds(-1500).Ticks),
-//                TemporalHelpers.ComputeNanosOfSecond(dateTime.AddSeconds(-1500).Ticks), "Europe/Rome");
-//
-//            cypherDateTime.DateTime.Should().Be(dateTime);
-//            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
-//        }
+        [Fact]
+        public void ShouldCreateDateTimeWithZoneIdWithDateTimeComponents()
+        {
+            var cypherDateTime = new CypherDateTimeWithZoneId(1947, 12, 17, 23, 49, 54, "Europe/Rome");
+
+            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
+            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.ZoneId.Should().Be("Europe/Rome");
+        }
+
+        [Fact]
+        public void ShouldCreateDateTimeWithZoneIdWithDateTimeComponentsWithNanoseconds()
+        {
+            var cypherDateTime = new CypherDateTimeWithZoneId(1947, 12, 17, 23, 49, 54, 192794500, "Europe/Rome");
+
+            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
+            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.ZoneId.Should().Be("Europe/Rome");
+        }
+
+        [Fact]
+        public void ShouldCreateDateTimeWithZoneIdWithDateTime()
+        {
+            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120);
+            var cypherDateTime = new CypherDateTimeWithZoneId(dateTime, "Europe/Rome");
+
+            cypherDateTime.DateTime.Should().Be(dateTime);
+            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.ZoneId.Should().Be("Europe/Rome");
+        }
+
+        [Fact]
+        public void ShouldCreateDateWithRawValues()
+        {
+            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945);
+            var cypherDateTime = new CypherDateTimeWithZoneId(TemporalHelpers.SecondsSinceEpoch(dateTime.Ticks),
+                TemporalHelpers.NanosOfSecond(dateTime.Ticks), "Europe/Rome");
+
+            cypherDateTime.DateTime.Should().Be(dateTime);
+            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.ZoneId.Should().Be("Europe/Rome");
+        }
 
         [Fact]
         public void ShouldGenerateCorrectString()
@@ -83,7 +85,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 15, 12, 01, 789000000, "Europe/Rome");
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 789), "Europe/Rome");
-            var dateTime3 = new CypherDateTimeWithZoneId(-695555279, 789000000, "Europe/Rome");
+            var dateTime3 = new CypherDateTimeWithZoneId(-695551679, 789000000, "Europe/Rome");
 
             dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode()).And.Be(dateTime3.GetHashCode());
         }
@@ -103,10 +105,10 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 15, 12, 01, 789000000, "Europe/Rome");
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 789), "Europe/Rome");
-            var dateTime3 = new CypherDateTimeWithZoneId(-695555279, 789000000, "Europe/Rome");
+            var dateTime3 = new CypherDateTimeWithZoneId(-695551679, 789000000, "Europe/Rome");
 
-            dateTime1.Equals(dateTime2).Should().BeTrue();
-            dateTime1.Equals(dateTime3).Should().BeTrue();
+            dateTime1.Should().Be(dateTime2);
+            dateTime1.Should().Be(dateTime3);
         }
 
         [Fact]
@@ -116,8 +118,8 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 790), "Europe/Rome");
             var dateTime3 = new CypherDateTimeWithZoneId(-695555279, 789005000, "Europe/Rome");
 
-            dateTime1.Equals(dateTime2).Should().BeFalse();
-            dateTime1.Equals(dateTime3).Should().BeFalse();
+            dateTime1.Should().NotBe(dateTime2);
+            dateTime1.Should().NotBe(dateTime3);
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithOffsetHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithOffsetHandler.cs
@@ -46,7 +46,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var dateTime = value.CastOrThrow<CypherDateTimeWithOffset>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(dateTime.EpochSecondsUtc);
+            writer.Write(dateTime.EpochSeconds);
             writer.Write(dateTime.NanosOfSecond);
             writer.Write(dateTime.OffsetSeconds);
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithZoneIdHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithZoneIdHandler.cs
@@ -46,7 +46,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var dateTime = value.CastOrThrow<CypherDateTimeWithZoneId>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(dateTime.EpochSecondsUtc);
+            writer.Write(dateTime.EpochSeconds);
             writer.Write(dateTime.NanosOfSecond);
             writer.Write(dateTime.ZoneId);
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
@@ -85,7 +85,7 @@ namespace Neo4j.Driver.V1
         /// <param name="dateTime"></param>
         /// <param name="offset"></param>
         public CypherDateTimeWithOffset(DateTime dateTime, TimeSpan offset)
-            : this((dateTime.Kind == DateTimeKind.Unspecified ? dateTime : new DateTime(dateTime.Ticks, DateTimeKind.Unspecified)).Ticks - offset.Ticks, (int)offset.TotalSeconds)
+            : this((dateTime.Kind == DateTimeKind.Unspecified ? dateTime : new DateTime(dateTime.Ticks, DateTimeKind.Unspecified)).Ticks, (int)offset.TotalSeconds)
         {
 
         }
@@ -93,19 +93,18 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from ticks.
         /// </summary>
-        /// <param name="ticksUtc"></param>
+        /// <param name="ticks"></param>
         /// <param name="offsetSeconds"></param>
-        public CypherDateTimeWithOffset(long ticksUtc, int offsetSeconds)
-            : this(TemporalHelpers.SecondsSinceEpoch(ticksUtc),
-                TemporalHelpers.NanosOfSecond(ticksUtc), offsetSeconds)
+        public CypherDateTimeWithOffset(long ticks, int offsetSeconds)
+            : this(TemporalHelpers.SecondsSinceEpoch(ticks),
+                TemporalHelpers.NanosOfSecond(ticks), offsetSeconds)
         {
 
         }
 
-        internal CypherDateTimeWithOffset(long epochSecondsUtc, int nanosOfSecond, int offsetSeconds)
+        internal CypherDateTimeWithOffset(long epochSeconds, int nanosOfSecond, int offsetSeconds)
         {
-            EpochSecondsUtc = epochSecondsUtc;
-            EpochSeconds = epochSecondsUtc + offsetSeconds;
+            EpochSeconds = epochSeconds;
             NanosOfSecond = nanosOfSecond;
             OffsetSeconds = offsetSeconds;
         }
@@ -114,8 +113,6 @@ namespace Neo4j.Driver.V1
         /// Seconds since Unix Epoch
         /// </summary>
         public long EpochSeconds { get; }
-
-        internal long EpochSecondsUtc { get; }
 
         /// <summary>
         /// Fraction of seconds in nanosecond precision


### PR DESCRIPTION
In 3.4.0-alpha releases of the server, the `CypherDateTimeWithOffset` and `CypherDateTimeWithZoneId` values were expected to be UTC normalized while interacting with the server. Starting with 3.4.0-beta01 this normalization is no longer in place.

This PR removes the UTC normalization logic from corresponding custom types.