### PR TITLE
Unflake ShouldThrowExceptionIfConnectionTimedOut

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
@@ -104,19 +104,19 @@ namespace Neo4j.Driver.Tests.Connector
             {
                 using (var tcpServer = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    tcpServer.Bind(new IPEndPoint(IPAddress.Loopback, 9999));
+                    tcpServer.Bind(new IPEndPoint(IPAddress.Loopback, 9998));
 
                     var client = new TcpSocketClient(new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(0)});
 
                     var exception = await Record.ExceptionAsync(
-                        () => client.ConnectAsync(new Uri("bolt://127.0.0.1:9999")));
+                        () => client.ConnectAsync(new Uri("bolt://127.0.0.1:9998")));
                     exception.Should().BeOfType<IOException>();
                     exception.Message.Should().Be(
-                        "Failed to connect to server 'bolt://127.0.0.1:9999/' via IP addresses'[127.0.0.1]' at port '9999'.");
+                        "Failed to connect to server 'bolt://127.0.0.1:9998/' via IP addresses'[127.0.0.1]' at port '9998'.");
 
                     var baseException = exception.GetBaseException();
                     baseException.Should().BeOfType<OperationCanceledException>(exception.ToString());
-                    baseException.Message.Should().Be("Failed to connect to server 127.0.0.1:9999 within 0ms.");
+                    baseException.Message.Should().Be("Failed to connect to server 127.0.0.1:9998 within 0ms.");
                 }
             }
         }


### PR DESCRIPTION
This PR applies the previous fix we had done to `ConnectSocketAsyncMethod.ShouldThrowExceptionIfConnectionTimedOut` to `ConnectAsyncMethod.ShouldThrowExceptionIfConnectionTimedOut` (with the test name changed from `ShouldThrowIOExceptionIfConnTimedOut` to `ShouldThrowExceptionIfConnectionTimedOut`).

The fix basically created a listening socket on port `9999`, so that we guarantee our time out logic to kick in - otherwise sometimes OS is more quick to fail with `IOException`.