### PR TITLE
TimeZone issue when creating `CypherDateTime` from `DateTime`

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.Tests.Types
         [Fact]
         public void ShouldCreateDateTimeWithDateTime()
         {
-            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120);
+            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120, DateTimeKind.Local);
             var cypherDateTime = new CypherDateTime(dateTime);
 
             cypherDateTime.ToDateTime().Should().Be(dateTime);
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldGenerateSameHashcode()
         {
             var dateTime1 = new CypherDateTime(1947, 12, 17, 15, 12, 01, 789000000);
-            var dateTime2 = new CypherDateTime(new DateTime(1947, 12, 17, 15, 12, 01, 789));
+            var dateTime2 = new CypherDateTime(new DateTime(1947, 12, 17, 15, 12, 01, 789, DateTimeKind.Local));
             var dateTime3 = new CypherDateTime(-695551679, 789000000);
 
             dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode()).And.Be(dateTime3.GetHashCode());
@@ -96,7 +96,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldBeEqual()
         {
             var dateTime1 = new CypherDateTime(1947, 12, 17, 15, 12, 01, 789000000);
-            var dateTime2 = new CypherDateTime(new DateTime(1947, 12, 17, 15, 12, 01, 789));
+            var dateTime2 = new CypherDateTime(new DateTime(1947, 12, 17, 15, 12, 01, 789, DateTimeKind.Local));
 
             dateTime1.Equals(dateTime2).Should().BeTrue();
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
@@ -60,13 +60,20 @@ namespace Neo4j.Driver.V1
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CypherDateTime"/> from given <see cref="DateTime"/> value
+        /// Initializes a new instance of <see cref="CypherDateTime"/> from given <see cref="DateTime"/> value.
+        /// The given <see cref="DateTime"/> value will be normalized to local time <see cref="DateTimeKind.Local"/>
+        /// before being used.
         /// </summary>
+        ///
+        /// <remarks>If the <see cref="DateTime"/> value was created with no <see cref="DateTimeKind"/> specified,
+        /// then <see cref="DateTimeKind.Unspecified"/> would be assigned by default.
+        /// Possible conversion from UTC to local time might happen when normalizing it to local time.
+        /// <seealso cref="DateTime.ToLocalTime"/>
+        /// </remarks>
         /// <param name="dateTime"></param>
         public CypherDateTime(DateTime dateTime)
             : this(dateTime.ToLocalTime().Ticks)
         {
-
         }
 
         internal CypherDateTime(long ticks)


### PR DESCRIPTION
By default `DateTime` uses `DateTimeKind.Unspecified` as the default value if not provided when creating.

However when calling `DateTime#ToLocalTime()` it will consider unspecified means `Utc` and convert from UTC to local.

However, when calling `DateTime#Equal`, the `Kind` will be ignored, and only Ticks will be compared.
This PR suggesting we should respect this `ToLocalTime` method think `Unspecified` as `Utc`. So added more docs for a user to read.