### PR TITLE
Change conversions to methods

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Types/TemporalTypesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Types/TemporalTypesIT.cs
@@ -680,7 +680,7 @@ namespace Neo4j.Driver.IntegrationTests.Types
                 _random.Next(TemporalHelpers.MinMinute, TemporalHelpers.MaxMinute),
                 _random.Next(TemporalHelpers.MinSecond, TemporalHelpers.MaxSecond),
                 (int)(_random.Next(TemporalHelpers.MinNanosecond, TemporalHelpers.MaxNanosecond) / 100) * 100
-            ).Time;
+            ).ToTimeSpan();
         }
 
         private OffsetTime RandomOffsetTime()

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTests.cs
@@ -30,7 +30,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDate = new LocalDate(1947, 12, 17);
 
-            cypherDate.DateTime.Should().Be(new DateTime(1947, 12, 17));
+            cypherDate.ToDateTime().Should().Be(new DateTime(1947, 12, 17));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tests.Types
             var date = new DateTime(1947, 12, 17);
             var cypherDate = new LocalDate(date);
 
-            cypherDate.DateTime.Should().Be(date);
+            cypherDate.ToDateTime().Should().Be(date);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnOverflow(int year)
         {
             var date = new LocalDate(year, 1, 1);
-            var ex = Record.Exception(() => date.DateTime);
+            var ex = Record.Exception(() => date.ToDateTime());
 
             ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTimeTests.cs
@@ -31,7 +31,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new LocalDateTime(1947, 12, 17, 23, 49, 54);
 
-            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
+            cypherDateTime.ToDateTime().Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new LocalDateTime(1947, 12, 17, 23, 49, 54, 192794500);
 
-            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
+            cypherDateTime.ToDateTime().Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120, DateTimeKind.Local);
             var cypherDateTime = new LocalDateTime(dateTime);
 
-            cypherDateTime.DateTime.Should().Be(dateTime);
+            cypherDateTime.ToDateTime().Should().Be(dateTime);
         }
 
         [Theory]
@@ -135,7 +135,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnOverflow(int year)
         {
             var dateTime = new LocalDateTime(year, 1, 1, 0, 0, 0, 0);
-            var ex = Record.Exception(() => dateTime.DateTime);
+            var ex = Record.Exception(() => dateTime.ToDateTime());
 
             ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
         }
@@ -150,7 +150,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnTruncation(int nanosecond)
         {
             var dateTime = new LocalDateTime(1, 1, 1, 0, 0, 0, nanosecond);
-            var ex = Record.Exception(() => dateTime.DateTime);
+            var ex = Record.Exception(() => dateTime.ToDateTime());
 
             ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalTimeTests.cs
@@ -30,7 +30,7 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherTime = new LocalTime(13, 15, 59);
 
-            cypherTime.Time.Should().Be(new TimeSpan(13, 15, 59));
+            cypherTime.ToTimeSpan().Should().Be(new TimeSpan(13, 15, 59));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Tests.Types
             var time = new TimeSpan(0, 13, 59, 59, 255);
             var cypherTime = new LocalTime(time);
 
-            cypherTime.Time.Should().Be(time);
+            cypherTime.ToTimeSpan().Should().Be(time);
         }
 
         [Theory]
@@ -94,7 +94,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnTruncation(int nanosecond)
         {
             var time = new LocalTime(0, 0, 0, nanosecond);
-            var ex = Record.Exception(() => time.Time);
+            var ex = Record.Exception(() => time.ToTimeSpan());
 
             ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/OffsetTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/OffsetTimeTests.cs
@@ -30,8 +30,11 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherTime = new OffsetTime(13, 15, 59, 1500);
 
-            cypherTime.Time.Should().Be(new TimeSpan(13, 15, 59));
-            cypherTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
+            cypherTime.Hour.Should().Be(13);
+            cypherTime.Minute.Should().Be(15);
+            cypherTime.Second.Should().Be(59);
+            cypherTime.Nanosecond.Should().Be(0);
+            cypherTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Fact]
@@ -40,8 +43,11 @@ namespace Neo4j.Driver.Tests.Types
             var time = new TimeSpan(0, 13, 59, 59, 255);
             var cypherTime = new OffsetTime(time, TimeSpan.FromSeconds(1500));
 
-            cypherTime.Time.Should().Be(time);
-            cypherTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
+            cypherTime.Hour.Should().Be(13);
+            cypherTime.Minute.Should().Be(59);
+            cypherTime.Second.Should().Be(59);
+            cypherTime.Nanosecond.Should().Be(255000000);
+            cypherTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Fact]
@@ -50,8 +56,11 @@ namespace Neo4j.Driver.Tests.Types
             var time = new DateTime(1, 1, 1, 13, 59, 59, 25);
             var cypherTime = new OffsetTime(time, TimeSpan.FromSeconds(1500));
 
-            cypherTime.Time.Should().Be(time.TimeOfDay);
-            cypherTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
+            cypherTime.Hour.Should().Be(13);
+            cypherTime.Minute.Should().Be(59);
+            cypherTime.Second.Should().Be(59);
+            cypherTime.Nanosecond.Should().Be(25000000);
+            cypherTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Theory]
@@ -104,21 +113,6 @@ namespace Neo4j.Driver.Tests.Types
             var ex = Record.Exception(() => new OffsetTime(0, 0, 0, 0, offset));
 
             ex.Should().NotBeNull().And.BeOfType<ArgumentOutOfRangeException>();
-        }
-
-        [Theory]
-        [InlineData(1)]
-        [InlineData(20)]
-        [InlineData(99)]
-        [InlineData(999000727)]
-        [InlineData(999000750)]
-        [InlineData(999000001)]
-        public void ShouldThrowOnTruncation(int nanosecond)
-        {
-            var time = new OffsetTime(0, 0, 0, nanosecond, 0);
-            var ex = Record.Exception(() => time.Time);
-
-            ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }
 
         [Theory]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
@@ -31,8 +31,13 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new ZonedDateTime(1947, 12, 17, 23, 49, 54, Zone.Of(1500));
 
-            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Fact]
@@ -40,8 +45,14 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new ZonedDateTime(1947, 12, 17, 23, 49, 54, 192794500, Zone.Of(1500));
 
-            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.Nanosecond.Should().Be(192794500);
+            cypherDateTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Fact]
@@ -50,8 +61,14 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120);
             var cypherDateTime = new ZonedDateTime(dateTime, TimeSpan.FromSeconds(1500));
 
-            cypherDateTime.DateTime.Should().Be(dateTime);
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromSeconds(1500));
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.Nanosecond.Should().Be(120000000);
+            cypherDateTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Fact]
@@ -60,8 +77,14 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime = new DateTimeOffset(1947, 12, 17, 23, 49, 54, 120, TimeSpan.FromSeconds(1500));
             var cypherDateTime = new ZonedDateTime(dateTime);
 
-            cypherDateTime.DateTime.Should().Be(dateTime.DateTime);
-            cypherDateTime.Offset.Should().Be(dateTime.Offset);
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.Nanosecond.Should().Be(120000000);
+            cypherDateTime.OffsetSeconds.Should().Be(1500);
         }
 
         [Theory]
@@ -155,7 +178,7 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime = new DateTimeOffset(1947, 12, 17, 23, 49, 54, 120, TimeSpan.FromSeconds(1500));
             var cypherDateTime = new ZonedDateTime(dateTime);
 
-            cypherDateTime.DateTimeOffset.Should().Be(dateTime);
+            cypherDateTime.ToDateTimeOffset().Should().Be(dateTime);
         }
 
         [Theory]
@@ -167,7 +190,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnOverflow(int year)
         {
             var dateTime = new ZonedDateTime(year, 1, 1, 0, 0, 0, 0, Zone.Of(0));
-            var ex = Record.Exception(() => dateTime.DateTime);
+            var ex = Record.Exception(() => dateTime.ToDateTimeOffset());
 
             ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
         }
@@ -182,7 +205,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnTruncation(int nanosecond)
         {
             var dateTime = new ZonedDateTime(1, 1, 1, 0, 0, 0, nanosecond, Zone.Of(0));
-            var ex = Record.Exception(() => dateTime.DateTime);
+            var ex = Record.Exception(() => dateTime.ToDateTimeOffset());
 
             ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -31,8 +31,14 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new ZonedDateTime(1947, 12, 17, 23, 49, 54, Zone.Of("Europe/Rome"));
 
-            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54));
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.Nanosecond.Should().Be(0);
+            cypherDateTime.OffsetSeconds.Should().Be(60 * 60);
             cypherDateTime.Zone.Should().Be(Zone.Of("Europe/Rome"));
         }
 
@@ -41,8 +47,14 @@ namespace Neo4j.Driver.Tests.Types
         {
             var cypherDateTime = new ZonedDateTime(1947, 12, 17, 23, 49, 54, 192794500, Zone.Of("Europe/Rome"));
 
-            cypherDateTime.DateTime.Should().Be(new DateTime(1947, 12, 17, 23, 49, 54).AddTicks(1927945));
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.Nanosecond.Should().Be(192794500);
+            cypherDateTime.OffsetSeconds.Should().Be(60 * 60);
             cypherDateTime.Zone.Should().Be(Zone.Of("Europe/Rome"));
         }
 
@@ -52,8 +64,14 @@ namespace Neo4j.Driver.Tests.Types
             var dateTime = new DateTime(1947, 12, 17, 23, 49, 54, 120);
             var cypherDateTime = new ZonedDateTime(dateTime, "Europe/Rome");
 
-            cypherDateTime.DateTime.Should().Be(dateTime);
-            cypherDateTime.Offset.Should().Be(TimeSpan.FromHours(1));
+            cypherDateTime.Year.Should().Be(1947);
+            cypherDateTime.Month.Should().Be(12);
+            cypherDateTime.Day.Should().Be(17);
+            cypherDateTime.Hour.Should().Be(23);
+            cypherDateTime.Minute.Should().Be(49);
+            cypherDateTime.Second.Should().Be(54);
+            cypherDateTime.Nanosecond.Should().Be(120000000);
+            cypherDateTime.OffsetSeconds.Should().Be(60 * 60);
             cypherDateTime.Zone.Should().Be(Zone.Of("Europe/Rome"));
         }
 
@@ -141,7 +159,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnOverflow(int year)
         {
             var dateTime = new ZonedDateTime(year, 1, 1, 0, 0, 0, 0, Zone.Of("Europe/London"));
-            var ex = Record.Exception(() => dateTime.DateTime);
+            var ex = Record.Exception(() => dateTime.ToDateTimeOffset());
 
             ex.Should().NotBeNull().And.BeOfType<ValueOverflowException>();
         }
@@ -156,7 +174,7 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowOnTruncation(int nanosecond)
         {
             var dateTime = new ZonedDateTime(1, 1, 1, 0, 0, 0, nanosecond, Zone.Of("Europe/London"));
-            var ex = Record.Exception(() => dateTime.DateTime);
+            var ex = Record.Exception(() => dateTime.ToDateTimeOffset());
 
             ex.Should().NotBeNull().And.BeOfType<ValueTruncationException>();
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/Duration.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/Duration.cs
@@ -114,7 +114,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(Duration other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Months == other.Months && Days == other.Days && Seconds == other.Seconds && Nanos == other.Nanos;
         }
@@ -127,7 +127,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is Duration && Equals((Duration) obj);
         }
@@ -167,7 +167,7 @@ namespace Neo4j.Driver.V1
         public int CompareTo(Duration other)
         {
             if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
+            if (other is null) return 1;
             var thisNanos = this.ToNanos();
             var otherNanos = other.ToNanos();
             return thisNanos.CompareTo(otherNanos);
@@ -182,7 +182,7 @@ namespace Neo4j.Driver.V1
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
+            if (obj is null) return 1;
             if (ReferenceEquals(this, obj)) return 0;
             if (!(obj is Duration)) throw new ArgumentException($"Object must be of type {nameof(Duration)}");
             return CompareTo((Duration) obj);

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/Duration.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/Duration.cs
@@ -129,7 +129,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is Duration && Equals((Duration) obj);
+            return obj is Duration duration && Equals(duration);
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
@@ -74,18 +74,15 @@ namespace Neo4j.Driver.V1
         public int Day { get; }
 
         /// <summary>
-        /// Gets a <see cref="DateTime"/> copy of this date value.
+        /// Converts this date value to a <see cref="DateTime"/> instance.
         /// </summary>
         /// <value>Equivalent <see cref="DateTime"/> value</value>
         /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
-        public DateTime DateTime
+        public DateTime ToDateTime()
         {
-            get
-            {
-                TemporalHelpers.AssertNoOverflow(this, nameof(System.DateTime));
+            TemporalHelpers.AssertNoOverflow(this, nameof(System.DateTime));
 
-                return new DateTime(Year, Month, Day);
-            }
+            return new DateTime(Year, Month, Day);
         }
 
         /// <summary>
@@ -220,10 +217,10 @@ namespace Neo4j.Driver.V1
             return left.CompareTo(right) >= 0;
         }
         
-        /// <inheritdoc cref="TemporalValue.ToDateTime"/>
-        protected override DateTime ToDateTime()
+        /// <inheritdoc cref="TemporalValue.ConvertToDateTime"/>
+        protected override DateTime ConvertToDateTime()
         {
-            return DateTime;
+            return ToDateTime();
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
@@ -109,7 +109,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is LocalDate && Equals((LocalDate) obj);
+            return obj is LocalDate date && Equals(date);
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDate.cs
@@ -94,7 +94,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(LocalDate other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Year == other.Year && Month == other.Month && Day == other.Day;
         }
@@ -107,7 +107,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is LocalDate && Equals((LocalDate) obj);
         }
@@ -146,7 +146,7 @@ namespace Neo4j.Driver.V1
         public int CompareTo(LocalDate other)
         {
             if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
+            if (other is null) return 1;
             var yearComparison = Year.CompareTo(other.Year);
             if (yearComparison != 0) return yearComparison;
             var monthComparison = Month.CompareTo(other.Month);
@@ -163,7 +163,7 @@ namespace Neo4j.Driver.V1
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
+            if (obj is null) return 1;
             if (ReferenceEquals(this, obj)) return 0;
             if (!(obj is LocalDate)) throw new ArgumentException($"Object must be of type {nameof(LocalDate)}");
             return CompareTo((LocalDate) obj);

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
@@ -131,21 +131,18 @@ namespace Neo4j.Driver.V1
         public int Nanosecond { get; }
 
         /// <summary>
-        /// Gets a <see cref="DateTime"/> copy of this date value.
+        /// Converts this date value to a <see cref="DateTime"/> instance.
         /// </summary>
         /// <value>Equivalent <see cref="DateTime"/> value</value>
         /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTime DateTime
+        public DateTime ToDateTime()
         {
-            get
-            {
-                TemporalHelpers.AssertNoTruncation(this, nameof(System.DateTime));
-                TemporalHelpers.AssertNoOverflow(this, nameof(System.DateTime));
+            TemporalHelpers.AssertNoTruncation(this, nameof(System.DateTime));
+            TemporalHelpers.AssertNoOverflow(this, nameof(System.DateTime));
 
-                return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
-                    TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));
-            }
+            return new DateTime(Year, Month, Day, Hour, Minute, Second).AddTicks(
+                TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond));
         }
 
         /// <summary>
@@ -293,10 +290,10 @@ namespace Neo4j.Driver.V1
             return left.CompareTo(right) >= 0;
         }
 
-        /// <inheritdoc cref="TemporalValue.ToDateTime"/>
-        protected override DateTime ToDateTime()
+        /// <inheritdoc cref="TemporalValue.ConvertToDateTime"/>
+        protected override DateTime ConvertToDateTime()
         {
-            return DateTime;
+            return ToDateTime();
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
@@ -154,7 +154,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(LocalDateTime other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Year == other.Year && Month == other.Month && Day == other.Day && Hour == other.Hour && Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond;
         }
@@ -167,7 +167,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is LocalDateTime && Equals((LocalDateTime) obj);
         }
@@ -211,7 +211,7 @@ namespace Neo4j.Driver.V1
         public int CompareTo(LocalDateTime other)
         {
             if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
+            if (other is null) return 1;
             var yearComparison = Year.CompareTo(other.Year);
             if (yearComparison != 0) return yearComparison;
             var monthComparison = Month.CompareTo(other.Month);
@@ -236,7 +236,7 @@ namespace Neo4j.Driver.V1
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
+            if (obj is null) return 1;
             if (ReferenceEquals(this, obj)) return 0;
             if (!(obj is LocalDateTime)) throw new ArgumentException($"Object must be of type {nameof(LocalDateTime)}");
             return CompareTo((LocalDateTime) obj);

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalDateTime.cs
@@ -33,14 +33,11 @@ namespace Neo4j.Driver.V1
 
         /// <summary>
         /// Initializes a new instance of <see cref="LocalDateTime"/> from given <see cref="System.DateTime"/> value.
-        /// The given <see cref="System.DateTime"/> value will be normalized to local time <see cref="DateTimeKind.Local"/>
-        /// before being used.
         /// </summary>
         ///
-        /// <remarks>If the <see cref="System.DateTime"/> value was created with no <see cref="DateTimeKind"/> specified,
-        /// then <see cref="DateTimeKind.Unspecified"/> would be assigned by default.
-        /// Possible conversion from UTC to local time might happen when normalizing it to local time.
-        /// <seealso cref="System.DateTime.ToLocalTime"/>
+        /// <remarks>
+        /// The value of <see cref="DateTime.Kind"/> has no effect. Date and time component values will be used without any
+        /// explicit conversions (i.e. we treat <see cref="DateTime.Kind"/> as if <see cref="DateTimeKind.Local"/>).
         /// </remarks>
         /// <param name="dateTime"></param>
         public LocalDateTime(DateTime dateTime)
@@ -169,7 +166,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is LocalDateTime && Equals((LocalDateTime) obj);
+            return obj is LocalDateTime time && Equals(time);
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalTime.cs
@@ -140,7 +140,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is LocalTime && Equals((LocalTime) obj);
+            return obj is LocalTime time && Equals(time);
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalTime.cs
@@ -125,7 +125,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(LocalTime other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Hour == other.Hour && Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond;
         }
@@ -138,7 +138,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is LocalTime && Equals((LocalTime) obj);
         }
@@ -178,7 +178,7 @@ namespace Neo4j.Driver.V1
         public int CompareTo(LocalTime other)
         {
             if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
+            if (other is null) return 1;
             var hourComparison = Hour.CompareTo(other.Hour);
             if (hourComparison != 0) return hourComparison;
             var minuteComparison = Minute.CompareTo(other.Minute);
@@ -197,7 +197,7 @@ namespace Neo4j.Driver.V1
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
+            if (obj is null) return 1;
             if (ReferenceEquals(this, obj)) return 0;
             if (!(obj is LocalTime)) throw new ArgumentException($"Object must be of type {nameof(LocalTime)}");
             return CompareTo((LocalTime) obj);

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/LocalTime.cs
@@ -104,19 +104,16 @@ namespace Neo4j.Driver.V1
         public int Nanosecond { get; }
 
         /// <summary>
-        /// Gets a <see cref="TimeSpan"/> copy of this time value.
+        /// Converts this time value to a <see cref="TimeSpan"/> instance.
         /// </summary>
         /// <value>Equivalent <see cref="TimeSpan"/> value</value>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public TimeSpan Time
+        public TimeSpan ToTimeSpan()
         {
-            get
-            {
-                TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
+            TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
 
-                return new TimeSpan(0, Hour, Minute, Second).Add(
-                    TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));
-            }
+            return new TimeSpan(0, Hour, Minute, Second).Add(
+                TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));
         }
 
         /// <summary>
@@ -254,16 +251,16 @@ namespace Neo4j.Driver.V1
             return left.CompareTo(right) >= 0;
         }
 
-        /// <inheritdoc cref="TemporalValue.ToDateTime"/>
-        protected override DateTime ToDateTime()
+        /// <inheritdoc cref="TemporalValue.ConvertToDateTime"/>
+        protected override DateTime ConvertToDateTime()
         {
-            return DateTime.Today.Add(Time);
+            return DateTime.Today.Add(ToTimeSpan());
         }
 
-        /// <inheritdoc cref="TemporalValue.ToTimeSpan"/>
-        protected override TimeSpan ToTimeSpan()
+        /// <inheritdoc cref="TemporalValue.ConvertToTimeSpan"/>
+        protected override TimeSpan ConvertToTimeSpan()
         {
-            return Time;
+            return ToTimeSpan();
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/OffsetTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/OffsetTime.cs
@@ -138,26 +138,6 @@ namespace Neo4j.Driver.V1
         public int OffsetSeconds { get; }
 
         /// <summary>
-        /// Gets a <see cref="TimeSpan"/> value that represents the time of this instance.
-        /// </summary>
-        /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public TimeSpan Time
-        {
-            get
-            {
-                TemporalHelpers.AssertNoTruncation(this, nameof(TimeSpan));
-
-                return new TimeSpan(0, Hour, Minute, Second).Add(
-                    TimeSpan.FromTicks(TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond)));
-            }
-        }
-
-        /// <summary>
-        /// Gets a <see cref="TimeSpan"/> value that represents the offset of this instance.
-        /// </summary>
-        public TimeSpan Offset => TimeSpan.FromSeconds(OffsetSeconds);
-
-        /// <summary>
         /// Returns a value indicating whether the value of this instance is equal to the 
         /// value of the specified <see cref="OffsetTime" /> instance. 
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/OffsetTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/OffsetTime.cs
@@ -161,7 +161,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is OffsetTime && Equals((OffsetTime) obj);
+            return obj is OffsetTime time && Equals(time);
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/OffsetTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/OffsetTime.cs
@@ -146,7 +146,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(OffsetTime other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Hour == other.Hour && Minute == other.Minute && Second == other.Second && Nanosecond == other.Nanosecond && OffsetSeconds == other.OffsetSeconds;
         }
@@ -159,7 +159,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is OffsetTime && Equals((OffsetTime) obj);
         }
@@ -201,7 +201,7 @@ namespace Neo4j.Driver.V1
         public int CompareTo(OffsetTime other)
         {
             if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
+            if (other is null) return 1;
 
             var thisNanoOfDay = this.ToNanoOfDay() - (OffsetSeconds * TemporalHelpers.NanosPerSecond);
             var otherNanoOfDay = other.ToNanoOfDay() - (other.OffsetSeconds * TemporalHelpers.NanosPerSecond);
@@ -228,7 +228,7 @@ namespace Neo4j.Driver.V1
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
+            if (obj is null) return 1;
             if (ReferenceEquals(this, obj)) return 0;
             if (!(obj is OffsetTime))
                 throw new ArgumentException($"Object must be of type {nameof(OffsetTime)}");

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/Point.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/Point.cs
@@ -134,7 +134,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is Point && Equals((Point) obj);
+            return obj is Point point && Equals(point);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/Point.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/Point.cs
@@ -119,7 +119,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(Point other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Dimension == other.Dimension && SrId == other.SrId && X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
         }
@@ -132,7 +132,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is Point && Equals((Point) obj);
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/TemporalValue.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/TemporalValue.cs
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.V1
         /// <exception cref="InvalidCastException">If conversion is not possible</exception>
         /// <exception cref="ValueTruncationException">If conversion results in a truncation under ms precision</exception>
         /// <exception cref="OverflowException">If the value falls beyond valid range of target type</exception>
-        protected virtual DateTime ToDateTime()
+        protected virtual DateTime ConvertToDateTime()
         {
             throw new InvalidCastException($"Conversion of {GetType().Name} to {nameof(DateTime)} is not supported.");
         }
@@ -44,7 +44,7 @@ namespace Neo4j.Driver.V1
         /// <exception cref="InvalidCastException">If conversion is not possible</exception>
         /// <exception cref="ValueTruncationException">If conversion results in a truncation under ms precision</exception>
         /// <exception cref="OverflowException">If the value falls beyond valid range of target type</exception>
-        protected virtual DateTimeOffset ToDateTimeOffset()
+        protected virtual DateTimeOffset ConvertToDateTimeOffset()
         {
             throw new InvalidCastException($"Conversion of {GetType().Name} to {nameof(DateTimeOffset)} is not supported.");
         }
@@ -56,7 +56,7 @@ namespace Neo4j.Driver.V1
         /// <exception cref="InvalidCastException">If conversion is not possible</exception>
         /// <exception cref="ValueTruncationException">If conversion results in a truncation under ms precision</exception>
         /// <exception cref="OverflowException">If the value falls beyond valid range of target type</exception>
-        protected virtual TimeSpan ToTimeSpan()
+        protected virtual TimeSpan ConvertToTimeSpan()
         {
             throw new InvalidCastException($"Conversion of {GetType().Name} to {nameof(TimeSpan)} is not supported.");
         }
@@ -133,7 +133,7 @@ namespace Neo4j.Driver.V1
 
         DateTime IConvertible.ToDateTime(IFormatProvider provider)
         {
-            return ToDateTime();
+            return ConvertToDateTime();
         }
 
         string IConvertible.ToString(IFormatProvider provider)
@@ -145,17 +145,17 @@ namespace Neo4j.Driver.V1
         {
             if (conversionType == typeof(DateTime))
             {
-                return ToDateTime();
+                return ConvertToDateTime();
             }
 
             if (conversionType == typeof(DateTimeOffset))
             {
-                return ToDateTimeOffset();
+                return ConvertToDateTimeOffset();
             }
 
             if (conversionType == typeof(TimeSpan))
             {
-                return ToTimeSpan();
+                return ConvertToTimeSpan();
             }
 
             if (conversionType == typeof(string))

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/TemporalValue.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/TemporalValue.cs
@@ -172,8 +172,8 @@ namespace Neo4j.Driver.V1
             public int Compare(T x, T y)
             {
                 if (ReferenceEquals(x, y)) return 0;
-                if (ReferenceEquals(null, y)) return 1;
-                if (ReferenceEquals(null, x)) return -1;
+                if (y is null) return 1;
+                if (x is null) return -1;
                 return x.CompareTo(y);
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZoneId.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZoneId.cs
@@ -58,7 +58,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(ZoneId other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return string.Equals(Id, other.Id);
         }
@@ -71,7 +71,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is ZoneId id && Equals(id);
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZoneOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZoneOffset.cs
@@ -62,7 +62,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(ZoneOffset other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return OffsetSeconds == other.OffsetSeconds;
         }
@@ -75,7 +75,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj is ZoneOffset offset && Equals(offset);
         }

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.V1
     /// <summary>
     /// Represents a date time value with a time zone, specified as a UTC offset
     /// </summary>
-    public class ZonedDateTime : TemporalValue, IEquatable<ZonedDateTime>, IComparable, IComparable<ZonedDateTime>, IHasDateTimeComponents
+    public sealed class ZonedDateTime : TemporalValue, IEquatable<ZonedDateTime>, IComparable, IComparable<ZonedDateTime>, IHasDateTimeComponents
     {
         /// <summary>
         /// Default comparer for <see cref="ZonedDateTime"/> values.
@@ -248,8 +248,7 @@ namespace Neo4j.Driver.V1
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((ZonedDateTime) obj);
+            return obj is ZonedDateTime dateTime && Equals(dateTime);
         }
 
         /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
@@ -233,7 +233,7 @@ namespace Neo4j.Driver.V1
         /// this instance; otherwise, <code>false</code></returns>
         public bool Equals(ZonedDateTime other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Year == other.Year && Month == other.Month && Day == other.Day && Hour == other.Hour && Second == other.Second && Nanosecond == other.Nanosecond && Equals(Zone, other.Zone);
         }
@@ -246,7 +246,7 @@ namespace Neo4j.Driver.V1
         /// equals the value of this instance; otherwise, <code>false</code></returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
             return Equals((ZonedDateTime) obj);
@@ -291,7 +291,7 @@ namespace Neo4j.Driver.V1
         public int CompareTo(ZonedDateTime other)
         {
             if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
+            if (other is null) return 1;
             var thisEpochSeconds = this.ToEpochSeconds() - OffsetSeconds;
             var otherEpochSeconds = other.ToEpochSeconds() - other.OffsetSeconds;
             var epochComparison = thisEpochSeconds.CompareTo(otherEpochSeconds);
@@ -308,7 +308,7 @@ namespace Neo4j.Driver.V1
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
+            if (obj is null) return 1;
             if (ReferenceEquals(this, obj)) return 0;
             if (!(obj is ZonedDateTime))
                 throw new ArgumentException($"Object must be of type {nameof(ZonedDateTime)}");

--- a/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Types/ZonedDateTime.cs
@@ -184,7 +184,7 @@ namespace Neo4j.Driver.V1
         /// </summary>
         /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTime DateTime
+        private DateTime DateTime
         {
             get
             {
@@ -204,7 +204,7 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets a <see cref="TimeSpan"/> value that represents the offset of this instance.
         /// </summary>
-        public TimeSpan Offset => TimeSpan.FromSeconds(OffsetSeconds);
+        private TimeSpan Offset => TimeSpan.FromSeconds(OffsetSeconds);
 
         /// <summary>
         /// Converts this instance to an equivalent <see cref="DateTimeOffset"/> value
@@ -212,17 +212,16 @@ namespace Neo4j.Driver.V1
         /// <returns>Equivalent <see cref="DateTimeOffset"/> value</returns>
         /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTimeOffset</exception>
         /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
-        public DateTimeOffset DateTimeOffset
+        public DateTimeOffset ToDateTimeOffset()
         {
-            get
-            {
-                var offset = Offset;
+            // we first get DateTime instance to force Truncation / Overflow checks
+            var dateTime = DateTime;
+            var offset = Offset;
 
-                TemporalHelpers.AssertNoTruncation(offset, nameof(DateTimeOffset));
-                TemporalHelpers.AssertNoOverflow(offset, nameof(DateTimeOffset));
+            TemporalHelpers.AssertNoTruncation(offset, nameof(DateTimeOffset));
+            TemporalHelpers.AssertNoOverflow(offset, nameof(DateTimeOffset));
 
-                return new DateTimeOffset(DateTime, offset);
-            }
+            return new DateTimeOffset(dateTime, offset);
         }
 
         /// <summary>
@@ -364,10 +363,10 @@ namespace Neo4j.Driver.V1
             return left.CompareTo(right) >= 0;
         }
 
-        /// <inheritdoc cref="TemporalValue.ToDateTimeOffset"/>
-        protected override DateTimeOffset ToDateTimeOffset()
+        /// <inheritdoc cref="TemporalValue.ConvertToDateTimeOffset"/>
+        protected override DateTimeOffset ConvertToDateTimeOffset()
         {
-            return DateTimeOffset;
+            return ToDateTimeOffset();
         }
     }
 }


### PR DESCRIPTION
This PR makes conversions of temporal types to CLR types through methods instead of properties. 

Non-convertable types do not expose any conversion methods / properties but only their related temporal components as properties.

It also improves a couple of documentation comments.