### PR TITLE
Implement IConvertible on temporal types

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateHandlerTests.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 using Moq;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.IO.StructHandlers;
 using Neo4j.Driver.Internal.Messaging;
@@ -48,7 +49,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(1);
             reader.ReadStructSignature().Should().Be((byte) 'D');
-            reader.Read().Should().Be(date.EpochDays);
+            reader.Read().Should().Be(-7063L);
         }
         
         [Fact]
@@ -58,14 +59,16 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var writer = writerMachine.Writer();
 
             writer.WriteStructHeader(DateHandler.StructSize, DateHandler.StructType);
-            writer.Write(6001);
+            writer.Write(-7063L);
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
             var reader = readerMachine.Reader();
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherDate>().Which.EpochDays.Should().Be(6001L);
+            value.Should().BeOfType<CypherDate>().Which.Year.Should().Be(1950);
+            value.Should().BeOfType<CypherDate>().Which.Month.Should().Be(8);
+            value.Should().BeOfType<CypherDate>().Which.Day.Should().Be(31);
         }
         
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeHandlerTests.cs
@@ -48,8 +48,8 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(2);
             reader.ReadStructSignature().Should().Be((byte) 'd');
-            reader.Read().Should().Be(dateTime.EpochSeconds);
-            reader.Read().Should().Be((long)dateTime.NanosOfSecond);
+            reader.Read().Should().Be(282659759L);
+            reader.Read().Should().Be(128000987L);
         }
         
         [Fact]
@@ -59,7 +59,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var writer = writerMachine.Writer();
 
             writer.WriteStructHeader(DateTimeHandler.StructSize, DateTimeHandler.StructType);
-            writer.Write(1520919278);
+            writer.Write(282659759);
             writer.Write(128000987);
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
@@ -67,8 +67,13 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherDateTime>().Which.EpochSeconds.Should().Be(1520919278);
-            value.Should().BeOfType<CypherDateTime>().Which.NanosOfSecond.Should().Be(128000987);
+            value.Should().BeOfType<CypherDateTime>().Which.Year.Should().Be(1978);
+            value.Should().BeOfType<CypherDateTime>().Which.Month.Should().Be(12);
+            value.Should().BeOfType<CypherDateTime>().Which.Day.Should().Be(16);
+            value.Should().BeOfType<CypherDateTime>().Which.Hour.Should().Be(12);
+            value.Should().BeOfType<CypherDateTime>().Which.Minute.Should().Be(35);
+            value.Should().BeOfType<CypherDateTime>().Which.Second.Should().Be(59);
+            value.Should().BeOfType<CypherDateTime>().Which.Nanosecond.Should().Be(128000987);
         }
         
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeWithOffsetHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeWithOffsetHandlerTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 using Moq;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.IO.StructHandlers;
 using Neo4j.Driver.Internal.Messaging;
@@ -50,9 +51,9 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(3);
             reader.ReadStructSignature().Should().Be((byte) 'F');
-            reader.Read().Should().Be(dateTime.EpochSeconds);
-            reader.Read().Should().Be((long) dateTime.NanosOfSecond);
-            reader.Read().Should().Be((long) dateTime.OffsetSeconds);
+            reader.Read().Should().Be(282659759L);
+            reader.Read().Should().Be(128000987L);
+            reader.Read().Should().Be(-9000L);
         }
         
         [Fact]
@@ -62,17 +63,22 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var writer = writerMachine.Writer();
 
             writer.WriteStructHeader(DateTimeWithOffsetHandler.StructSize, DateTimeWithOffsetHandler.StructType);
-            writer.Write(1520919278);
+            writer.Write(282659759);
             writer.Write(128000987);
-            writer.Write((int) TimeSpan.FromMinutes(-150).TotalSeconds);
+            writer.Write(-9000);
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
             var reader = readerMachine.Reader();
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.EpochSeconds.Should().Be(1520919278);
-            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.NanosOfSecond.Should().Be(128000987);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Year.Should().Be(1978);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Month.Should().Be(12);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Day.Should().Be(16);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Hour.Should().Be(12);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Minute.Should().Be(35);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Second.Should().Be(59);
+            value.Should().BeOfType<CypherDateTimeWithOffset>().Which.Nanosecond.Should().Be(128000987);
             value.Should().BeOfType<CypherDateTimeWithOffset>().Which.OffsetSeconds.Should().Be((int)TimeSpan.FromMinutes(-150).TotalSeconds);
         }
         

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeWithZoneIdHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/DateTimeWithZoneIdHandlerTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 using Moq;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.IO.StructHandlers;
 using Neo4j.Driver.Internal.Messaging;
@@ -49,8 +50,8 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(3);
             reader.ReadStructSignature().Should().Be((byte) 'f');
-            reader.Read().Should().Be(dateTime.EpochSeconds);
-            reader.Read().Should().Be((long) dateTime.NanosOfSecond);
+            reader.Read().Should().Be(282659759L);
+            reader.Read().Should().Be(128000987L);
             reader.Read().Should().Be("Europe/Istanbul");
         }
         
@@ -61,7 +62,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var writer = writerMachine.Writer();
 
             writer.WriteStructHeader(DateTimeWithZoneIdHandler.StructSize, DateTimeWithZoneIdHandler.StructType);
-            writer.Write(1520919278);
+            writer.Write(282659759);
             writer.Write(128000987);
             writer.Write("Europe/Istanbul");
 
@@ -70,8 +71,13 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.EpochSeconds.Should().Be(1520919278);
-            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.NanosOfSecond.Should().Be(128000987);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Year.Should().Be(1978);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Month.Should().Be(12);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Day.Should().Be(16);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Hour.Should().Be(12);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Minute.Should().Be(35);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Second.Should().Be(59);
+            value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.Nanosecond.Should().Be(128000987);
             value.Should().BeOfType<CypherDateTimeWithZoneId>().Which.ZoneId.Should().Be("Europe/Istanbul");
         }
         

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/TimeHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/TimeHandlerTests.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 using Moq;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.IO.StructHandlers;
 using Neo4j.Driver.Internal.Messaging;
@@ -48,7 +49,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(1);
             reader.ReadStructSignature().Should().Be((byte) 't');
-            reader.Read().Should().Be(time.NanosecondsOfDay);
+            reader.Read().Should().Be(45359128000987L);
         }
         
         [Fact]
@@ -65,7 +66,10 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherTime>().Which.NanosecondsOfDay.Should().Be(45359128000987);
+            value.Should().BeOfType<CypherTime>().Which.Hour.Should().Be(12);
+            value.Should().BeOfType<CypherTime>().Which.Minute.Should().Be(35);
+            value.Should().BeOfType<CypherTime>().Which.Second.Should().Be(59);
+            value.Should().BeOfType<CypherTime>().Which.Nanosecond.Should().Be(128000987);
         }
         
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/TimeWithOffsetHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/StructHandlers/Temporal/TimeWithOffsetHandlerTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 using Moq;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.IO.StructHandlers;
 using Neo4j.Driver.Internal.Messaging;
@@ -49,7 +50,7 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             reader.PeekNextType().Should().Be(PackStream.PackType.Struct);
             reader.ReadStructHeader().Should().Be(2);
             reader.ReadStructSignature().Should().Be((byte) 'T');
-            reader.Read().Should().Be(time.NanosecondsOfDay);
+            reader.Read().Should().Be(45359128000987L);
             reader.Read().Should().Be((long)time.OffsetSeconds);
         }
         
@@ -68,7 +69,10 @@ namespace Neo4j.Driver.Tests.IO.StructHandlers
             var value = reader.Read();
 
             value.Should().NotBeNull();
-            value.Should().BeOfType<CypherTimeWithOffset>().Which.NanosecondsOfDay.Should().Be(45359128000987);
+            value.Should().BeOfType<CypherTimeWithOffset>().Which.Hour.Should().Be(12);
+            value.Should().BeOfType<CypherTimeWithOffset>().Which.Minute.Should().Be(35);
+            value.Should().BeOfType<CypherTimeWithOffset>().Which.Second.Should().Be(59);
+            value.Should().BeOfType<CypherTimeWithOffset>().Which.Nanosecond.Should().Be(128000987);
             value.Should().BeOfType<CypherTimeWithOffset>().Which.OffsetSeconds.Should().Be((int)TimeSpan.FromMinutes(150).TotalSeconds);
         }
         

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
@@ -76,6 +76,20 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Theory]
+        [InlineData(-9999)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10000)]
+        [InlineData(9999999)]
+        public void ShouldThrowOnOverflow(int year)
+        {
+            var date = new CypherDate(year, 1, 1);
+            var ex = Record.Exception(() => date.ToDateTime());
+
+            ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
+        }
+
+        [Theory]
         [InlineData(1947, 12, 17, "1947-12-17")]
         [InlineData(1947, 1, 1, "1947-01-01")]
         [InlineData(1, 1, 1, "0001-01-01")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
@@ -30,7 +30,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDate = new CypherDate(1947, 12, 17);
 
-            cypherDate.ToDateTime().Should().Be(new DateTime(1947, 12, 17));
+            cypherDate.DateTime.Should().Be(new DateTime(1947, 12, 17));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tests.Types
             var date = new DateTime(1947, 12, 17);
             var cypherDate = new CypherDate(date);
 
-            cypherDate.ToDateTime().Should().Be(date);
+            cypherDate.DateTime.Should().Be(date);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnOverflow(int year)
         {
             var date = new CypherDate(year, 1, 1);
-            var ex = Record.Exception(() => date.ToDateTime());
+            var ex = Record.Exception(() => date.DateTime);
 
             ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
@@ -158,5 +158,58 @@ namespace Neo4j.Driver.Tests.Types
 
             date.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var date1 = new CypherDate(1947, 12, 17);
+
+            var ex = Record.Exception(() => date1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var date1 = new CypherDate(1947, 12, 17);
+
+            var comp = date1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var date1 = new CypherDate(1947, 12, 17);
+            var date2 = new CypherDate(1947, 12, 16);
+
+            var comp = date1.CompareTo(date2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var date1 = new CypherDate(1947, 12, 17);
+            var date2 = new CypherDate(1947, 12, 17);
+
+            var comp = date1.CompareTo(date2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var date1 = new CypherDate(1947, 12, 16);
+            var date2 = new CypherDate(1947, 12, 17);
+
+            var comp = date1.CompareTo(date2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using FluentAssertions;
 using Neo4j.Driver.V1;
 using Xunit;
@@ -210,6 +211,57 @@ namespace Neo4j.Driver.Tests.Types
             var comp = date1.CompareTo(date2);
 
             comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToDateTime()
+        {
+            var date = new DateTime(1947, 12, 16);
+            var date1 = new CypherDate(date);
+            var date2 = Convert.ToDateTime(date1);
+            var date3 = Convert.ChangeType(date1, typeof(DateTime));
+
+            date2.Should().Be(date);
+            date3.Should().Be(date);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToString()
+        {
+            var date = new CypherDate(1947, 12, 16);
+            var dateStr1 = Convert.ToString(date);
+            var dateStr2 = Convert.ChangeType(date, typeof(string));
+
+            dateStr1.Should().Be("1947-12-16");
+            dateStr2.Should().Be("1947-12-16");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConversionIsNotSupported()
+        {
+            var date = new CypherDate(1947, 12, 16);
+            var conversions = new Action[]
+            {
+                () => Convert.ToBoolean(date),
+                () => Convert.ToByte(date),
+                () => Convert.ToChar(date),
+                () => Convert.ToDecimal(date),
+                () => Convert.ToDouble(date),
+                () => Convert.ToInt16(date),
+                () => Convert.ToInt32(date),
+                () => Convert.ToInt64(date),
+                () => Convert.ToSByte(date),
+                () => Convert.ToUInt16(date),
+                () => Convert.ToUInt32(date),
+                () => Convert.ToUInt64(date),
+                () => Convert.ToSingle(date),
+                () => Convert.ChangeType(date, typeof(ArrayList))
+            };
+
+            foreach (var testAction in conversions)
+            {
+                testAction.ShouldThrow<InvalidCastException>();
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
@@ -276,6 +277,57 @@ namespace Neo4j.Driver.Tests.Types
             var comp = dateTime1.CompareTo(dateTime2);
 
             comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToDateTime()
+        {
+            var date = new DateTime(1947, 12, 16, 12, 15, 59, 660);
+            var date1 = new CypherDateTime(date);
+            var date2 = Convert.ToDateTime(date1);
+            var date3 = Convert.ChangeType(date1, typeof(DateTime));
+
+            date2.Should().Be(date);
+            date3.Should().Be(date);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToString()
+        {
+            var date = new CypherDateTime(1947, 12, 16, 12, 15, 59, 660000999);
+            var dateStr1 = Convert.ToString(date);
+            var dateStr2 = Convert.ChangeType(date, typeof(string));
+
+            dateStr1.Should().Be("1947-12-16T12:15:59.660000999");
+            dateStr2.Should().Be("1947-12-16T12:15:59.660000999");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConversionIsNotSupported()
+        {
+            var date = new CypherDateTime(1947, 12, 16, 12, 15, 59, 660000999);
+            var conversions = new Action[]
+            {
+                () => Convert.ToBoolean(date),
+                () => Convert.ToByte(date),
+                () => Convert.ToChar(date),
+                () => Convert.ToDecimal(date),
+                () => Convert.ToDouble(date),
+                () => Convert.ToInt16(date),
+                () => Convert.ToInt32(date),
+                () => Convert.ToInt64(date),
+                () => Convert.ToSByte(date),
+                () => Convert.ToUInt16(date),
+                () => Convert.ToUInt32(date),
+                () => Convert.ToUInt64(date),
+                () => Convert.ToSingle(date),
+                () => Convert.ChangeType(date, typeof(ArrayList))
+            };
+
+            foreach (var testAction in conversions)
+            {
+                testAction.ShouldThrow<InvalidCastException>();
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
@@ -224,5 +224,58 @@ namespace Neo4j.Driver.Tests.Types
 
             dateTime.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var dateTime1 = new CypherDateTime(1947, 12, 17, 0, 0, 0, 0);
+
+            var ex = Record.Exception(() => dateTime1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var dateTime1 = new CypherDateTime(1947, 12, 17, 0, 0, 0, 0);
+
+            var comp = dateTime1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTime(1947, 12, 17, 0, 0, 0, 0);
+            var dateTime2 = new CypherDateTime(1947, 12, 16, 23, 59, 59, 999999999);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTime(1947, 12, 16, 23, 59, 59, 999999999);
+            var dateTime2 = new CypherDateTime(1947, 12, 16, 23, 59, 59, 999999999);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTime(1947, 12, 16, 23, 59, 59, 999999999);
+            var dateTime2 = new CypherDateTime(1947, 12, 17, 0, 59, 59, 999999999);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
@@ -51,25 +51,95 @@ namespace Neo4j.Driver.Tests.Types
             cypherDateTime.ToDateTime().Should().Be(dateTime);
         }
 
-        [Fact]
-        public void ShouldCreateDateTimeWithRawValues()
+        [Theory]
+        [InlineData(-1000000000)]
+        [InlineData(1000000000)]
+        public void ShouldThrowOnInvalidYear(int year)
         {
-            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945);
-            var cypherDateTime = new CypherDateTime(TemporalHelpers.SecondsSinceEpoch(dateTime.Ticks),
-                TemporalHelpers.NanosOfSecond(dateTime.Ticks));
+            var ex = Record.Exception(() => new CypherDateTime(year, 1, 1, 0, 0, 0));
 
-            cypherDateTime.ToDateTime().Should().Be(dateTime);
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
         }
 
-        [Fact]
-        public void ShouldGenerateCorrectString()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(13)]
+        public void ShouldThrowOnInvalidMonth(int month)
         {
-            var cypherDateTime = new CypherDateTime(1947, 12, 17, 23, 49, 54, 192794500);
+            var ex = Record.Exception(() => new CypherDateTime(1990, month, 1, 0, 0, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(2018, 1, 0)]
+        [InlineData(2018, 1, 32)]
+        [InlineData(2018, 6, 31)]
+        [InlineData(2018, 2, 29)]
+        [InlineData(2018, 12, -1)]
+        public void ShouldThrowOnInvalidDay(int year, int month, int day)
+        {
+            var ex = Record.Exception(() => new CypherDateTime(year, month, day, 0, 0, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(24)]
+        public void ShouldThrowOnInvalidHour(int hour)
+        {
+            var ex = Record.Exception(() => new CypherDateTime(1990, 1, 1, hour, 0, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        [InlineData(61)]
+        public void ShouldThrowOnInvalidMinute(int minute)
+        {
+            var ex = Record.Exception(() => new CypherDateTime(1990, 1, 1, 0, minute, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        [InlineData(61)]
+        public void ShouldThrowOnInvalidSecond(int second)
+        {
+            var ex = Record.Exception(() => new CypherDateTime(1990, 1, 1, 0, 0, second));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(999_999_999 + 1)]
+        public void ShouldThrowOnInvalidNanosecond(int nanosecond)
+        {
+            var ex = Record.Exception(() => new CypherDateTime(1990, 1, 1, 0, 0, 0, nanosecond));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(1947, 12, 17, 23, 5, 54, 192794500, "1947-12-17T23:05:54.192794500")]
+        [InlineData(1947, 12, 5, 0, 5, 54, 192794500, "1947-12-05T00:05:54.192794500")]
+        [InlineData(1947, 12, 5, 0, 5, 54, 0, "1947-12-05T00:05:54.000000000")]
+        [InlineData(5, 1, 5, 0, 5, 54, 0, "0005-01-05T00:05:54.000000000")]
+        [InlineData(-5, 1, 5, 0, 5, 54, 1250, "-0005-01-05T00:05:54.000001250")]
+        [InlineData(999999, 1, 1, 5, 1, 25, 1, "999999-01-01T05:01:25.000000001")]
+        [InlineData(-999999, 1, 1, 5, 1, 25, 1, "-999999-01-01T05:01:25.000000001")]
+        public void ShouldGenerateCorrectString(int year, int month, int day, int hour, int minute, int second, int nanosecond, string expected)
+        {
+            var cypherDateTime = new CypherDateTime(year, month, day, hour, minute, second, nanosecond);
             var cypherDateTimeStr = cypherDateTime.ToString();
 
-            cypherDateTimeStr.Should()
-                .Be(
-                    $"DateTime{{epochSeconds: {cypherDateTime.EpochSeconds}, nanosOfSecond: {cypherDateTime.NanosOfSecond}}}");
+            cypherDateTimeStr.Should().Be(expected);
         }
 
         [Fact]
@@ -77,9 +147,8 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTime(1947, 12, 17, 15, 12, 01, 789000000);
             var dateTime2 = new CypherDateTime(new DateTime(1947, 12, 17, 15, 12, 01, 789, DateTimeKind.Local));
-            var dateTime3 = new CypherDateTime(-695551679, 789000000);
 
-            dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode()).And.Be(dateTime3.GetHashCode());
+            dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode());
         }
 
         [Fact]
@@ -87,9 +156,8 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTime(1947, 12, 17, 15, 12, 01, 789000000);
             var dateTime2 = new CypherDateTime(new DateTime(1947, 12, 17, 15, 12, 01, 790));
-            var dateTime3 = new CypherDateTime(-695551678, 788000000);
 
-            dateTime1.GetHashCode().Should().NotBe(dateTime2.GetHashCode()).And.NotBe(dateTime3.GetHashCode());
+            dateTime1.GetHashCode().Should().NotBe(dateTime2.GetHashCode());
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
@@ -31,7 +31,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new CypherDateTime(1947, 12, 17, 23, 49, 54);
 
-            cypherDateTime.ToDateTime().Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
+            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new CypherDateTime(1947, 12, 17, 23, 49, 54, 192794500);
 
-            cypherDateTime.ToDateTime().Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
+            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120, DateTimeKind.Local);
             var cypherDateTime = new CypherDateTime(dateTime);
 
-            cypherDateTime.ToDateTime().Should().Be(dateTime);
+            cypherDateTime.DateTime.Should().Be(dateTime);
         }
 
         [Theory]
@@ -135,7 +135,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnOverflow(int year)
         {
             var dateTime = new CypherDateTime(year, 1, 1, 0, 0, 0, 0);
-            var ex = Record.Exception(() => dateTime.ToDateTime());
+            var ex = Record.Exception(() => dateTime.DateTime);
 
             ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
         }
@@ -150,7 +150,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnTruncation(int nanosecond)
         {
             var dateTime = new CypherDateTime(1, 1, 1, 0, 0, 0, nanosecond);
-            var ex = Record.Exception(() => dateTime.ToDateTime());
+            var ex = Record.Exception(() => dateTime.DateTime);
 
             ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeTests.cs
@@ -127,6 +127,35 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Theory]
+        [InlineData(-9999)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10000)]
+        [InlineData(9999999)]
+        public void ShouldThrowOnOverflow(int year)
+        {
+            var dateTime = new CypherDateTime(year, 1, 1, 0, 0, 0, 0);
+            var ex = Record.Exception(() => dateTime.ToDateTime());
+
+            ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(20)]
+        [InlineData(99)]
+        [InlineData(999000727)]
+        [InlineData(999000750)]
+        [InlineData(999000001)]
+        public void ShouldThrowOnTruncation(int nanosecond)
+        {
+            var dateTime = new CypherDateTime(1, 1, 1, 0, 0, 0, nanosecond);
+            var ex = Record.Exception(() => dateTime.ToDateTime());
+
+            ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
+        }
+
+        [Theory]
         [InlineData(1947, 12, 17, 23, 5, 54, 192794500, "1947-12-17T23:05:54.192794500")]
         [InlineData(1947, 12, 5, 0, 5, 54, 192794500, "1947-12-05T00:05:54.192794500")]
         [InlineData(1947, 12, 5, 0, 5, 54, 0, "1947-12-05T00:05:54.000000000")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithOffsetTests.cs
@@ -159,6 +159,35 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Theory]
+        [InlineData(-9999)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10000)]
+        [InlineData(9999999)]
+        public void ShouldThrowOnOverflow(int year)
+        {
+            var dateTime = new CypherDateTimeWithOffset(year, 1, 1, 0, 0, 0, 0, 0);
+            var ex = Record.Exception(() => dateTime.DateTime);
+
+            ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(20)]
+        [InlineData(99)]
+        [InlineData(999000727)]
+        [InlineData(999000750)]
+        [InlineData(999000001)]
+        public void ShouldThrowOnTruncation(int nanosecond)
+        {
+            var dateTime = new CypherDateTimeWithOffset(1, 1, 1, 0, 0, 0, nanosecond, 0);
+            var ex = Record.Exception(() => dateTime.DateTime);
+
+            ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
+        }
+
+        [Theory]
         [InlineData(1947, 12, 17, 23, 5, 54, 192794500, 1500, "1947-12-17T23:05:54.192794500+00:25")]
         [InlineData(1947, 12, 5, 0, 5, 54, 192794500, -1500, "1947-12-05T00:05:54.192794500-00:25")]
         [InlineData(1947, 12, 17, 23, 5, 54, 192794500, 1501, "1947-12-17T23:05:54.192794500+00:25:01")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithOffsetTests.cs
@@ -259,5 +259,91 @@ namespace Neo4j.Driver.Tests.Types
 
             dateTime.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 17, 0, 0, 0, 0, 1800);
+
+            var ex = Record.Exception(() => dateTime1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 17, 0, 0, 0, 0, 1800);
+
+            var comp = dateTime1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 17, 0, 0, 0, 0, 1800);
+            var dateTime2 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1800);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToDiffOffset()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 17, 23, 59, 59, 999999999, 1800);
+            var dateTime2 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1750);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1800);
+            var dateTime2 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1800);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareToDiffOffset()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1800);
+            var dateTime2 = new CypherDateTimeWithOffset(1947, 12, 17, 0, 59, 59, 999999999, 5400);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1800);
+            var dateTime2 = new CypherDateTimeWithOffset(1947, 12, 17, 0, 59, 59, 999999999, 1800);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareToDiffOffset()
+        {
+            var dateTime1 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, 1800);
+            var dateTime2 = new CypherDateTimeWithOffset(1947, 12, 16, 23, 59, 59, 999999999, -1799);
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
@@ -315,6 +316,67 @@ namespace Neo4j.Driver.Tests.Types
             var comp = dateTime1.CompareTo(dateTime2);
 
             comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToDateTime()
+        {
+            var date = new DateTime(1947, 12, 16, 12, 15, 59, 660);
+            var date1 = new CypherDateTimeWithZoneId(date, "Europe/Rome");
+            var date2 = Convert.ToDateTime(date1);
+            var date3 = Convert.ChangeType(date1, typeof(DateTime));
+
+            date2.Should().Be(date);
+            date3.Should().Be(date);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToDateTimeOffset()
+        {
+            var date = new DateTime(1947, 12, 16, 12, 15, 59, 660);
+            var date1 = new CypherDateTimeWithZoneId(date, "Europe/Rome");
+            var date2 = Convert.ChangeType(date1, typeof(DateTimeOffset));
+
+            date2.Should().Be(new DateTimeOffset(date, TimeSpan.FromSeconds(3600)));
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToString()
+        {
+            var date = new CypherDateTimeWithOffset(1947, 12, 16, 12, 15, 59, 660000999, 3600);
+            var dateStr1 = Convert.ToString(date);
+            var dateStr2 = Convert.ChangeType(date, typeof(string));
+
+            dateStr1.Should().Be("1947-12-16T12:15:59.660000999+01:00");
+            dateStr2.Should().Be("1947-12-16T12:15:59.660000999+01:00");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConversionIsNotSupported()
+        {
+            var date = new CypherDateTimeWithZoneId(1947, 12, 16, 12, 15, 59, 660000999, "");
+            var conversions = new Action[]
+            {
+                () => Convert.ToBoolean(date),
+                () => Convert.ToByte(date),
+                () => Convert.ToChar(date),
+                () => Convert.ToDecimal(date),
+                () => Convert.ToDouble(date),
+                () => Convert.ToInt16(date),
+                () => Convert.ToInt32(date),
+                () => Convert.ToInt64(date),
+                () => Convert.ToSByte(date),
+                () => Convert.ToUInt16(date),
+                () => Convert.ToUInt32(date),
+                () => Convert.ToUInt64(date),
+                () => Convert.ToSingle(date),
+                () => Convert.ChangeType(date, typeof(ArrayList))
+            };
+
+            foreach (var testAction in conversions)
+            {
+                testAction.ShouldThrow<InvalidCastException>();
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
@@ -230,5 +230,91 @@ namespace Neo4j.Driver.Tests.Types
 
             dateTime.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 0, 0, 0, 0, "Europe/Amsterdam");
+
+            var ex = Record.Exception(() => dateTime1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 0, 0, 0, 0, "Europe/Amsterdam");
+
+            var comp = dateTime1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 0, 0, 0, 0, "Europe/Amsterdam");
+            var dateTime2 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/Amsterdam");
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToDiffOffset()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 23, 59, 59, 999999900, "Europe/Amsterdam");
+            var dateTime2 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/London");
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/Amsterdam");
+            var dateTime2 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/Amsterdam");
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareToDiffOffset()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/London");
+            var dateTime2 = new CypherDateTimeWithZoneId(1947, 12, 17, 0, 59, 59, 999999900, "Europe/Amsterdam");
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/Amsterdam");
+            var dateTime2 = new CypherDateTimeWithZoneId(1947, 12, 17, 0, 59, 59, 999999900, "Europe/Amsterdam");
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareToDiffOffset()
+        {
+            var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/Amsterdam");
+            var dateTime2 = new CypherDateTimeWithZoneId(1947, 12, 16, 23, 59, 59, 999999900, "Europe/London");
+
+            var comp = dateTime1.CompareTo(dateTime2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
@@ -133,6 +133,35 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Theory]
+        [InlineData(-9999)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(10000)]
+        [InlineData(9999999)]
+        public void ShouldThrowOnOverflow(int year)
+        {
+            var dateTime = new CypherDateTimeWithZoneId(year, 1, 1, 0, 0, 0, 0, "Europe/London");
+            var ex = Record.Exception(() => dateTime.DateTime);
+
+            ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(20)]
+        [InlineData(99)]
+        [InlineData(999000727)]
+        [InlineData(999000750)]
+        [InlineData(999000001)]
+        public void ShouldThrowOnTruncation(int nanosecond)
+        {
+            var dateTime = new CypherDateTimeWithZoneId(1, 1, 1, 0, 0, 0, nanosecond, "Europe/London");
+            var ex = Record.Exception(() => dateTime.DateTime);
+
+            ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
+        }
+
+        [Theory]
         [InlineData(1947, 12, 17, 23, 5, 54, 192794500, "Europe/Rome", "1947-12-17T23:05:54.192794500[Europe/Rome]")]
         [InlineData(1947, 12, 5, 0, 5, 54, 192794500, "Europe/Amsterdam", "1947-12-05T00:05:54.192794500[Europe/Amsterdam]")]
         [InlineData(1947, 12, 5, 0, 5, 54, 0, "Europe/Istanbul", "1947-12-05T00:05:54.000000000[Europe/Istanbul]")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDateTimeWithZoneIdTests.cs
@@ -57,27 +57,95 @@ namespace Neo4j.Driver.Tests.Types
             cypherDateTime.ZoneId.Should().Be("Europe/Rome");
         }
 
-        [Fact]
-        public void ShouldCreateDateWithRawValues()
+        [Theory]
+        [InlineData(-1000000000)]
+        [InlineData(1000000000)]
+        public void ShouldThrowOnInvalidYear(int year)
         {
-            var dateTime = new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945);
-            var cypherDateTime = new CypherDateTimeWithZoneId(TemporalHelpers.SecondsSinceEpoch(dateTime.Ticks),
-                TemporalHelpers.NanosOfSecond(dateTime.Ticks), "Europe/Rome");
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(year, 1, 1, 0, 0, 0, "Europe/Amsterdam"));
 
-            cypherDateTime.DateTime.Should().Be(dateTime);
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
-            cypherDateTime.ZoneId.Should().Be("Europe/Rome");
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
         }
 
-        [Fact]
-        public void ShouldGenerateCorrectString()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(13)]
+        public void ShouldThrowOnInvalidMonth(int month)
         {
-            var cypherDateTime = new CypherDateTimeWithZoneId(1947, 12, 17, 23, 49, 54, 192794500, "Europe/Rome");
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(1990, month, 1, 0, 0, 0, "Europe/Istanbul"));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(2018, 1, 0)]
+        [InlineData(2018, 1, 32)]
+        [InlineData(2018, 6, 31)]
+        [InlineData(2018, 2, 29)]
+        [InlineData(2018, 12, -1)]
+        public void ShouldThrowOnInvalidDay(int year, int month, int day)
+        {
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(year, month, day, 0, 0, 0, "Europe/Istanbul"));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(24)]
+        public void ShouldThrowOnInvalidHour(int hour)
+        {
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(1990, 1, 1, hour, 0, 0, "Europe/Istanbul"));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        [InlineData(61)]
+        public void ShouldThrowOnInvalidMinute(int minute)
+        {
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(1990, 1, 1, 0, minute, 0, "Europe/Paris"));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        [InlineData(61)]
+        public void ShouldThrowOnInvalidSecond(int second)
+        {
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(1990, 1, 1, 0, 0, second, "Europe/Rome"));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(999_999_999 + 1)]
+        public void ShouldThrowOnInvalidNanosecond(int nanosecond)
+        {
+            var ex = Record.Exception(() => new CypherDateTimeWithZoneId(1990, 1, 1, 0, 0, 0, nanosecond, "Europe/Athens"));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(1947, 12, 17, 23, 5, 54, 192794500, "Europe/Rome", "1947-12-17T23:05:54.192794500[Europe/Rome]")]
+        [InlineData(1947, 12, 5, 0, 5, 54, 192794500, "Europe/Amsterdam", "1947-12-05T00:05:54.192794500[Europe/Amsterdam]")]
+        [InlineData(1947, 12, 5, 0, 5, 54, 0, "Europe/Istanbul", "1947-12-05T00:05:54.000000000[Europe/Istanbul]")]
+        [InlineData(5, 1, 5, 0, 5, 54, 0, "Africa/Nairobi", "0005-01-05T00:05:54.000000000[Africa/Nairobi]")]
+        [InlineData(-5, 1, 5, 0, 5, 54, 1250, "America/Halifax", "-0005-01-05T00:05:54.000001250[America/Halifax]")]
+        [InlineData(999999, 1, 1, 5, 1, 25, 1, "America/New_York", "999999-01-01T05:01:25.000000001[America/New_York]")]
+        [InlineData(-999999, 1, 1, 5, 1, 25, 1, "Asia/Seoul", "-999999-01-01T05:01:25.000000001[Asia/Seoul]")]
+        public void ShouldGenerateCorrectString(int year, int month, int day, int hour, int minute, int second, int nanosecond, string zoneId, string expected)
+        {
+            var cypherDateTime = new CypherDateTimeWithZoneId(year, month, day, hour, minute, second, nanosecond, zoneId);
             var cypherDateTimeStr = cypherDateTime.ToString();
 
-            cypherDateTimeStr.Should()
-                .Be(
-                    $"DateTimeWithZoneId{{epochSeconds: {cypherDateTime.EpochSeconds}, nanosOfSecond: {cypherDateTime.NanosOfSecond}, zoneId: '{cypherDateTime.ZoneId}'}}");
+            cypherDateTimeStr.Should().Be(expected);
         }
 
         [Fact]
@@ -85,9 +153,8 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 15, 12, 01, 789000000, "Europe/Rome");
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 789), "Europe/Rome");
-            var dateTime3 = new CypherDateTimeWithZoneId(-695551679, 789000000, "Europe/Rome");
 
-            dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode()).And.Be(dateTime3.GetHashCode());
+            dateTime1.GetHashCode().Should().Be(dateTime2.GetHashCode());
         }
 
         [Fact]
@@ -95,9 +162,8 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 15, 12, 01, 789000000, "Europe/Rome");
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 790), "Europe/Rome");
-            var dateTime3 = new CypherDateTimeWithZoneId(-695555279, 789000200, "Europe/Rome");
 
-            dateTime1.GetHashCode().Should().NotBe(dateTime2.GetHashCode()).And.NotBe(dateTime3.GetHashCode());
+            dateTime1.GetHashCode().Should().NotBe(dateTime2.GetHashCode());
         }
 
         [Fact]
@@ -105,10 +171,8 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 15, 12, 01, 789000000, "Europe/Rome");
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 789), "Europe/Rome");
-            var dateTime3 = new CypherDateTimeWithZoneId(-695551679, 789000000, "Europe/Rome");
 
             dateTime1.Should().Be(dateTime2);
-            dateTime1.Should().Be(dateTime3);
         }
 
         [Fact]
@@ -116,10 +180,8 @@ namespace Neo4j.Driver.Tests.Types
         {
             var dateTime1 = new CypherDateTimeWithZoneId(1947, 12, 17, 15, 12, 01, 789000000, "Europe/Rome");
             var dateTime2 = new CypherDateTimeWithZoneId(new DateTime(1947, 12, 17, 15, 12, 01, 790), "Europe/Rome");
-            var dateTime3 = new CypherDateTimeWithZoneId(-695555279, 789005000, "Europe/Rome");
 
             dateTime1.Should().NotBe(dateTime2);
-            dateTime1.Should().NotBe(dateTime3);
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDurationTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDurationTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using FluentAssertions;
 using Neo4j.Driver.V1;
 using Xunit;
@@ -223,6 +224,46 @@ namespace Neo4j.Driver.Tests.Types
             var comp = duration1.CompareTo(duration2);
 
             comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToString()
+        {
+            var duration = new CypherDuration(12, 15, 59, 660000999);
+            var durationStr1 = Convert.ToString(duration);
+            var durationStr2 = Convert.ChangeType(duration, typeof(string));
+
+            durationStr1.Should().Be("P12M15DT59.660000999S");
+            durationStr2.Should().Be("P12M15DT59.660000999S");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConversionIsNotSupported()
+        {
+            var duration = new CypherDuration(12, 15, 59, 660000999);
+            var conversions = new Action[]
+            {
+                () => Convert.ToDateTime(duration),
+                () => Convert.ToBoolean(duration),
+                () => Convert.ToByte(duration),
+                () => Convert.ToChar(duration),
+                () => Convert.ToDecimal(duration),
+                () => Convert.ToDouble(duration),
+                () => Convert.ToInt16(duration),
+                () => Convert.ToInt32(duration),
+                () => Convert.ToInt64(duration),
+                () => Convert.ToSByte(duration),
+                () => Convert.ToUInt16(duration),
+                () => Convert.ToUInt32(duration),
+                () => Convert.ToUInt64(duration),
+                () => Convert.ToSingle(duration),
+                () => Convert.ChangeType(duration, typeof(ArrayList))
+            };
+
+            foreach (var testAction in conversions)
+            {
+                testAction.ShouldThrow<InvalidCastException>();
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDurationTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDurationTests.cs
@@ -69,13 +69,20 @@ namespace Neo4j.Driver.Tests.Types
             cypherDuration.Nanos.Should().Be(789215800);
         }
 
-        [Fact]
-        public void ShouldGenerateCorrectString()
+        [Theory]
+        [InlineData(15, 32, 785, 789215800, "P15M32DT785.789215800S")]
+        [InlineData(0, 32, 785, 789215800, "P0M32DT785.789215800S")]
+        [InlineData(0, 0, 785, 789215800, "P0M0DT785.789215800S")]
+        [InlineData(0, 0, 0, 789215800, "P0M0DT0.789215800S")]
+        [InlineData(0, 0, 0, 0, "P0M0DT0.000000000S")]
+        [InlineData(500, 0, 0, 0, "P500M0DT0.000000000S")]
+        [InlineData(0, 0, 0, 5, "P0M0DT0.000000005S")]
+        public void ShouldGenerateCorrectString(int months, int days, int seconds, int nanoseconds, string expected)
         {
-            var cypherDuration = new CypherDuration(15, 32, 785, 789215800);
+            var cypherDuration = new CypherDuration(months, days, seconds, nanoseconds);
             var cypherDurationStr = cypherDuration.ToString();
 
-            cypherDurationStr.Should().Be($"Duration{{months: 15, days: 32, seconds: 785, nanos: 789215800}}");
+            cypherDurationStr.Should().Be(expected);
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDurationTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherDurationTests.cs
@@ -138,5 +138,91 @@ namespace Neo4j.Driver.Tests.Types
 
             duration.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var duration1 = new CypherDuration(0, 0, 0, 0);
+
+            var ex = Record.Exception(() => duration1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var duration1 = new CypherDuration(0, 0, 0, 0);
+
+            var comp = duration1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var duration1 = new CypherDuration(1, 12, 500, 999999999);
+            var duration2 = new CypherDuration(1, 12, 500, 0);
+
+            var comp = duration1.CompareTo(duration2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToAbsolute()
+        {
+            var duration1 = new CypherDuration(0, 1, 0, 1);
+            var duration2 = new CypherDuration(0, 0, 86400, 0);
+
+            var comp = duration1.CompareTo(duration2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var duration1 = new CypherDuration(1, 12, 500, 999999999);
+            var duration2 = new CypherDuration(1, 12, 500, 999999999);
+
+            var comp = duration1.CompareTo(duration2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareToAbsolute()
+        {
+            var duration1 = new CypherDuration(0, 1, 0, 999999999);
+            var duration2 = new CypherDuration(0, 0, 86400, 999999999);
+
+            var comp = duration1.CompareTo(duration2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var duration1 = new CypherDuration(1, 12, 500, 999999999);
+            var duration2 = new CypherDuration(1, 12, 501, 0);
+
+            var comp = duration1.CompareTo(duration2);
+
+            comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareToAbsolute()
+        {
+            var duration1 = new CypherDuration(0, 1, 0, 999999999);
+            var duration2 = new CypherDuration(0, 0, 86401, 999999999);
+
+            var comp = duration1.CompareTo(duration2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
@@ -85,6 +85,21 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Theory]
+        [InlineData(1)]
+        [InlineData(20)]
+        [InlineData(99)]
+        [InlineData(999000727)]
+        [InlineData(999000750)]
+        [InlineData(999000001)]
+        public void ShouldThrowOnTruncation(int nanosecond)
+        {
+            var time = new CypherTime(0, 0, 0, nanosecond);
+            var ex = Record.Exception(() => time.ToTimeSpan());
+
+            ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
+        }
+
+        [Theory]
         [InlineData(13, 15, 59, 274000000, "13:15:59.274000000")]
         [InlineData(0, 1, 2, 000000000, "00:01:02.000000000")]
         [InlineData(0, 1, 2, 5001, "00:01:02.000005001")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using FluentAssertions;
 using Neo4j.Driver.V1;
 using Xunit;
@@ -222,6 +223,68 @@ namespace Neo4j.Driver.Tests.Types
             var comp = time1.CompareTo(time2);
 
             comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToDateTime()
+        {
+            var time = new TimeSpan(0, 12, 15, 59, 660);
+            var time1 = new CypherTime(DateTime.Today.Add(time));
+            var time2 = Convert.ToDateTime(time1);
+            var time3 = (DateTime)Convert.ChangeType(time1, typeof(DateTime));
+
+            time2.TimeOfDay.Should().Be(time);
+            time3.TimeOfDay.Should().Be(time);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToTimeSpan()
+        {
+            var time = new TimeSpan(0, 12, 15, 59, 660);
+            var date = DateTime.Today.Add(time);
+            var time1 = new CypherTime(date);
+            var time2 = (TimeSpan)Convert.ChangeType(time1, typeof(TimeSpan));
+
+            time2.Should().Be(time);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToString()
+        {
+            var time = new CypherTime(12, 15, 59, 660000999);
+            var timeStr1 = Convert.ToString(time);
+            var timeStr2 = Convert.ChangeType(time, typeof(string));
+
+            timeStr1.Should().Be("12:15:59.660000999");
+            timeStr2.Should().Be("12:15:59.660000999");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConversionIsNotSupported()
+        {
+            var time = new CypherTime(12, 15, 59, 660000999);
+            var conversions = new Action[]
+            {
+                () => Convert.ToBoolean(time),
+                () => Convert.ToByte(time),
+                () => Convert.ToChar(time),
+                () => Convert.ToDecimal(time),
+                () => Convert.ToDouble(time),
+                () => Convert.ToInt16(time),
+                () => Convert.ToInt32(time),
+                () => Convert.ToInt64(time),
+                () => Convert.ToSByte(time),
+                () => Convert.ToUInt16(time),
+                () => Convert.ToUInt32(time),
+                () => Convert.ToUInt64(time),
+                () => Convert.ToSingle(time),
+                () => Convert.ChangeType(time, typeof(ArrayList))
+            };
+
+            foreach (var testAction in conversions)
+            {
+                testAction.ShouldThrow<InvalidCastException>();
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
@@ -30,7 +30,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherTime = new CypherTime(13, 15, 59);
 
-            cypherTime.ToTimeSpan().Should().Be(new TimeSpan(13, 15, 59));
+            cypherTime.Time.Should().Be(new TimeSpan(13, 15, 59));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tests.Types
             var time = new TimeSpan(0, 13, 59, 59, 255);
             var cypherTime = new CypherTime(time);
 
-            cypherTime.ToTimeSpan().Should().Be(time);
+            cypherTime.Time.Should().Be(time);
         }
 
         [Theory]
@@ -94,7 +94,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnTruncation(int nanosecond)
         {
             var time = new CypherTime(0, 0, 0, nanosecond);
-            var ex = Record.Exception(() => time.ToTimeSpan());
+            var ex = Record.Exception(() => time.Time);
 
             ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeTests.cs
@@ -170,5 +170,58 @@ namespace Neo4j.Driver.Tests.Types
 
             time.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var time1 = new CypherTime(0, 0, 0, 0);
+
+            var ex = Record.Exception(() => time1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var time1 = new CypherTime(0, 0, 0, 0);
+
+            var comp = time1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var time1 = new CypherTime(23, 59, 59, 999999999);
+            var time2 = new CypherTime(23, 59, 59, 0);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var time1 = new CypherTime(23, 59, 59, 999999999);
+            var time2 = new CypherTime(23, 59, 59, 999999999);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().Be(0);
+        }
+        
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var time1 = new CypherTime(0, 59, 59, 999999999);
+            var time2 = new CypherTime(23, 59, 59, 999999999);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
@@ -196,5 +196,91 @@ namespace Neo4j.Driver.Tests.Types
 
             time.Equals(other).Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldThrowOnCompareToOtherType()
+        {
+            var time1 = new CypherTimeWithOffset(0, 0, 0, 0, 1800);
+
+            var ex = Record.Exception(() => time1.CompareTo(new DateTime(1947, 12, 17)));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToNull()
+        {
+            var time1 = new CypherTimeWithOffset(0, 0, 0, 0, 1800);
+
+            var comp = time1.CompareTo(null);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareTo()
+        {
+            var time1 = new CypherTimeWithOffset(0, 0, 0, 0, 1800);
+            var time2 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1800);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportLargerOnCompareToDiffOffset()
+        {
+            var time1 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1700);
+            var time2 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1750);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareTo()
+        {
+            var time1 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1800);
+            var time2 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1800);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportEqualOnCompareToDiffOffset()
+        {
+            var time1 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1800);
+            var time2 = new CypherTimeWithOffset(0, 59, 59, 999999999, 5400);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareTo()
+        {
+            var time1 = new CypherTimeWithOffset(0, 59, 59, 999999999, 1800);
+            var time2 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1800);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldReportSmallerOnCompareToDiffOffset()
+        {
+            var time1 = new CypherTimeWithOffset(23, 59, 59, 999999999, 1800);
+            var time2 = new CypherTimeWithOffset(23, 59, 59, 999999999, -1799);
+
+            var comp = time1.CompareTo(time2);
+
+            comp.Should().BeLessThan(0);
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using FluentAssertions;
 using Neo4j.Driver.V1;
 using Xunit;
@@ -281,6 +282,46 @@ namespace Neo4j.Driver.Tests.Types
             var comp = time1.CompareTo(time2);
 
             comp.Should().BeLessThan(0);
+        }
+
+        [Fact]
+        public void ShouldBeConvertableToString()
+        {
+            var time = new CypherTimeWithOffset(12, 15, 59, 660000999, 1800);
+            var timeStr1 = Convert.ToString(time);
+            var timeStr2 = Convert.ChangeType(time, typeof(string));
+
+            timeStr1.Should().Be("12:15:59.660000999+00:30");
+            timeStr2.Should().Be("12:15:59.660000999+00:30");
+        }
+
+        [Fact]
+        public void ShouldThrowWhenConversionIsNotSupported()
+        {
+            var time = new CypherTimeWithOffset(12, 15, 59, 660000999, 1800);
+            var conversions = new Action[]
+            {
+                () => Convert.ToDateTime(time),
+                () => Convert.ToBoolean(time),
+                () => Convert.ToByte(time),
+                () => Convert.ToChar(time),
+                () => Convert.ToDecimal(time),
+                () => Convert.ToDouble(time),
+                () => Convert.ToInt16(time),
+                () => Convert.ToInt32(time),
+                () => Convert.ToInt64(time),
+                () => Convert.ToSByte(time),
+                () => Convert.ToUInt16(time),
+                () => Convert.ToUInt32(time),
+                () => Convert.ToUInt64(time),
+                () => Convert.ToSingle(time),
+                () => Convert.ChangeType(time, typeof(ArrayList))
+            };
+
+            foreach (var testAction in conversions)
+            {
+                testAction.ShouldThrow<InvalidCastException>();
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
@@ -107,6 +107,21 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Theory]
+        [InlineData(1)]
+        [InlineData(20)]
+        [InlineData(99)]
+        [InlineData(999000727)]
+        [InlineData(999000750)]
+        [InlineData(999000001)]
+        public void ShouldThrowOnTruncation(int nanosecond)
+        {
+            var time = new CypherTimeWithOffset(0, 0, 0, nanosecond, 0);
+            var ex = Record.Exception(() => time.Time);
+
+            ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
+        }
+
+        [Theory]
         [InlineData(13, 15, 59, 274000000, 1500, "13:15:59.274000000+00:25")]
         [InlineData(0, 1, 2, 000000000, 1501, "00:01:02.000000000+00:25:01")]
         [InlineData(0, 1, 2, 000000000, -1501, "00:01:02.000000000-00:25:01")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/CypherTimeWithOffsetTests.cs
@@ -45,23 +45,81 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Fact]
-        public void ShouldCreateTimeWithOffsetWithRawValues()
+        public void ShouldCreateTimeWithOffsetWithDateTime()
         {
-            var time = new TimeSpan(0, 13, 59, 59, 25);
-            var cypherTime = new CypherTimeWithOffset(time.Ticks * 100, 1500);
+            var time = new DateTime(1, 1, 1, 13, 59, 59, 25);
+            var cypherTime = new CypherTimeWithOffset(time, TimeSpan.FromSeconds(1500));
 
-            cypherTime.Time.Should().Be(time);
+            cypherTime.Time.Should().Be(time.TimeOfDay);
             cypherTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
         }
 
-        [Fact]
-        public void ShouldGenerateCorrectString()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(24)]
+        public void ShouldThrowOnInvalidHour(int hour)
         {
-            var cypherTime = new CypherTimeWithOffset(13, 15, 59, 274000000, 1500);
+            var ex = Record.Exception(() => new CypherTimeWithOffset(hour, 0, 0, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        [InlineData(61)]
+        public void ShouldThrowOnInvalidMinute(int minute)
+        {
+            var ex = Record.Exception(() => new CypherTimeWithOffset(0, minute, 0, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(60)]
+        [InlineData(61)]
+        public void ShouldThrowOnInvalidSecond(int second)
+        {
+            var ex = Record.Exception(() => new CypherTimeWithOffset(0, 0, second, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(999_999_999 + 1)]
+        public void ShouldThrowOnInvalidNanosecond(int nanosecond)
+        {
+            var ex = Record.Exception(() => new CypherTimeWithOffset(0, 0, 0, nanosecond, 0));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(-64801)]
+        [InlineData(64801)]
+        public void ShouldThrowOnInvalidOffset(int offset)
+        {
+            var ex = Record.Exception(() => new CypherTimeWithOffset(0, 0, 0, 0, offset));
+
+            ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Theory]
+        [InlineData(13, 15, 59, 274000000, 1500, "13:15:59.274000000+00:25")]
+        [InlineData(0, 1, 2, 000000000, 1501, "00:01:02.000000000+00:25:01")]
+        [InlineData(0, 1, 2, 000000000, -1501, "00:01:02.000000000-00:25:01")]
+        [InlineData(0, 1, 2, 750000000, 10800, "00:01:02.750000000+03:00")]
+        [InlineData(0, 1, 2, 750000000, 10805, "00:01:02.750000000+03:00:05")]
+        [InlineData(0, 1, 2, 750000000, 10795, "00:01:02.750000000+02:59:55")]
+        [InlineData(0, 1, 2, 750000000, 0, "00:01:02.750000000Z")]
+        public void ShouldGenerateCorrectString(int hour, int minute, int second, int nanosecond, int offsetSeconds, string expected)
+        {
+            var cypherTime = new CypherTimeWithOffset(hour, minute, second, nanosecond, offsetSeconds);
             var cypherTimeStr = cypherTime.ToString();
 
-            cypherTimeStr.Should()
-                .Be($"TimeWithOffset{{nanosOfDay: {cypherTime.NanosecondsOfDay}, offsetSeconds: {cypherTime.OffsetSeconds}}}");
+            cypherTimeStr.Should().Be(expected);
         }
 
         [Fact]
@@ -70,10 +128,8 @@ namespace Neo4j.Driver.Tests.Types
             var time1 = new CypherTimeWithOffset(12, 49, 55, 123000000, 1500);
             var time2 = new CypherTimeWithOffset(new DateTime(2017, 1, 1, 12, 49, 55, 123), TimeSpan.FromSeconds(1500));
             var time3 = new CypherTimeWithOffset(new TimeSpan(0, 12, 49, 55, 123), TimeSpan.FromSeconds(1500));
-            var time4 = new CypherTimeWithOffset(46195123000000, 1500);
 
-            time1.GetHashCode().Should().Be(time2.GetHashCode()).And.Be(time3.GetHashCode()).And
-                .Be(time4.GetHashCode());
+            time1.GetHashCode().Should().Be(time2.GetHashCode()).And.Be(time3.GetHashCode());
         }
 
         [Fact]
@@ -82,10 +138,8 @@ namespace Neo4j.Driver.Tests.Types
             var time1 = new CypherTimeWithOffset(12, 49, 55, 123000000, 1500);
             var time2 = new CypherTimeWithOffset(new DateTime(2017, 1, 1, 12, 49, 55, 123), TimeSpan.FromSeconds(1800));
             var time3 = new CypherTimeWithOffset(new TimeSpan(0, 12, 49, 55, 125), TimeSpan.FromSeconds(1500));
-            var time4 = new CypherTimeWithOffset(46195123003000, 1500);
 
-            time1.GetHashCode().Should().NotBe(time2.GetHashCode()).And.NotBe(time3.GetHashCode()).And
-                .NotBe(time4.GetHashCode());
+            time1.GetHashCode().Should().NotBe(time2.GetHashCode()).And.NotBe(time3.GetHashCode());
         }
 
         [Fact]
@@ -94,11 +148,9 @@ namespace Neo4j.Driver.Tests.Types
             var time1 = new CypherTimeWithOffset(12, 49, 55, 123000000, 1500);
             var time2 = new CypherTimeWithOffset(new DateTime(2017, 1, 1, 12, 49, 55, 123), TimeSpan.FromSeconds(1500));
             var time3 = new CypherTimeWithOffset(new TimeSpan(0, 12, 49, 55, 123), TimeSpan.FromSeconds(1500));
-            var time4 = new CypherTimeWithOffset(46195123000000, 1500);
 
             time1.Equals(time2).Should().BeTrue();
             time1.Equals(time3).Should().BeTrue();
-            time1.Equals(time4).Should().BeTrue();
         }
 
         [Fact]
@@ -107,11 +159,9 @@ namespace Neo4j.Driver.Tests.Types
             var time1 = new CypherTimeWithOffset(12, 49, 55, 123000000, 1800);
             var time2 = new CypherTimeWithOffset(new DateTime(2017, 1, 1, 12, 49, 55, 123), TimeSpan.FromSeconds(1200));
             var time3 = new CypherTimeWithOffset(new TimeSpan(0, 12, 49, 55, 125), TimeSpan.FromSeconds(1500));
-            var time4 = new CypherTimeWithOffset(46195123000001, 1500);
 
             time1.Equals(time2).Should().BeFalse();
             time1.Equals(time3).Should().BeFalse();
-            time1.Equals(time4).Should().BeFalse();
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/CollectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/CollectionExtensions.cs
@@ -20,13 +20,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal
 {
     internal static class CollectionExtensions
     {
-        private static readonly TypeInfo NeoValueTypeInfo = typeof(ICypherValue).GetTypeInfo();
+        private static readonly TypeInfo NeoValueTypeInfo = typeof(IValue).GetTypeInfo();
         private const string DefalutItemSeparator = ", ";
 
         public static T GetMandatoryValue<T>(this IDictionary<string, object> dictionary, string key)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -201,12 +201,20 @@ namespace Neo4j.Driver.Internal
             }
         }
 
-        public static void AssertNoTruncation(long nanosecond, string target)
+        public static void AssertNoOverflow(IHasDateComponents date, string target)
         {
-            if (nanosecond % NanosecondsPerTick > 0)
+            if (date.Year > DateTime.MaxValue.Year || date.Year < DateTime.MinValue.Year)
+            {
+                throw new ValueOverflowException($"Year component ({date.Year}) of this instance is not valid for a {target} instance.");
+            }
+        }
+
+        public static void AssertNoTruncation(IHasTimeComponents time, string target)
+        {
+            if (time.Nanosecond % NanosecondsPerTick > 0)
             {
                 throw new ValueTruncationException(
-                    $"Conversion of this instance into {target} will cause a truncation of ${nanosecond % TemporalHelpers.NanosecondsPerTick}ns.");
+                    $"Conversion of this instance into {target} will cause a truncation of ${time.Nanosecond % TemporalHelpers.NanosecondsPerTick}ns.");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -16,7 +16,10 @@
 // limitations under the License.
 
 using System;
+using HdrHistogram;
 using HdrHistogram.Utilities;
+using Neo4j.Driver.Internal.Protocol;
+using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.V1;
 using TimeZoneConverter;
 
@@ -24,84 +27,241 @@ namespace Neo4j.Driver.Internal
 {
     internal static class TemporalHelpers
     {
-        public const int NanosecondsPerTick = 100;
+        public const int MinYear = -999_999_999;
+        public const int MaxYear = 999_999_999;
+        public const int MinMonth = 1;
+        public const int MaxMonth = 12;
+        public const int MinDay = 1;
+        public const int MaxDay = 31;
+        public const int MaxHour = 23;
+        public const int MinHour = 0;
+        public const int MaxMinute = 59;
+        public const int MinMinute = 0;
+        public const int MaxSecond = 59;
+        public const int MinSecond = 0;
+        public const int MaxNanosecond = 999_999_999;
+        public const int MinNanosecond = 0;
+        public const int MinOffset = -64_800;
+        public const int MaxOffset = 64_800;
 
-        public static readonly DateTime Epoch = new DateTime(1970, 1, 1);
-        public static readonly long EpochSeconds = new DateTime(1970, 1, 1).Ticks / TimeSpan.TicksPerSecond;
+        private const int HoursPerDay = 24;
+        private const int MinutesPerHour = 60;
+        private const int SecondsPerMinute = 60;
+        private const int SecondsPerHour = SecondsPerMinute * MinutesPerHour;
+        private const int SecondsPerDay = SecondsPerHour * HoursPerDay;
+        private const long NanosPerSecond = 1_000_000_000;
+        private const long NanosPerMinute = NanosPerSecond * SecondsPerMinute;
+        private const long NanosPerHour = NanosPerMinute * MinutesPerHour;
+        private const long Days0000To1970 = (DaysPerCycle * 5L) - (30L * 365L + 7L);
+        private const int DaysPerCycle = 146_097;
+        private const int NanosecondsPerTick = 100;
 
-        public static long DaysSinceEpoch(this DateTime date)
+        public static long ToNanoOfDay(this IHasTimeComponents time)
         {
-            return (long)date.Subtract(Epoch).TotalDays;
+            return (time.Hour * NanosPerHour) + (time.Minute * NanosPerMinute) + (time.Second * NanosPerSecond) + time.Nanosecond;
         }
 
-        public static long NanosOf(this TimeSpan time)
+        public static long ToEpochSeconds(this IHasDateTimeComponents dateTime)
         {
-            return time.Ticks * NanosecondsPerTick;
+            var epochDays = dateTime.ToEpochDays();
+            var timeSeconds = dateTime.ToSecondsOfDay();
+
+            return epochDays * SecondsPerDay + timeSeconds;
         }
 
-        public static long SecondsSinceEpoch(long ticks)
+        public static int ToSecondsOfDay(this IHasTimeComponents time)
         {
-            return (ticks / TimeSpan.TicksPerSecond) - EpochSeconds;
+            return (time.Hour * SecondsPerHour) + (time.Minute * SecondsPerMinute) + time.Second;
         }
 
-        public static int NanosOfSecond(long ticks)
+        public static long ToEpochDays(this IHasDateComponents date)
+        {
+            return ComputeEpochDays(date.Year, date.Month, date.Day);
+        }
+
+        public static CypherTime NanoOfDayToTime(long nanoOfDay)
+        {
+            ComponentsOfNanoOfDay(nanoOfDay, out var hour, out var minute, out var second, out var nanosecond);
+
+            return new CypherTime(hour, minute, second, nanosecond);
+        }
+
+        public static CypherDate EpochDaysToDate(long epochDays)
+        {
+            ComponentsOfEpochDays(epochDays, out var year, out var month, out var day);
+
+            return new CypherDate(year, month, day);
+        }
+
+        public static CypherDateTime EpochSecondsAndNanoToDateTime(long epochSeconds, int nano)
+        {
+            var epochDay = FloorDiv(epochSeconds, SecondsPerDay);
+            var secondsOfDay = FloorMod(epochSeconds, SecondsPerDay);
+            var nanoOfDay = secondsOfDay * NanosPerSecond + nano;
+
+            ComponentsOfEpochDays(epochDay, out var year, out var month, out var day);
+            ComponentsOfNanoOfDay(nanoOfDay, out var hour, out var minute, out var second, out var nanosecond);
+
+            return new CypherDateTime(year, month, day, hour, minute, second, nanosecond);
+        }
+
+        private static long ComputeEpochDays(int year, int month, int day)
+        {
+            var y = (long) year;
+            var m = (long) month;
+            var total = 0L;
+
+            total += y * 365;
+            if (y >= 0)
+            {
+                total += (y + 3) / 4 - (y + 99) / 100 + (y + 399) / 400;
+            }
+            else
+            {
+                total -= y / -4 - y / -100 + y / -400;
+            }
+
+            total += ((367 * m - 362) / 12);
+            total += day - 1;
+            if (m > 2)
+            {
+                total -= 1;
+                if (IsLeapYear(year) == false)
+                {
+                    total -= 1;
+                }
+            }
+
+            return total - Days0000To1970;
+        }
+
+        private static void ComponentsOfNanoOfDay(long nanoOfDay, out int hour, out int minute, out int second, out int nanosecond)
+        {
+            hour = (int)(nanoOfDay / NanosPerHour);
+            nanoOfDay -= hour * NanosPerHour;
+
+            minute = (int)(nanoOfDay / NanosPerMinute);
+            nanoOfDay -= minute * NanosPerMinute;
+
+            second = (int)(nanoOfDay / NanosPerSecond);
+            nanosecond = (int)(nanoOfDay - second * NanosPerSecond);
+        }
+
+        private static void ComponentsOfEpochDays(long epochDays, out int year, out int month, out int day)
+        {
+            var zeroDay = (epochDays + Days0000To1970) - 60;
+            var adjust = 0L;
+            if (zeroDay < 0)
+            {
+                var adjustCycles = (zeroDay + 1) / DaysPerCycle - 1;
+                adjust = adjustCycles * 400;
+                zeroDay -= adjustCycles * DaysPerCycle;
+            }
+
+            var yearEst = (400 * zeroDay + 591) / DaysPerCycle;
+            var dayOfYearEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+            if (dayOfYearEst < 0)
+            {
+                yearEst -= 1;
+                dayOfYearEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+            }
+            yearEst += adjust;
+            var marchDayOfYear0 = (int)dayOfYearEst;
+
+            var marchMonth0 = (marchDayOfYear0 * 5 + 2) / 153;
+            month = (marchMonth0 + 2) % 12 + 1;
+            day = marchDayOfYear0 - (marchMonth0 * 306 + 5) / 10 + 1;
+            yearEst += marchMonth0 / 10;
+            year = (int)yearEst;
+        }
+
+        public static int ExtractNanosecondFromTicks(long ticks)
         {
             return (int)((ticks % TimeSpan.TicksPerSecond) * NanosecondsPerTick);
         }
 
-        public static long NanosOf(int hour, int minute, int second, int nanoOfSecond)
+        public static int ExtractTicksFromNanosecond(int nanosecond)
         {
-            return ((hour * TimeSpan.TicksPerHour + minute * TimeSpan.TicksPerMinute +
-                     second * TimeSpan.TicksPerSecond) * NanosecondsPerTick) + nanoOfSecond;
+            return nanosecond / NanosecondsPerTick;
         }
 
-        public static DateTime DateOf(long epochDays)
+        public static int MaxDayOfMonth(int year, int month)
         {
-            return Epoch.AddDays(epochDays);
+            switch (month)
+            {
+                case 2:
+                    return IsLeapYear(year) ? 29 : 28;
+                case 4:
+                case 6:
+                case 9:
+                case 11:
+                    return 30;
+                default:
+                    return 31;
+            }
         }
 
-        public static TimeSpan TimeOf(long nanosOfDay, bool throwOnTruncate = false)
+        public static void AssertNoTruncation(long nanosecond, string target)
         {
-            if (throwOnTruncate && nanosOfDay % NanosecondsPerTick != 0)
+            if (nanosecond % NanosecondsPerTick > 0)
             {
-                throw new TruncationException(
-                    $"Conversion of the incoming data into TimeSpan will cause a truncation of ${nanosOfDay % NanosecondsPerTick}ns.");
+                throw new ValueTruncationException(
+                    $"Conversion of this instance into {target} will cause a truncation of ${nanosecond % TemporalHelpers.NanosecondsPerTick}ns.");
             }
-
-            return new TimeSpan(nanosOfDay / NanosecondsPerTick);
         }
 
-        public static DateTime DateTimeOf(long epochSeconds, int nanosOfSecond, DateTimeKind kind = DateTimeKind.Local, bool throwOnTruncate = false)
+        public static string ToIsoDurationString(long months, long days, long seconds, int nanoseconds)
         {
-            if (throwOnTruncate && nanosOfSecond % NanosecondsPerTick != 0)
-            {
-                throw new TruncationException(
-                    $"Conversion of the incoming data into DateTime will cause a truncation of ${nanosOfSecond % NanosecondsPerTick}ns.");
-            }
-
-            var result = Epoch.AddSeconds(epochSeconds).AddTicks(nanosOfSecond / 100);
-            if (result.Kind != kind)
-            {
-                result = new DateTime(result.Ticks, kind);
-            }
-
-            return result;
+            return $"P{months}M{days}DT{seconds}.{nanoseconds:D9}S";
         }
 
-        public static DateTime AddNanosOfSecond(this DateTime dateTime, int nanosOfSecond, bool throwOnTruncate = false)
+        public static string ToIsoDateString(int year, int month, int day)
         {
-            if (throwOnTruncate && nanosOfSecond % NanosecondsPerTick != 0)
+            return $"{year:D4}-{month:D2}-{day:D2}";
+        }
+
+        public static string ToIsoTimeString(int hour, int minute, int second, int nanosecond)
+        {
+            return $"{hour:D2}:{minute:D2}:{second:D2}.{nanosecond:D9}";
+        }
+
+        public static string ToIsoTimeZoneOffset(int offsetSeconds)
+        {
+            if (offsetSeconds == 0)
             {
-                throw new TruncationException(
-                    $"Conversion of the incoming data into DateTime will cause a truncation of ${nanosOfSecond % NanosecondsPerTick}ns.");
+                return "Z";
             }
 
-            return dateTime.AddTicks(nanosOfSecond / 100);
+            var offset = TimeSpan.FromSeconds(offsetSeconds);
+
+            var sign = "+";
+            if (offsetSeconds < 0)
+            {
+                offset = offset.Negate();
+                sign = "-";
+            }
+
+            return offset.Seconds != 0 ? $"{sign}{offset.Hours:D2}:{offset.Minutes:D2}:{offset.Seconds:D2}" : $"{sign}{offset.Hours:D2}:{offset.Minutes:D2}";
         }
 
         public static TimeZoneInfo GetTimeZoneInfo(string zoneId)
         {
             return TZConvert.GetTimeZoneInfo(zoneId);
+        }
+
+        private static bool IsLeapYear(long year)
+        {
+            return ((year & 3) == 0) && ((year % 100) != 0 || (year % 400) == 0);
+        }
+
+        private static long FloorDiv(long a, long b)
+        {
+            return a >= 0 ? a / b : ((a + 1) / b) - 1;
+        }
+
+        private static long FloorMod(long a, long b)
+        {
+            return ((a % b) + b) % b;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -44,21 +44,25 @@ namespace Neo4j.Driver.Internal
         public const int MinOffset = -64_800;
         public const int MaxOffset = 64_800;
 
+        public const long NanosPerSecond = 1_000_000_000;
+        public const long NanosPerDay = NanosPerHour * HoursPerDay;
+
         private const int HoursPerDay = 24;
         private const int MinutesPerHour = 60;
         private const int SecondsPerMinute = 60;
         private const int SecondsPerHour = SecondsPerMinute * MinutesPerHour;
         private const int SecondsPerDay = SecondsPerHour * HoursPerDay;
-        private const long NanosPerSecond = 1_000_000_000;
         private const long NanosPerMinute = NanosPerSecond * SecondsPerMinute;
         private const long NanosPerHour = NanosPerMinute * MinutesPerHour;
+
         private const long Days0000To1970 = (DaysPerCycle * 5L) - (30L * 365L + 7L);
         private const int DaysPerCycle = 146_097;
         private const int NanosecondsPerTick = 100;
 
         public static long ToNanoOfDay(this IHasTimeComponents time)
         {
-            return (time.Hour * NanosPerHour) + (time.Minute * NanosPerMinute) + (time.Second * NanosPerSecond) + time.Nanosecond;
+            return (time.Hour * NanosPerHour) + (time.Minute * NanosPerMinute) + (time.Second * NanosPerSecond) +
+                   time.Nanosecond;
         }
 
         public static long ToEpochSeconds(this IHasDateTimeComponents dateTime)
@@ -77,6 +81,13 @@ namespace Neo4j.Driver.Internal
         public static long ToEpochDays(this IHasDateComponents date)
         {
             return ComputeEpochDays(date.Year, date.Month, date.Day);
+        }
+
+        public static long ToNanos(this CypherDuration duration)
+        {
+            return (duration.Months * 30 * TemporalHelpers.NanosPerDay) +
+                   (duration.Days * TemporalHelpers.NanosPerDay) +
+                   (duration.Seconds * TemporalHelpers.NanosPerSecond) + duration.Nanos;
         }
 
         public static CypherTime NanoOfDayToTime(long nanoOfDay)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/Throw.cs
@@ -96,6 +96,13 @@ namespace Neo4j.Driver.Internal
                 if (!value)
                     throw new System.ArgumentOutOfRangeException($"Expecting {nameofValue} to be true, however the value is false");
             }
+
+            public static void IfValueNotBetween(long value, long minInclusive, long maxInclusive, string parameterName)
+            {
+                if (value < minInclusive || value > maxInclusive)
+                    throw new System.ArgumentOutOfRangeException(parameterName, value, $"Value given ({value}) must be between {minInclusive} and {maxInclusive}.");
+            }
+
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateHandler.cs
@@ -36,7 +36,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
 
             var epochDays = reader.ReadLong();
 
-            return new CypherDate(epochDays);
+            return TemporalHelpers.EpochDaysToDate(epochDays);
         }
 
         public void Write(IPackStreamWriter writer, object value)
@@ -44,7 +44,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var date = value.CastOrThrow<CypherDate>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(date.EpochDays);
+            writer.Write(date.ToEpochDays());
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeHandler.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var epochSeconds = reader.ReadLong();
             var nanosOfSecond = reader.ReadInteger();
 
-            return new CypherDateTime(epochSeconds, nanosOfSecond);
+            return TemporalHelpers.EpochSecondsAndNanoToDateTime(epochSeconds, nanosOfSecond);
         }
 
         public void Write(IPackStreamWriter writer, object value)
@@ -45,8 +45,8 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var dateTime = value.CastOrThrow<CypherDateTime>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(dateTime.EpochSeconds);
-            writer.Write(dateTime.NanosOfSecond);
+            writer.Write(dateTime.ToEpochSeconds());
+            writer.Write(dateTime.Nanosecond);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithOffsetHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithOffsetHandler.cs
@@ -38,7 +38,8 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var nanosOfSecond = reader.ReadInteger();
             var offsetSeconds = reader.ReadInteger();
 
-            return new CypherDateTimeWithOffset(epochSecondsUtc, nanosOfSecond, offsetSeconds);
+            return new CypherDateTimeWithOffset(
+                TemporalHelpers.EpochSecondsAndNanoToDateTime(epochSecondsUtc, nanosOfSecond), offsetSeconds);
         }
 
         public void Write(IPackStreamWriter writer, object value)
@@ -46,8 +47,8 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var dateTime = value.CastOrThrow<CypherDateTimeWithOffset>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(dateTime.EpochSeconds);
-            writer.Write(dateTime.NanosOfSecond);
+            writer.Write(dateTime.ToEpochSeconds());
+            writer.Write(dateTime.Nanosecond);
             writer.Write(dateTime.OffsetSeconds);
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithZoneIdHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/DateTimeWithZoneIdHandler.cs
@@ -38,7 +38,8 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var nanosOfSecond = reader.ReadInteger();
             var zoneId = reader.ReadString();
 
-            return new CypherDateTimeWithZoneId(epochSecondsUtc, nanosOfSecond, zoneId);
+            return new CypherDateTimeWithZoneId(
+                TemporalHelpers.EpochSecondsAndNanoToDateTime(epochSecondsUtc, nanosOfSecond), zoneId);
         }
 
         public void Write(IPackStreamWriter writer, object value)
@@ -46,8 +47,8 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var dateTime = value.CastOrThrow<CypherDateTimeWithZoneId>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(dateTime.EpochSeconds);
-            writer.Write(dateTime.NanosOfSecond);
+            writer.Write(dateTime.ToEpochSeconds());
+            writer.Write(dateTime.Nanosecond);
             writer.Write(dateTime.ZoneId);
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/TimeHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/TimeHandler.cs
@@ -36,7 +36,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
 
             var nanosOfDay = reader.ReadLong();
 
-            return new CypherTime(nanosOfDay);
+            return TemporalHelpers.NanoOfDayToTime(nanosOfDay);
         }
 
         public void Write(IPackStreamWriter writer, object value)
@@ -44,7 +44,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var time = value.CastOrThrow<CypherTime>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(time.NanosecondsOfDay);
+            writer.Write(time.ToNanoOfDay());
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/TimeWithOffsetHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/StructHandlers/Temporal/TimeWithOffsetHandler.cs
@@ -37,7 +37,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var nanosOfDay = reader.ReadLong();
             var offsetSeconds = reader.ReadInteger();
 
-            return new CypherTimeWithOffset(nanosOfDay, offsetSeconds);
+            return new CypherTimeWithOffset(TemporalHelpers.NanoOfDayToTime(nanosOfDay), offsetSeconds);
         }
 
         public void Write(IPackStreamWriter writer, object value)
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.Internal.IO.StructHandlers
             var time = value.CastOrThrow<CypherTimeWithOffset>();
 
             writer.WriteStructHeader(StructSize, StructType);
-            writer.Write(time.NanosecondsOfDay);
+            writer.Write(time.ToNanoOfDay());
             writer.Write(time.OffsetSeconds);
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateComponents.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateComponents.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2002-2018 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neo4j.Driver.Internal.Types
+{
+    internal interface IHasDateComponents
+    {
+
+        int Year { get; }
+
+        int Month { get; }
+
+        int Day { get; }
+
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateTimeComponents.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateTimeComponents.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2002-2018 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neo4j.Driver.Internal.Types
+{
+    internal interface IHasDateTimeComponents: IHasDateComponents, IHasTimeComponents
+    {
+        
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasTimeComponents.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasTimeComponents.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2002-2018 "Neo Technology,"
+// Network Engine for Objects in Lund AB [http://neotechnology.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neo4j.Driver.Internal.Types
+{
+    internal interface IHasTimeComponents
+    {
+        
+        int Hour { get; }
+
+        int Minute { get; }
+
+        int Second { get; }
+
+        int Nanosecond { get; }
+
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IValue.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IValue.cs
@@ -15,15 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.V1
+namespace Neo4j.Driver.Internal.Types
 {
-    /// <summary>
-    /// This is a marker interface that's currently used to identify Neo4j data
-    /// types that can be sent to the server.
-    /// </summary>
-    /// <remarks>This type is currently experimental, and can be removed on upcoming
-    /// pre-release versions of the driver.</remarks>
-    public interface ICypherValue
+    internal interface IValue
     {
         
     }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Neo4jException.cs
@@ -363,15 +363,33 @@ namespace Neo4j.Driver.V1
     /// cause working with a modified data.
     /// </summary>
     [DataContract]
-    public class TruncationException : ClientException
+    public class ValueTruncationException : ClientException
     {
 
         /// <summary>
-        /// Create a new <see cref="TruncationException"/> with an error message.
+        /// Create a new <see cref="ValueTruncationException"/> with an error message.
         /// </summary>
         /// <param name="message">The error message.</param>
 
-        public TruncationException(string message) : base(message)
+        public ValueTruncationException(string message) : base(message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A value retrieved from the database cannot be represented with the type to be converted, and will
+    /// cause working with a modified data.
+    /// </summary>
+    [DataContract]
+    public class ValueOverflowException : ClientException
+    {
+
+        /// <summary>
+        /// Create a new <see cref="ValueTruncationException"/> with an error message.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+
+        public ValueOverflowException(string message) : base(message)
         {
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date value, without a time zone and time related components
     /// </summary>
-    public struct CypherDate : IValue, IEquatable<CypherDate>, IComparable, IComparable<CypherDate>, IHasDateComponents
+    public struct CypherDate : IValue, IEquatable<CypherDate>, IComparable, IComparable<CypherDate>, IConvertible, IHasDateComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDate"/> from a date value
@@ -208,5 +208,104 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return DateTime;
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(DateTime))
+            {
+                return DateTime;
+            }
+
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
@@ -24,9 +24,8 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date value, without a time zone and time related components
     /// </summary>
-    public struct CypherDate : ICypherValue, IEquatable<CypherDate>, IHasDateComponents
+    public struct CypherDate : IValue, IEquatable<CypherDate>, IComparable, IComparable<CypherDate>, IHasDateComponents
     {
-
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDate"/> from a date value
         /// </summary>
@@ -130,6 +129,84 @@ namespace Neo4j.Driver.V1
         public override string ToString()
         {
             return TemporalHelpers.ToIsoDateString(Year, Month, Day);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherDate"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherDate other)
+        {
+            var yearComparison = Year.CompareTo(other.Year);
+            if (yearComparison != 0) return yearComparison;
+            var monthComparison = Month.CompareTo(other.Month);
+            if (monthComparison != 0) return monthComparison;
+            return Day.CompareTo(other.Day);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherDate"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherDate"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherDate)) throw new ArgumentException($"Object must be of type {nameof(CypherDate)}");
+            return CompareTo((CypherDate) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDate"/> is earlier than another specified 
+        /// <see cref="CypherDate"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherDate left, CypherDate right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDate"/> is later than another specified 
+        /// <see cref="CypherDate"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherDate left, CypherDate right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDate"/> represents a duration that is the 
+        /// same as or later than the other specified <see cref="CypherDate"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherDate left, CypherDate right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDate"/> represents a duration that is the 
+        /// same as or earlier than the other specified <see cref="CypherDate"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherDate left, CypherDate right)
+        {
+            return left.CompareTo(right) >= 0;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
@@ -72,12 +72,16 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="DateTime"/> copy of this date value.
         /// </summary>
-        /// <returns>Equivalent <see cref="DateTime"/> value</returns>
-        public DateTime ToDateTime()
+        /// <value>Equivalent <see cref="DateTime"/> value</value>
+        /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
+        public DateTime DateTime
         {
-            TemporalHelpers.AssertNoOverflow(this, nameof(DateTime));
+            get
+            {
+                TemporalHelpers.AssertNoOverflow(this, nameof(System.DateTime));
 
-            return new DateTime(Year, Month, Day);
+                return new DateTime(Year, Month, Day);
+            }
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDate.cs
@@ -75,10 +75,7 @@ namespace Neo4j.Driver.V1
         /// <returns>Equivalent <see cref="DateTime"/> value</returns>
         public DateTime ToDateTime()
         {
-            if (Year > DateTime.MaxValue.Year || Year < DateTime.MinValue.Year)
-            {
-                throw new ValueOverflowException($"Year component ({Year}) of this instance is not between valid values for a DateTime.");
-            }
+            TemporalHelpers.AssertNoOverflow(this, nameof(DateTime));
 
             return new DateTime(Year, Month, Day);
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a local date time value, without a time zone
     /// </summary>
-    public struct CypherDateTime : ICypherValue, IEquatable<CypherDateTime>, IHasDateTimeComponents
+    public struct CypherDateTime : IValue, IEquatable<CypherDateTime>, IComparable, IComparable<CypherDateTime>, IHasDateTimeComponents
     {
 
         /// <summary>
@@ -196,6 +196,92 @@ namespace Neo4j.Driver.V1
         {
             return
                 $"{TemporalHelpers.ToIsoDateString(Year, Month, Day)}T{TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond)}";
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherDateTime"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherDateTime other)
+        {
+            var yearComparison = Year.CompareTo(other.Year);
+            if (yearComparison != 0) return yearComparison;
+            var monthComparison = Month.CompareTo(other.Month);
+            if (monthComparison != 0) return monthComparison;
+            var dayComparison = Day.CompareTo(other.Day);
+            if (dayComparison != 0) return dayComparison;
+            var hourComparison = Hour.CompareTo(other.Hour);
+            if (hourComparison != 0) return hourComparison;
+            var minuteComparison = Minute.CompareTo(other.Minute);
+            if (minuteComparison != 0) return minuteComparison;
+            var secondComparison = Second.CompareTo(other.Second);
+            if (secondComparison != 0) return secondComparison;
+            return Nanosecond.CompareTo(other.Nanosecond);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherDateTime"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherDateTime"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherDateTime)) throw new ArgumentException($"Object must be of type {nameof(CypherDateTime)}");
+            return CompareTo((CypherDateTime) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTime"/> is earlier than another specified 
+        /// <see cref="CypherDateTime"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherDateTime left, CypherDateTime right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTime"/> is later than another specified 
+        /// <see cref="CypherDateTime"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherDateTime left, CypherDateTime right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTime"/> represents a duration that is the 
+        /// same as or later than the other specified <see cref="CypherDateTime"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherDateTime left, CypherDateTime right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTime"/> represents a duration that is the 
+        /// same as or earlier than the other specified <see cref="CypherDateTime"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherDateTime left, CypherDateTime right)
+        {
+            return left.CompareTo(right) >= 0;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a local date time value, without a time zone
     /// </summary>
-    public struct CypherDateTime : IValue, IEquatable<CypherDateTime>, IComparable, IComparable<CypherDateTime>, IHasDateTimeComponents
+    public struct CypherDateTime : IValue, IEquatable<CypherDateTime>, IComparable, IComparable<CypherDateTime>, IConvertible, IHasDateTimeComponents
     {
 
         /// <summary>
@@ -283,5 +283,104 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return DateTime;
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(DateTime))
+            {
+                return DateTime;
+            }
+
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
@@ -133,7 +133,8 @@ namespace Neo4j.Driver.V1
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public DateTime ToDateTime()
         {
-            TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(DateTime));
+            TemporalHelpers.AssertNoTruncation(this, nameof(DateTime));
+            TemporalHelpers.AssertNoOverflow(this, nameof(DateTime));
 
             return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
                 TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTime.cs
@@ -44,15 +44,15 @@ namespace Neo4j.Driver.V1
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CypherDateTime"/> from given <see cref="DateTime"/> value.
-        /// The given <see cref="DateTime"/> value will be normalized to local time <see cref="DateTimeKind.Local"/>
+        /// Initializes a new instance of <see cref="CypherDateTime"/> from given <see cref="System.DateTime"/> value.
+        /// The given <see cref="System.DateTime"/> value will be normalized to local time <see cref="DateTimeKind.Local"/>
         /// before being used.
         /// </summary>
         ///
-        /// <remarks>If the <see cref="DateTime"/> value was created with no <see cref="DateTimeKind"/> specified,
+        /// <remarks>If the <see cref="System.DateTime"/> value was created with no <see cref="DateTimeKind"/> specified,
         /// then <see cref="DateTimeKind.Unspecified"/> would be assigned by default.
         /// Possible conversion from UTC to local time might happen when normalizing it to local time.
-        /// <seealso cref="DateTime.ToLocalTime"/>
+        /// <seealso cref="System.DateTime.ToLocalTime"/>
         /// </remarks>
         /// <param name="dateTime"></param>
         public CypherDateTime(DateTime dateTime)
@@ -129,15 +129,19 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="DateTime"/> copy of this date value.
         /// </summary>
-        /// <returns>Equivalent <see cref="DateTime"/> value</returns>
+        /// <value>Equivalent <see cref="DateTime"/> value</value>
+        /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTime ToDateTime()
+        public DateTime DateTime
         {
-            TemporalHelpers.AssertNoTruncation(this, nameof(DateTime));
-            TemporalHelpers.AssertNoOverflow(this, nameof(DateTime));
+            get
+            {
+                TemporalHelpers.AssertNoTruncation(this, nameof(System.DateTime));
+                TemporalHelpers.AssertNoOverflow(this, nameof(System.DateTime));
 
-            return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
-                TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));
+                return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
+                    TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));
+            }
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
@@ -156,6 +156,8 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="DateTime"/> value that represents the date and time of this instance.
         /// </summary>
+        /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
+        /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public DateTime DateTime
         {
             get

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
@@ -160,7 +160,8 @@ namespace Neo4j.Driver.V1
         {
             get
             {
-                TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(DateTime));
+                TemporalHelpers.AssertNoTruncation(this, nameof(DateTime));
+                TemporalHelpers.AssertNoOverflow(this, nameof(DateTime));
 
                 return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
                     TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
@@ -17,14 +17,47 @@
 
 using System;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.V1
 {
     /// <summary>
     /// Represents a date time value with a time zone, specified as a UTC offset
     /// </summary>
-    public struct CypherDateTimeWithOffset : ICypherValue, IEquatable<CypherDateTimeWithOffset>
+    public struct CypherDateTimeWithOffset : ICypherValue, IEquatable<CypherDateTimeWithOffset>, IHasDateTimeComponents
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTimeOffset"/> value.
+        /// </summary>
+        /// <param name="dateTimeOffset"></param>
+        public CypherDateTimeWithOffset(DateTimeOffset dateTimeOffset)
+            : this(dateTimeOffset.DateTime, dateTimeOffset.Offset)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="dateTime"></param>
+        /// <param name="offset"></param>
+        public CypherDateTimeWithOffset(DateTime dateTime, TimeSpan offset)
+            : this(dateTime, (int)offset.TotalSeconds)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="dateTime"></param>
+        /// <param name="offsetSeconds"></param>
+        public CypherDateTimeWithOffset(DateTime dateTime, int offsetSeconds)
+            : this(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second, TemporalHelpers.ExtractNanosecondFromTicks(dateTime.Ticks), offsetSeconds)
+        {
+
+        }
+
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from individual date time component values
         /// </summary>
@@ -50,74 +83,70 @@ namespace Neo4j.Driver.V1
         /// <param name="hour"></param>
         /// <param name="minute"></param>
         /// <param name="second"></param>
-        /// <param name="nanosOfSecond"></param>
+        /// <param name="nanosecond"></param>
         /// <param name="offsetSeconds"></param>
-        public CypherDateTimeWithOffset(int year, int month, int day, int hour, int minute, int second, int nanosOfSecond, int offsetSeconds)
-            : this(new DateTime(year, month, day, hour, minute, second, DateTimeKind.Unspecified), offsetSeconds)
+        public CypherDateTimeWithOffset(int year, int month, int day, int hour, int minute, int second, int nanosecond, int offsetSeconds)
         {
-            NanosOfSecond += nanosOfSecond;
-        }
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(year, TemporalHelpers.MinYear, TemporalHelpers.MaxYear, nameof(year));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(month, TemporalHelpers.MinMonth, TemporalHelpers.MaxMonth, nameof(month));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(day, TemporalHelpers.MinDay, TemporalHelpers.MaxDayOfMonth(year, month), nameof(day));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(hour, TemporalHelpers.MinHour, TemporalHelpers.MaxHour, nameof(hour));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(minute, TemporalHelpers.MinMinute, TemporalHelpers.MaxMinute, nameof(minute));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(second, TemporalHelpers.MinSecond, TemporalHelpers.MaxSecond, nameof(second));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanosecond, TemporalHelpers.MinNanosecond, TemporalHelpers.MaxNanosecond, nameof(nanosecond));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(offsetSeconds, TemporalHelpers.MinOffset, TemporalHelpers.MaxOffset, nameof(offsetSeconds));
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTime"/> value.
-        /// </summary>
-        /// <param name="dateTime"></param>
-        /// <param name="offsetSeconds"></param>
-        public CypherDateTimeWithOffset(DateTime dateTime, int offsetSeconds)
-            : this(dateTime.Kind == DateTimeKind.Unspecified ? dateTime : new DateTime(dateTime.Ticks, DateTimeKind.Unspecified), TimeSpan.FromSeconds(offsetSeconds))
-        {
-
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTimeOffset"/> value.
-        /// </summary>
-        /// <param name="dateTimeOffset"></param>
-        public CypherDateTimeWithOffset(DateTimeOffset dateTimeOffset)
-            : this(dateTimeOffset.DateTime, dateTimeOffset.Offset)
-        {
-
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTime"/> value.
-        /// </summary>
-        /// <param name="dateTime"></param>
-        /// <param name="offset"></param>
-        public CypherDateTimeWithOffset(DateTime dateTime, TimeSpan offset)
-            : this((dateTime.Kind == DateTimeKind.Unspecified ? dateTime : new DateTime(dateTime.Ticks, DateTimeKind.Unspecified)).Ticks, (int)offset.TotalSeconds)
-        {
-
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from ticks.
-        /// </summary>
-        /// <param name="ticks"></param>
-        /// <param name="offsetSeconds"></param>
-        public CypherDateTimeWithOffset(long ticks, int offsetSeconds)
-            : this(TemporalHelpers.SecondsSinceEpoch(ticks),
-                TemporalHelpers.NanosOfSecond(ticks), offsetSeconds)
-        {
-
-        }
-
-        internal CypherDateTimeWithOffset(long epochSeconds, int nanosOfSecond, int offsetSeconds)
-        {
-            EpochSeconds = epochSeconds;
-            NanosOfSecond = nanosOfSecond;
+            Year = year;
+            Month = month;
+            Day = day;
+            Hour = hour;
+            Minute = minute;
+            Second = second;
+            Nanosecond = nanosecond;
             OffsetSeconds = offsetSeconds;
         }
 
-        /// <summary>
-        /// Seconds since Unix Epoch
-        /// </summary>
-        public long EpochSeconds { get; }
+        internal CypherDateTimeWithOffset(IHasDateTimeComponents dateTime, int offsetSeconds)
+            : this(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second,
+                dateTime.Nanosecond, offsetSeconds)
+        {
+
+        }
 
         /// <summary>
-        /// Fraction of seconds in nanosecond precision
+        /// Gets the year component of this instance.
         /// </summary>
-        public int NanosOfSecond { get; }
+        public int Year { get; }
+
+        /// <summary>
+        /// Gets the month component of this instance.
+        /// </summary>
+        public int Month { get; }
+
+        /// <summary>
+        /// Gets the day of month component of this instance.
+        /// </summary>
+        public int Day { get; }
+
+        /// <summary>
+        /// Gets the hour component of this instance.
+        /// </summary>
+        public int Hour { get; }
+
+        /// <summary>
+        /// Gets the minute component of this instance.
+        /// </summary>
+        public int Minute { get; }
+
+        /// <summary>
+        /// Gets the second component of this instance.
+        /// </summary>
+        public int Second { get; }
+
+        /// <summary>
+        /// Gets the nanosecond component of this instance.
+        /// </summary>
+        public int Nanosecond { get; }
 
         /// <summary>
         /// Offset in seconds precision
@@ -127,8 +156,16 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="DateTime"/> value that represents the date and time of this instance.
         /// </summary>
-        public DateTime DateTime =>
-            TemporalHelpers.DateTimeOf(EpochSeconds, NanosOfSecond, DateTimeKind.Unspecified, true);
+        public DateTime DateTime
+        {
+            get
+            {
+                TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(DateTime));
+
+                return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
+                    TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));
+            }
+        }
 
         /// <summary>
         /// Gets a <see cref="TimeSpan"/> value that represents the offset of this instance.
@@ -139,7 +176,7 @@ namespace Neo4j.Driver.V1
         /// Converts this instance to an equivalent <see cref="DateTimeOffset"/> value
         /// </summary>
         /// <returns>Equivalent <see cref="DateTimeOffset"/> value</returns>
-        /// <exception cref="TruncationException">If a truncation occurs during conversion</exception>
+        /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public DateTimeOffset ToDateTimeOffset()
         {
             return new DateTimeOffset(DateTime, Offset);
@@ -154,7 +191,9 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(CypherDateTimeWithOffset other)
         {
-            return EpochSeconds == other.EpochSeconds && NanosOfSecond == other.NanosOfSecond && OffsetSeconds == other.OffsetSeconds;
+            return Year == other.Year && Month == other.Month && Day == other.Day && Hour == other.Hour &&
+                   Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond &&
+                   OffsetSeconds == other.OffsetSeconds;
         }
 
         /// <summary>
@@ -177,8 +216,13 @@ namespace Neo4j.Driver.V1
         {
             unchecked
             {
-                var hashCode = EpochSeconds.GetHashCode();
-                hashCode = (hashCode * 397) ^ NanosOfSecond;
+                var hashCode = Year;
+                hashCode = (hashCode * 397) ^ Month;
+                hashCode = (hashCode * 397) ^ Day;
+                hashCode = (hashCode * 397) ^ Hour;
+                hashCode = (hashCode * 397) ^ Minute;
+                hashCode = (hashCode * 397) ^ Second;
+                hashCode = (hashCode * 397) ^ Nanosecond;
                 hashCode = (hashCode * 397) ^ OffsetSeconds;
                 return hashCode;
             }
@@ -190,7 +234,8 @@ namespace Neo4j.Driver.V1
         /// <returns>String representation of this Point.</returns>
         public override string ToString()
         {
-            return $"DateTimeWithOffset{{epochSeconds: {EpochSeconds}, nanosOfSecond: {NanosOfSecond}, offsetSeconds: {OffsetSeconds}}}";
+            return
+                $"{TemporalHelpers.ToIsoDateString(Year, Month, Day)}T{TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond)}{TemporalHelpers.ToIsoTimeZoneOffset(OffsetSeconds)}";
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date time value with a time zone, specified as a UTC offset
     /// </summary>
-    public struct CypherDateTimeWithOffset : ICypherValue, IEquatable<CypherDateTimeWithOffset>, IHasDateTimeComponents
+    public struct CypherDateTimeWithOffset : IValue, IEquatable<CypherDateTimeWithOffset>, IComparable, IComparable<CypherDateTimeWithOffset>, IHasDateTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTimeOffset"/> value.
@@ -239,6 +239,84 @@ namespace Neo4j.Driver.V1
         {
             return
                 $"{TemporalHelpers.ToIsoDateString(Year, Month, Day)}T{TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond)}{TemporalHelpers.ToIsoTimeZoneOffset(OffsetSeconds)}";
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherDateTimeWithOffset"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherDateTimeWithOffset other)
+        {
+            var thisEpochSeconds = this.ToEpochSeconds() - OffsetSeconds;
+            var otherEpochSeconds = other.ToEpochSeconds() - other.OffsetSeconds;
+            var epochComparison = thisEpochSeconds.CompareTo(otherEpochSeconds);
+            if (epochComparison != 0) return epochComparison;
+            return Nanosecond.CompareTo(other.Nanosecond);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherDateTimeWithOffset"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherDateTimeWithOffset"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherDateTimeWithOffset)) throw new ArgumentException($"Object must be of type {nameof(CypherDateTimeWithOffset)}");
+            return CompareTo((CypherDateTimeWithOffset) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithOffset"/> is earlier than another specified 
+        /// <see cref="CypherDateTimeWithOffset"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherDateTimeWithOffset left, CypherDateTimeWithOffset right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithOffset"/> is later than another specified 
+        /// <see cref="CypherDateTimeWithOffset"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherDateTimeWithOffset left, CypherDateTimeWithOffset right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithOffset"/> represents a duration that is the 
+        /// same as or later than the other specified <see cref="CypherDateTimeWithOffset"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherDateTimeWithOffset left, CypherDateTimeWithOffset right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithOffset"/> represents a duration that is the 
+        /// same as or earlier than the other specified <see cref="CypherDateTimeWithOffset"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherDateTimeWithOffset left, CypherDateTimeWithOffset right)
+        {
+            return left.CompareTo(right) >= 0;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithOffset.cs
@@ -24,7 +24,8 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date time value with a time zone, specified as a UTC offset
     /// </summary>
-    public struct CypherDateTimeWithOffset : IValue, IEquatable<CypherDateTimeWithOffset>, IComparable, IComparable<CypherDateTimeWithOffset>, IHasDateTimeComponents
+    public struct CypherDateTimeWithOffset : IValue, IEquatable<CypherDateTimeWithOffset>, IComparable,
+        IComparable<CypherDateTimeWithOffset>, IConvertible, IHasDateTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDateTimeWithOffset"/> from given <see cref="DateTimeOffset"/> value.
@@ -42,7 +43,7 @@ namespace Neo4j.Driver.V1
         /// <param name="dateTime"></param>
         /// <param name="offset"></param>
         public CypherDateTimeWithOffset(DateTime dateTime, TimeSpan offset)
-            : this(dateTime, (int)offset.TotalSeconds)
+            : this(dateTime, (int) offset.TotalSeconds)
         {
 
         }
@@ -53,7 +54,8 @@ namespace Neo4j.Driver.V1
         /// <param name="dateTime"></param>
         /// <param name="offsetSeconds"></param>
         public CypherDateTimeWithOffset(DateTime dateTime, int offsetSeconds)
-            : this(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second, TemporalHelpers.ExtractNanosecondFromTicks(dateTime.Ticks), offsetSeconds)
+            : this(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second,
+                TemporalHelpers.ExtractNanosecondFromTicks(dateTime.Ticks), offsetSeconds)
         {
 
         }
@@ -68,7 +70,8 @@ namespace Neo4j.Driver.V1
         /// <param name="minute"></param>
         /// <param name="second"></param>
         /// <param name="offsetSeconds"></param>
-        public CypherDateTimeWithOffset(int year, int month, int day, int hour, int minute, int second, int offsetSeconds)
+        public CypherDateTimeWithOffset(int year, int month, int day, int hour, int minute, int second,
+            int offsetSeconds)
             : this(year, month, day, hour, minute, second, 0, offsetSeconds)
         {
 
@@ -85,16 +88,25 @@ namespace Neo4j.Driver.V1
         /// <param name="second"></param>
         /// <param name="nanosecond"></param>
         /// <param name="offsetSeconds"></param>
-        public CypherDateTimeWithOffset(int year, int month, int day, int hour, int minute, int second, int nanosecond, int offsetSeconds)
+        public CypherDateTimeWithOffset(int year, int month, int day, int hour, int minute, int second, int nanosecond,
+            int offsetSeconds)
         {
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(year, TemporalHelpers.MinYear, TemporalHelpers.MaxYear, nameof(year));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(month, TemporalHelpers.MinMonth, TemporalHelpers.MaxMonth, nameof(month));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(day, TemporalHelpers.MinDay, TemporalHelpers.MaxDayOfMonth(year, month), nameof(day));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(hour, TemporalHelpers.MinHour, TemporalHelpers.MaxHour, nameof(hour));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(minute, TemporalHelpers.MinMinute, TemporalHelpers.MaxMinute, nameof(minute));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(second, TemporalHelpers.MinSecond, TemporalHelpers.MaxSecond, nameof(second));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanosecond, TemporalHelpers.MinNanosecond, TemporalHelpers.MaxNanosecond, nameof(nanosecond));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(offsetSeconds, TemporalHelpers.MinOffset, TemporalHelpers.MaxOffset, nameof(offsetSeconds));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(year, TemporalHelpers.MinYear, TemporalHelpers.MaxYear,
+                nameof(year));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(month, TemporalHelpers.MinMonth,
+                TemporalHelpers.MaxMonth, nameof(month));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(day, TemporalHelpers.MinDay,
+                TemporalHelpers.MaxDayOfMonth(year, month), nameof(day));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(hour, TemporalHelpers.MinHour, TemporalHelpers.MaxHour,
+                nameof(hour));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(minute, TemporalHelpers.MinMinute,
+                TemporalHelpers.MaxMinute, nameof(minute));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(second, TemporalHelpers.MinSecond,
+                TemporalHelpers.MaxSecond, nameof(second));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanosecond, TemporalHelpers.MinNanosecond,
+                TemporalHelpers.MaxNanosecond, nameof(nanosecond));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(offsetSeconds, TemporalHelpers.MinOffset,
+                TemporalHelpers.MaxOffset, nameof(offsetSeconds));
 
             Year = year;
             Month = month;
@@ -174,16 +186,13 @@ namespace Neo4j.Driver.V1
         /// Gets a <see cref="TimeSpan"/> value that represents the offset of this instance.
         /// </summary>
         public TimeSpan Offset => TimeSpan.FromSeconds(OffsetSeconds);
-        
+
         /// <summary>
         /// Converts this instance to an equivalent <see cref="DateTimeOffset"/> value
         /// </summary>
         /// <returns>Equivalent <see cref="DateTimeOffset"/> value</returns>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTimeOffset ToDateTimeOffset()
-        {
-            return new DateTimeOffset(DateTime, Offset);
-        }
+        public DateTimeOffset DateTimeOffset => new DateTimeOffset(DateTime, Offset);
 
         /// <summary>
         /// Returns a value indicating whether the value of this instance is equal to the 
@@ -267,7 +276,8 @@ namespace Neo4j.Driver.V1
         public int CompareTo(object obj)
         {
             if (ReferenceEquals(null, obj)) return 1;
-            if (!(obj is CypherDateTimeWithOffset)) throw new ArgumentException($"Object must be of type {nameof(CypherDateTimeWithOffset)}");
+            if (!(obj is CypherDateTimeWithOffset))
+                throw new ArgumentException($"Object must be of type {nameof(CypherDateTimeWithOffset)}");
             return CompareTo((CypherDateTimeWithOffset) obj);
         }
 
@@ -318,5 +328,109 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return DateTimeOffset.DateTime;
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(DateTime))
+            {
+                return DateTimeOffset.DateTime;
+            }
+
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            if (conversionType == typeof(DateTimeOffset))
+            {
+                return DateTimeOffset;
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
@@ -153,7 +153,8 @@ namespace Neo4j.Driver.V1
         {
             get
             {
-                TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(DateTime));
+                TemporalHelpers.AssertNoTruncation(this, nameof(DateTime));
+                TemporalHelpers.AssertNoOverflow(this, nameof(DateTime));
 
                 return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
                     TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
@@ -149,6 +149,8 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="DateTime"/> value that represents the date and time of this instance.
         /// </summary>
+        /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
+        /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public DateTime DateTime
         {
             get

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date time value with a time zone, specified as a zone id
     /// </summary>
-    public struct CypherDateTimeWithZoneId : IValue, IEquatable<CypherDateTimeWithZoneId>, IComparable, IComparable<CypherDateTimeWithZoneId>, IHasDateTimeComponents
+    public struct CypherDateTimeWithZoneId : IValue, IEquatable<CypherDateTimeWithZoneId>, IComparable, IComparable<CypherDateTimeWithZoneId>, IConvertible, IHasDateTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDateTimeWithZoneId"/> from given <see cref="DateTimeOffset"/> value
@@ -174,10 +174,7 @@ namespace Neo4j.Driver.V1
         /// </summary>
         /// <returns>Equivalent <see cref="DateTimeOffset"/> value</returns>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTimeOffset ToDateTimeOffset()
-        {
-            return new DateTimeOffset(DateTime, Offset);
-        }
+        public DateTimeOffset DateTimeOffset => new DateTimeOffset(DateTime, Offset);
 
         /// <summary>
         /// Returns a value indicating whether the value of this instance is equal to the 
@@ -312,5 +309,110 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return DateTimeOffset.DateTime;
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(DateTime))
+            {
+                return DateTimeOffset.DateTime;
+            }
+
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            if (conversionType == typeof(DateTimeOffset))
+            {
+                return DateTimeOffset;
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDateTimeWithZoneId.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date time value with a time zone, specified as a zone id
     /// </summary>
-    public struct CypherDateTimeWithZoneId : ICypherValue, IEquatable<CypherDateTimeWithZoneId>, IHasDateTimeComponents
+    public struct CypherDateTimeWithZoneId : IValue, IEquatable<CypherDateTimeWithZoneId>, IComparable, IComparable<CypherDateTimeWithZoneId>, IHasDateTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherDateTimeWithZoneId"/> from given <see cref="DateTimeOffset"/> value
@@ -188,7 +188,9 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(CypherDateTimeWithZoneId other)
         {
-            return Year == other.Year && Month == other.Month && Day == other.Day && Hour == other.Hour && Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond && string.Equals(ZoneId, other.ZoneId);
+            return Year == other.Year && Month == other.Month && Day == other.Day && Hour == other.Hour &&
+                   Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond &&
+                   string.Equals(ZoneId, other.ZoneId);
         }
 
         /// <summary>
@@ -233,5 +235,82 @@ namespace Neo4j.Driver.V1
                 $"{TemporalHelpers.ToIsoDateString(Year, Month, Day)}T{TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond)}[{ZoneId}]";
         }
 
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherDateTimeWithZoneId"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherDateTimeWithZoneId other)
+        {
+            var thisEpochSeconds = this.ToEpochSeconds() - (int)Offset.TotalSeconds;
+            var otherEpochSeconds = other.ToEpochSeconds() - (int)other.Offset.TotalSeconds;
+            var epochComparison = thisEpochSeconds.CompareTo(otherEpochSeconds);
+            if (epochComparison != 0) return epochComparison;
+            return Nanosecond.CompareTo(other.Nanosecond);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherDateTimeWithZoneId"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherDateTimeWithZoneId"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherDateTimeWithZoneId)) throw new ArgumentException($"Object must be of type {nameof(CypherDateTimeWithZoneId)}");
+            return CompareTo((CypherDateTimeWithZoneId) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithZoneId"/> is earlier than another specified 
+        /// <see cref="CypherDateTimeWithZoneId"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherDateTimeWithZoneId left, CypherDateTimeWithZoneId right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithZoneId"/> is later than another specified 
+        /// <see cref="CypherDateTimeWithZoneId"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherDateTimeWithZoneId left, CypherDateTimeWithZoneId right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithZoneId"/> represents a duration that is the 
+        /// same as or later than the other specified <see cref="CypherDateTimeWithZoneId"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherDateTimeWithZoneId left, CypherDateTimeWithZoneId right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDateTimeWithZoneId"/> represents a duration that is the 
+        /// same as or earlier than the other specified <see cref="CypherDateTimeWithZoneId"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherDateTimeWithZoneId left, CypherDateTimeWithZoneId right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDuration.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDuration.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 using System;
+using Neo4j.Driver.Internal;
 
 namespace Neo4j.Driver.V1
 {
@@ -142,7 +143,7 @@ namespace Neo4j.Driver.V1
         /// <returns>String representation of this Point.</returns>
         public override string ToString()
         {
-            return $"Duration{{months: {Months}, days: {Days}, seconds: {Seconds}, nanos: {Nanos}}}";
+            return TemporalHelpers.ToIsoDurationString(Months, Days, Seconds, Nanos);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDuration.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDuration.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.V1
     /// Represents temporal amount containing months, days, seconds and nanoseconds. 
     /// <remarks>A duration can hold a negative value.</remarks>
     /// </summary>
-    public struct CypherDuration : IValue, IEquatable<CypherDuration>, IComparable, IComparable<CypherDuration>
+    public struct CypherDuration : IValue, IEquatable<CypherDuration>, IComparable, IComparable<CypherDuration>, IConvertible
     {
 
         /// <summary>
@@ -225,5 +225,99 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to DateTime is not supported.");
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDuration.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherDuration.cs
@@ -17,6 +17,7 @@
 
 using System;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.V1
 {
@@ -24,7 +25,7 @@ namespace Neo4j.Driver.V1
     /// Represents temporal amount containing months, days, seconds and nanoseconds. 
     /// <remarks>A duration can hold a negative value.</remarks>
     /// </summary>
-    public struct CypherDuration : ICypherValue, IEquatable<CypherDuration>
+    public struct CypherDuration : IValue, IEquatable<CypherDuration>, IComparable, IComparable<CypherDuration>
     {
 
         /// <summary>
@@ -71,6 +72,9 @@ namespace Neo4j.Driver.V1
         /// <param name="nanos"><see cref="Nanos"/></param>
         public CypherDuration(long months, long days, long seconds, int nanos)
         {
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanos, TemporalHelpers.MinNanosecond,
+                TemporalHelpers.MaxNanosecond, nameof(nanos));
+
             Months = months;
             Days = days;
             Seconds = seconds;
@@ -144,6 +148,82 @@ namespace Neo4j.Driver.V1
         public override string ToString()
         {
             return TemporalHelpers.ToIsoDurationString(Months, Days, Seconds, Nanos);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherDuration"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherDuration other)
+        {
+            var thisNanos = this.ToNanos();
+            var otherNanos = other.ToNanos();
+            return thisNanos.CompareTo(otherNanos);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherDuration"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherDuration"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherDuration)) throw new ArgumentException($"Object must be of type {nameof(CypherDuration)}");
+            return CompareTo((CypherDuration) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDuration"/> is less than another specified 
+        /// <see cref="CypherDuration"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherDuration left, CypherDuration right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDuration"/> is more than another specified 
+        /// <see cref="CypherDuration"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherDuration left, CypherDuration right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDuration"/> represents a duration that is the 
+        /// same as or more than the other specified <see cref="CypherDuration"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherDuration left, CypherDuration right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherDuration"/> represents a duration that is the 
+        /// same as or less than the other specified <see cref="CypherDuration"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherDuration left, CypherDuration right)
+        {
+            return left.CompareTo(right) >= 0;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherPoint.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherPoint.cs
@@ -16,13 +16,14 @@
 // limitations under the License.
 
 using System;
+using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.V1
 {
     /// <summary>
     /// Represents a single three-dimensional point in a particular coordinate reference system.
     /// </summary>
-    public struct CypherPoint: ICypherValue, IEquatable<CypherPoint>
+    public struct CypherPoint: IValue, IEquatable<CypherPoint>
     {
         internal const int TwoD = 2;
         internal const int ThreeD = 3;

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
@@ -101,14 +101,17 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="TimeSpan"/> copy of this time value.
         /// </summary>
-        /// <returns>Equivalent <see cref="TimeSpan"/> value</returns>
+        /// <value>Equivalent <see cref="TimeSpan"/> value</value>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public TimeSpan ToTimeSpan()
+        public TimeSpan Time
         {
-            TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
+            get
+            {
+                TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
 
-            return new TimeSpan(0, Hour, Minute, Second).Add(
-                TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));
+                return new TimeSpan(0, Hour, Minute, Second).Add(
+                    TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));
+            }
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a local time value
     /// </summary>
-    public struct CypherTime : ICypherValue, IEquatable<CypherTime>, IHasTimeComponents
+    public struct CypherTime : IValue, IEquatable<CypherTime>, IComparable, IComparable<CypherTime>, IHasTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherTime"/> from time components of given <see cref="DateTime"/>
@@ -163,5 +163,84 @@ namespace Neo4j.Driver.V1
             return TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond);
         }
 
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherTime"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherTime other)
+        {
+            var hourComparison = Hour.CompareTo(other.Hour);
+            if (hourComparison != 0) return hourComparison;
+            var minuteComparison = Minute.CompareTo(other.Minute);
+            if (minuteComparison != 0) return minuteComparison;
+            var secondComparison = Second.CompareTo(other.Second);
+            if (secondComparison != 0) return secondComparison;
+            return Nanosecond.CompareTo(other.Nanosecond);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherTime"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherTime"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherTime)) throw new ArgumentException($"Object must be of type {nameof(CypherTime)}");
+            return CompareTo((CypherTime) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTime"/> is earlier than another specified 
+        /// <see cref="CypherTime"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherTime left, CypherTime right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTime"/> is later than another specified 
+        /// <see cref="CypherTime"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherTime left, CypherTime right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTime"/> represents a duration that is the 
+        /// same as or later than the other specified <see cref="CypherTime"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherTime left, CypherTime right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTime"/> represents a duration that is the 
+        /// same as or earlier than the other specified <see cref="CypherTime"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherTime left, CypherTime right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
@@ -105,7 +105,7 @@ namespace Neo4j.Driver.V1
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public TimeSpan ToTimeSpan()
         {
-            TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(TimeSpan));
+            TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
 
             return new TimeSpan(0, Hour, Minute, Second).Add(
                 TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a local time value
     /// </summary>
-    public struct CypherTime : IValue, IEquatable<CypherTime>, IComparable, IComparable<CypherTime>, IHasTimeComponents
+    public struct CypherTime : IValue, IEquatable<CypherTime>, IComparable, IComparable<CypherTime>, IConvertible, IHasTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherTime"/> from time components of given <see cref="DateTime"/>
@@ -242,5 +242,109 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            return DateTime.Today.Add(Time);
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(TimeSpan))
+            {
+                return Time;
+            }
+
+            if (conversionType == typeof(DateTime))
+            {
+                return DateTime.Today.Add(Time);
+            }
+
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTime.cs
@@ -17,14 +17,35 @@
 
 using System;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.V1
 {
     /// <summary>
     /// Represents a local time value
     /// </summary>
-    public struct CypherTime : ICypherValue, IEquatable<CypherTime>
+    public struct CypherTime : ICypherValue, IEquatable<CypherTime>, IHasTimeComponents
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="CypherTime"/> from time components of given <see cref="DateTime"/>
+        /// </summary>
+        /// <param name="time"></param>
+        public CypherTime(DateTime time)
+            : this(time.TimeOfDay)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CypherTime"/> from given <see cref="TimeSpan"/> value
+        /// </summary>
+        /// <param name="time"></param>
+        public CypherTime(TimeSpan time)
+            : this(time.Hours, time.Minutes, time.Seconds, TemporalHelpers.ExtractNanosecondFromTicks(time.Ticks))
+        {
+
+        }
+
         /// <summary>
         /// Initializes a new instance of <see cref="CypherTime"/> from individual time components
         /// </summary>
@@ -43,51 +64,51 @@ namespace Neo4j.Driver.V1
         /// <param name="hour"></param>
         /// <param name="minute"></param>
         /// <param name="second"></param>
-        /// <param name="nanoOfSecond"></param>
-        public CypherTime(int hour, int minute, int second, int nanoOfSecond)
-            : this(TemporalHelpers.NanosOf(hour, minute, second, nanoOfSecond))
+        /// <param name="nanosecond"></param>
+        public CypherTime(int hour, int minute, int second, int nanosecond)
         {
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(hour, TemporalHelpers.MinHour, TemporalHelpers.MaxHour, nameof(hour));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(minute, TemporalHelpers.MinMinute, TemporalHelpers.MaxMinute, nameof(minute));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(second, TemporalHelpers.MinSecond, TemporalHelpers.MaxSecond, nameof(second));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanosecond, TemporalHelpers.MinNanosecond, TemporalHelpers.MaxNanosecond, nameof(nanosecond));
 
+            Hour = hour;
+            Minute = minute;
+            Second = second;
+            Nanosecond = nanosecond;
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CypherTime"/> from given <see cref="TimeSpan"/> value
+        /// Gets the hour component of this instance.
         /// </summary>
-        /// <param name="time"></param>
-        public CypherTime(TimeSpan time)
-            : this(time.NanosOf())
-        {
-
-        }
+        public int Hour { get; }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CypherTime"/> from time components of given <see cref="DateTime"/>
+        /// Gets the minute component of this instance.
         /// </summary>
-        /// <param name="time"></param>
-        public CypherTime(DateTime time)
-            : this(time.TimeOfDay)
-        {
-
-        }
-
-        internal CypherTime(long nanosecondsOfDay)
-        {
-            NanosecondsOfDay = nanosecondsOfDay;
-        }
+        public int Minute { get; }
 
         /// <summary>
-        /// Nanoseconds since midnight
+        /// Gets the second component of this instance.
         /// </summary>
-        public long NanosecondsOfDay { get; }
+        public int Second { get; }
+
+        /// <summary>
+        /// Gets the nanosecond component of this instance.
+        /// </summary>
+        public int Nanosecond { get; }
 
         /// <summary>
         /// Gets a <see cref="TimeSpan"/> copy of this time value.
         /// </summary>
         /// <returns>Equivalent <see cref="TimeSpan"/> value</returns>
-        /// <exception cref="TruncationException">If a truncation occurs during conversion</exception>
+        /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public TimeSpan ToTimeSpan()
         {
-            return TemporalHelpers.TimeOf(NanosecondsOfDay, true);
+            TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(TimeSpan));
+
+            return new TimeSpan(0, Hour, Minute, Second).Add(
+                TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));
         }
 
         /// <summary>
@@ -99,7 +120,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(CypherTime other)
         {
-            return NanosecondsOfDay == other.NanosecondsOfDay;
+            return Hour == other.Hour && Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond;
         }
 
         /// <summary>
@@ -111,7 +132,7 @@ namespace Neo4j.Driver.V1
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
-            return obj is CypherTime && Equals((CypherTime)obj);
+            return obj is CypherTime && Equals((CypherTime) obj);
         }
 
         /// <summary>
@@ -120,7 +141,14 @@ namespace Neo4j.Driver.V1
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return NanosecondsOfDay.GetHashCode();
+            unchecked
+            {
+                var hashCode = Hour;
+                hashCode = (hashCode * 397) ^ Minute;
+                hashCode = (hashCode * 397) ^ Second;
+                hashCode = (hashCode * 397) ^ Nanosecond;
+                return hashCode;
+            }
         }
 
         /// <summary>
@@ -129,7 +157,7 @@ namespace Neo4j.Driver.V1
         /// <returns>String representation of this Point.</returns>
         public override string ToString()
         {
-            return $"Time{{nanosOfDay: {NanosecondsOfDay}}}";
+            return TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond);
         }
 
     }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
@@ -24,7 +24,8 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a time value with a UTC offset
     /// </summary>
-    public struct CypherTimeWithOffset : IValue, IEquatable<CypherTimeWithOffset>, IComparable, IComparable<CypherTimeWithOffset>, IHasTimeComponents
+    public struct CypherTimeWithOffset : IValue, IEquatable<CypherTimeWithOffset>, IComparable,
+        IComparable<CypherTimeWithOffset>, IConvertible, IHasTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherTimeWithOffset"/> from time components of given <see cref="DateTime"/> value
@@ -32,7 +33,7 @@ namespace Neo4j.Driver.V1
         /// <param name="time"></param>
         /// <param name="offset"></param>
         public CypherTimeWithOffset(DateTime time, TimeSpan offset)
-            : this(time.TimeOfDay, (int)offset.TotalSeconds)
+            : this(time.TimeOfDay, (int) offset.TotalSeconds)
         {
 
         }
@@ -54,7 +55,8 @@ namespace Neo4j.Driver.V1
         /// <param name="time"></param>
         /// <param name="offsetSeconds"></param>
         private CypherTimeWithOffset(TimeSpan time, int offsetSeconds)
-            : this(time.Hours, time.Minutes, time.Seconds, TemporalHelpers.ExtractNanosecondFromTicks(time.Ticks), offsetSeconds)
+            : this(time.Hours, time.Minutes, time.Seconds, TemporalHelpers.ExtractNanosecondFromTicks(time.Ticks),
+                offsetSeconds)
         {
 
         }
@@ -82,11 +84,16 @@ namespace Neo4j.Driver.V1
         /// <param name="offsetSeconds"></param>
         public CypherTimeWithOffset(int hour, int minute, int second, int nanosecond, int offsetSeconds)
         {
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(hour, TemporalHelpers.MinHour, TemporalHelpers.MaxHour, nameof(hour));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(minute, TemporalHelpers.MinMinute, TemporalHelpers.MaxMinute, nameof(minute));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(second, TemporalHelpers.MinSecond, TemporalHelpers.MaxSecond, nameof(second));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanosecond, TemporalHelpers.MinNanosecond, TemporalHelpers.MaxNanosecond, nameof(nanosecond));
-            Throw.ArgumentOutOfRangeException.IfValueNotBetween(offsetSeconds, TemporalHelpers.MinOffset, TemporalHelpers.MaxOffset, nameof(offsetSeconds));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(hour, TemporalHelpers.MinHour, TemporalHelpers.MaxHour,
+                nameof(hour));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(minute, TemporalHelpers.MinMinute,
+                TemporalHelpers.MaxMinute, nameof(minute));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(second, TemporalHelpers.MinSecond,
+                TemporalHelpers.MaxSecond, nameof(second));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(nanosecond, TemporalHelpers.MinNanosecond,
+                TemporalHelpers.MaxNanosecond, nameof(nanosecond));
+            Throw.ArgumentOutOfRangeException.IfValueNotBetween(offsetSeconds, TemporalHelpers.MinOffset,
+                TemporalHelpers.MaxOffset, nameof(offsetSeconds));
 
             Hour = hour;
             Minute = minute;
@@ -155,7 +162,8 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(CypherTimeWithOffset other)
         {
-            return Hour == other.Hour && Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond && OffsetSeconds == other.OffsetSeconds;
+            return Hour == other.Hour && Minute == other.Minute && Second == other.Second &&
+                   Nanosecond == other.Nanosecond && OffsetSeconds == other.OffsetSeconds;
         }
 
         /// <summary>
@@ -186,7 +194,7 @@ namespace Neo4j.Driver.V1
                 return hashCode;
             }
         }
-        
+
         /// <summary>
         /// Converts the value of the current <see cref="CypherTimeWithOffset"/> object to its equivalent string representation.
         /// </summary>
@@ -232,7 +240,8 @@ namespace Neo4j.Driver.V1
         public int CompareTo(object obj)
         {
             if (ReferenceEquals(null, obj)) return 1;
-            if (!(obj is CypherTimeWithOffset)) throw new ArgumentException($"Object must be of type {nameof(CypherTimeWithOffset)}");
+            if (!(obj is CypherTimeWithOffset))
+                throw new ArgumentException($"Object must be of type {nameof(CypherTimeWithOffset)}");
             return CompareTo((CypherTimeWithOffset) obj);
         }
 
@@ -283,5 +292,99 @@ namespace Neo4j.Driver.V1
         {
             return left.CompareTo(right) >= 0;
         }
+
+        #region IConvertible Implementation
+
+        TypeCode IConvertible.GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to boolean is not supported.");
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to char is not supported.");
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to sbyte is not supported.");
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to byte is not supported.");
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to short is not supported.");
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned short is not supported.");
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to int is not supported.");
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned int is not supported.");
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to long is not supported.");
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to unsigned long is not supported.");
+        }
+
+        float IConvertible.ToSingle(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to single is not supported.");
+        }
+
+        double IConvertible.ToDouble(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to double is not supported.");
+        }
+
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to decimal is not supported.");
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            throw new InvalidCastException($"Conversion of {GetType().Name} to DateTime is not supported.");
+        }
+
+        string IConvertible.ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(string))
+            {
+                return ToString();
+            }
+
+            throw new InvalidCastException($"Conversion of {GetType().Name} to {conversionType.Name} is not supported.");
+        }
+
+        #endregion
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
@@ -129,6 +129,7 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="TimeSpan"/> value that represents the time of this instance.
         /// </summary>
+        /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
         public TimeSpan Time
         {
             get

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
@@ -133,7 +133,7 @@ namespace Neo4j.Driver.V1
         {
             get
             {
-                TemporalHelpers.AssertNoTruncation(Nanosecond, nameof(TimeSpan));
+                TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
 
                 return new TimeSpan(0, Hour, Minute, Second).Add(
                     TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/CypherTimeWithOffset.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a time value with a UTC offset
     /// </summary>
-    public struct CypherTimeWithOffset : ICypherValue, IEquatable<CypherTimeWithOffset>, IHasTimeComponents
+    public struct CypherTimeWithOffset : IValue, IEquatable<CypherTimeWithOffset>, IComparable, IComparable<CypherTimeWithOffset>, IHasTimeComponents
     {
         /// <summary>
         /// Initializes a new instance of <see cref="CypherTimeWithOffset"/> from time components of given <see cref="DateTime"/> value
@@ -195,6 +195,93 @@ namespace Neo4j.Driver.V1
         {
             return TemporalHelpers.ToIsoTimeString(Hour, Minute, Second, Nanosecond) +
                    TemporalHelpers.ToIsoTimeZoneOffset(OffsetSeconds);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified <see cref="CypherTimeWithOffset"/> value and returns an integer 
+        /// that indicates whether this instance is earlier than, the same as, or later than the specified 
+        /// DateTime value.
+        /// </summary>
+        /// <param name="other">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(CypherTimeWithOffset other)
+        {
+            var thisNanoOfDay = this.ToNanoOfDay() - (OffsetSeconds * TemporalHelpers.NanosPerSecond);
+            var otherNanoOfDay = other.ToNanoOfDay() - (other.OffsetSeconds * TemporalHelpers.NanosPerSecond);
+
+            if (thisNanoOfDay < 0)
+            {
+                thisNanoOfDay = TemporalHelpers.NanosPerDay + thisNanoOfDay;
+            }
+
+            if (otherNanoOfDay < 0)
+            {
+                otherNanoOfDay = TemporalHelpers.NanosPerDay + otherNanoOfDay;
+            }
+
+            return thisNanoOfDay.CompareTo(otherNanoOfDay);
+        }
+
+        /// <summary>
+        /// Compares the value of this instance to a specified object which is expected to be a <see cref="CypherTimeWithOffset"/>
+        /// value, and returns an integer that indicates whether this instance is earlier than, the same as, 
+        /// or later than the specified <see cref="CypherTimeWithOffset"/> value.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current instance.</param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return 1;
+            if (!(obj is CypherTimeWithOffset)) throw new ArgumentException($"Object must be of type {nameof(CypherTimeWithOffset)}");
+            return CompareTo((CypherTimeWithOffset) obj);
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTimeWithOffset"/> is earlier than another specified 
+        /// <see cref="CypherTimeWithOffset"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <(CypherTimeWithOffset left, CypherTimeWithOffset right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTimeWithOffset"/> is later than another specified 
+        /// <see cref="CypherTimeWithOffset"/>.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >(CypherTimeWithOffset left, CypherTimeWithOffset right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTimeWithOffset"/> represents a duration that is the 
+        /// same as or later than the other specified <see cref="CypherTimeWithOffset"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator <=(CypherTimeWithOffset left, CypherTimeWithOffset right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified <see cref="CypherTimeWithOffset"/> represents a duration that is the 
+        /// same as or earlier than the other specified <see cref="CypherTimeWithOffset"/> 
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns></returns>
+        public static bool operator >=(CypherTimeWithOffset left, CypherTimeWithOffset right)
+        {
+            return left.CompareTo(right) >= 0;
         }
     }
 }


### PR DESCRIPTION
This PR adds IConvertible implementations to each of the temporal types. Valid conversions are implemented using conversion properties on the actual types, and invalid conversions throw `InvalidCastException`.

Based on #287.