### PR TITLE
Make version configurable

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -19,8 +19,10 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
+    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+    <AssemblyFileVersion>1.6.0.0</AssemblyFileVersion>
+    <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
     <Version>0.0.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.3|AnyCPU'">

--- a/Neo4j.Driver/Neo4j.Driver/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Properties/AssemblyInfo.cs
@@ -32,16 +32,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.6.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
 [assembly: InternalsVisibleTo("Neo4j.Driver.Tests"), InternalsVisibleTo("Neo4j.Driver.IntegrationTests"), InternalsVisibleTo("Neo4j.Driver.Tck.Tests"), InternalsVisibleTo("DynamicProxyGenAssembly2"), InternalsVisibleTo("Neo4j.Driver.Benchmark.NBench.Akka"), InternalsVisibleTo("Neo4j.Driver.Simple.Test")]


### PR DESCRIPTION
This PR makes `AssemblyVersion` and `AssemblyFileVersion` properties to be part of the `csproj` and be specified as part of the build process to gain better control.