### PR TITLE
Update and Test IConvertible implementations

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
@@ -346,19 +346,7 @@ namespace Neo4j.Driver.Tests.Types
 
             comp.Should().BeLessThan(0);
         }
-
-        [Fact]
-        public void ShouldBeConvertableToDateTime()
-        {
-            var date = new DateTime(1947, 12, 16, 12, 15, 59, 660);
-            var date1 = new ZonedDateTime(date, 3600);
-            var date2 = Convert.ToDateTime(date1);
-            var date3 = Convert.ChangeType(date1, typeof(DateTime));
-
-            date2.Should().Be(date);
-            date3.Should().Be(date);
-        }
-
+        
         [Fact]
         public void ShouldBeConvertableToDateTimeOffset()
         {
@@ -387,6 +375,7 @@ namespace Neo4j.Driver.Tests.Types
             var conversions = new Action[]
             {
                 () => Convert.ToBoolean(date),
+                () => Convert.ToDateTime(date),
                 () => Convert.ToByte(date),
                 () => Convert.ToChar(date),
                 () => Convert.ToDecimal(date),

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -319,18 +319,6 @@ namespace Neo4j.Driver.Tests.Types
         }
 
         [Fact]
-        public void ShouldBeConvertableToDateTime()
-        {
-            var date = new DateTime(1947, 12, 16, 12, 15, 59, 660);
-            var date1 = new ZonedDateTime(date, "Europe/Rome");
-            var date2 = Convert.ToDateTime(date1);
-            var date3 = Convert.ChangeType(date1, typeof(DateTime));
-
-            date2.Should().Be(date);
-            date3.Should().Be(date);
-        }
-
-        [Fact]
         public void ShouldBeConvertableToDateTimeOffset()
         {
             var date = new DateTime(1947, 12, 16, 12, 15, 59, 660);
@@ -358,6 +346,7 @@ namespace Neo4j.Driver.Tests.Types
             var conversions = new Action[]
             {
                 () => Convert.ToBoolean(date),
+                () => Convert.ToDateTime(date),
                 () => Convert.ToByte(date),
                 () => Convert.ToChar(date),
                 () => Convert.ToDecimal(date),

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
@@ -198,7 +198,7 @@ namespace Neo4j.Driver.Tests
                 object value = 10;
                 var ex = Record.Exception(() => value.ValueAs<List<int>>());
                 ex.Should().BeOfType<InvalidCastException>();
-                ex.Message.Should().Be("Unable to cast object of type `System.Int32` to type `System.Collections.Generic.List`1[System.Int32]`.");
+                ex.Message.Should().StartWith("Invalid cast from 'System.Int32' to 'System.Collections.Generic.List`1[[System.Int32");
             }
             [Fact]
             public void ShouldThrowExceptionWhenCastFromListToInt()

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -220,12 +220,29 @@ namespace Neo4j.Driver.Internal
             }
         }
 
+        public static void AssertNoOverflow(TimeSpan offset, string target)
+        {
+            if (Math.Abs(offset.TotalHours) > 14)
+            {
+                throw new ValueOverflowException($"{target} expects Offset values to be in range [-14, 14] hours.");
+            }
+        }
+
         public static void AssertNoTruncation(IHasTimeComponents time, string target)
         {
             if (time.Nanosecond % NanosecondsPerTick > 0)
             {
                 throw new ValueTruncationException(
-                    $"Conversion of this instance into {target} will cause a truncation of {time.Nanosecond % TemporalHelpers.NanosecondsPerTick}ns.");
+                    $"Conversion of this instance ({time}) into {target} will cause a truncation of {time.Nanosecond % TemporalHelpers.NanosecondsPerTick}ns.");
+            }
+        }
+
+        public static void AssertNoTruncation(TimeSpan offset, string target)
+        {
+            if (offset.Ticks % TimeSpan.TicksPerMinute != 0)
+            {
+                throw new ValueTruncationException(
+                    $"{target} expects Offset values to be in minutes precision. Use of this instance ({offset}) as an offset will cause a truncation of {offset.Ticks % TimeSpan.TicksPerMinute}ns.");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
@@ -226,11 +226,5 @@ namespace Neo4j.Driver.V1
         {
             return DateTime;
         }
-
-        /// <inheritdoc cref="TemporalValue.ToDateTimeOffset"/>
-        protected override DateTimeOffset ToDateTimeOffset()
-        {
-            return new DateTimeOffset(DateTime);
-        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
@@ -299,11 +299,5 @@ namespace Neo4j.Driver.V1
         {
             return DateTime;
         }
-
-        /// <inheritdoc cref="TemporalValue.ToDateTimeOffset"/>
-        protected override DateTimeOffset ToDateTimeOffset()
-        {
-            return new DateTimeOffset(DateTime);
-        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
@@ -353,12 +353,6 @@ namespace Neo4j.Driver.V1
             return left.CompareTo(right) >= 0;
         }
 
-        /// <inheritdoc cref="TemporalValue.ToDateTime"/>
-        protected override DateTime ToDateTime()
-        {
-            return DateTimeOffset.DateTime;
-        }
-
         /// <inheritdoc cref="TemporalValue.ToDateTimeOffset"/>
         protected override DateTimeOffset ToDateTimeOffset()
         {

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
@@ -211,8 +211,20 @@ namespace Neo4j.Driver.V1
         /// Converts this instance to an equivalent <see cref="DateTimeOffset"/> value
         /// </summary>
         /// <returns>Equivalent <see cref="DateTimeOffset"/> value</returns>
+        /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTimeOffset</exception>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTimeOffset DateTimeOffset => new DateTimeOffset(DateTime, Offset);
+        public DateTimeOffset DateTimeOffset
+        {
+            get
+            {
+                var offset = Offset;
+
+                TemporalHelpers.AssertNoTruncation(offset, nameof(DateTimeOffset));
+                TemporalHelpers.AssertNoOverflow(offset, nameof(DateTimeOffset));
+
+                return new DateTimeOffset(DateTime, offset);
+            }
+        }
 
         /// <summary>
         /// Returns a value indicating whether the value of this instance is equal to the 


### PR DESCRIPTION
Removed some conversions to make the things more consistent across data types, added integration tests against usage of `System.DateTime`, `System.DateTimeOffset` and `System.TimeSpan` and couple of reflection improvements in `ValueExtensions` helpers.

Here is the latest conversions supported;

| Cypher Type | Driver Type | C# type |
| ----------: | ----------- | ------- |
| Date | LocalDate | DateTime |
| Time | OffsetTime | --- |
| LocalTime | LocalTime | TimeSpan, DateTime |
| DateTime | ZonedDateTime | DateTimeOffset |
| LocalDateTime | LocalDateTime | DateTime |
| Duration | Duration | --- |

_All types are by default convertible to `string` which returns ISO 8601 string representation of temporal types._