### PR TITLE
Couple of test improvements

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ProcessBasedCommandRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/ProcessBasedCommandRunner.cs
@@ -24,7 +24,7 @@ namespace Neo4j.Driver.IntegrationTests.Internals
 {
     public class ProcessBasedCommandRunner : ShellCommandRunner
     {
-        private const int DefaultTimeOut = 2 * 60 * 1000; // 2 minutes
+        private const int DefaultTimeOut = 4 * 60 * 1000; // 4 minutes
 
         private List<string> _stdOut;
         private StringBuilder _stdErr;

--- a/Neo4j.Driver/Neo4j.Driver.Metrics/ConnectionPoolMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Metrics/ConnectionPoolMetrics.cs
@@ -33,15 +33,15 @@ namespace Neo4j.Driver.Internal.Metrics
         private long _timedOutToAcquire;
 
         public int Creating => _creating;
-        public long Created => _created;
-        public long FailedToCreate => _failedToCreate;
+        public long Created => Interlocked.Read(ref _created);
+        public long FailedToCreate => Interlocked.Read(ref _failedToCreate);
 
         public int Closing => _closing;
-        public long Closed => _closed;
+        public long Closed => Interlocked.Read(ref _closed);
 
         public int Acquiring => _acquiring;
-        public long Acquired => _acquired;
-        public long TimedOutToAcquire => _timedOutToAcquire;
+        public long Acquired => Interlocked.Read(ref _acquired);
+        public long TimedOutToAcquire => Interlocked.Read(ref _timedOutToAcquire);
 
         public string UniqueName { get; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Metrics/DefaultMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Metrics/DefaultMetrics.cs
@@ -41,8 +41,7 @@ namespace Neo4j.Driver.Internal.Metrics
             var poolMetrics = new ConnectionPoolMetrics(poolUri, pool, acquisitionTimeout);
             var key = poolMetrics.UniqueName;
 
-            _poolMetrics.AddOrUpdate(key, poolMetrics, (oldKey, oldValue) => poolMetrics);
-            return poolMetrics;
+            return (IConnectionPoolListener) _poolMetrics.GetOrAdd(key, poolMetrics);
         }
 
         public IConnectionListener CreateConnectionListener(Uri poolUri)
@@ -51,8 +50,7 @@ namespace Neo4j.Driver.Internal.Metrics
             var connMetrics = new ConnectionMetrics(poolUri, connectionTimeout);
             var key = connMetrics.UniqueName;
 
-            _connMetrics.AddOrUpdate(key, connMetrics, (oldKey, oldValue) => connMetrics);
-            return connMetrics;
+            return (IConnectionListener) _connMetrics.GetOrAdd(key, connMetrics);
         }
 
         public IDictionary<string, IConnectionPoolMetrics> ConnectionPoolMetrics => new ReadOnlyDictionary<string, IConnectionPoolMetrics>(_poolMetrics);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
@@ -60,12 +60,13 @@ namespace Neo4j.Driver.Tests.Connector
                     tcpServer.Bind(new IPEndPoint(IPAddress.Loopback, 9999));
 
                     var client = new TcpSocketClientWithDisposeDetection(
-                        new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(0)});
+                        new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(1)});
 
                     var exception = await Record.ExceptionAsync(
                         () => client.ConnectSocketAsync(IPAddress.Parse("127.0.0.1"), 9999));
+                    exception.Should().NotBeNull();
                     exception.Should().BeOfType<OperationCanceledException>(exception.ToString());
-                    exception.Message.Should().Be("Failed to connect to server 127.0.0.1:9999 within 0ms.");
+                    exception.Message.Should().Be("Failed to connect to server 127.0.0.1:9999 within 1000ms.");
                     client.DisposeCalled.Should().BeTrue();
                 }
             }
@@ -77,6 +78,7 @@ namespace Neo4j.Driver.Tests.Connector
                 var client = new TcpSocketClient(socketSettings);
 
                 // We fail to connect the first time as there is no server to connect to
+                // ReSharper disable once PossibleNullReferenceException
                 var exception = await Record.ExceptionAsync(
                     async()=> await client.ConnectSocketAsync(IPAddress.Parse("127.0.0.1"), 20003));
                 // start a server on port 20003
@@ -105,17 +107,19 @@ namespace Neo4j.Driver.Tests.Connector
                 {
                     tcpServer.Bind(new IPEndPoint(IPAddress.Loopback, 9998));
 
-                    var client = new TcpSocketClient(new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(0)});
+                    var client = new TcpSocketClient(new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(1)});
 
+                    // ReSharper disable once PossibleNullReferenceException
                     var exception = await Record.ExceptionAsync(
                         () => client.ConnectAsync(new Uri("bolt://127.0.0.1:9998")));
+                    exception.Should().NotBeNull();
                     exception.Should().BeOfType<IOException>();
                     exception.Message.Should().Be(
                         "Failed to connect to server 'bolt://127.0.0.1:9998/' via IP addresses'[127.0.0.1]' at port '9998'.");
 
                     var baseException = exception.GetBaseException();
                     baseException.Should().BeOfType<OperationCanceledException>(exception.ToString());
-                    baseException.Message.Should().Be("Failed to connect to server 127.0.0.1:9998 within 0ms.");
+                    baseException.Message.Should().Be("Failed to connect to server 127.0.0.1:9998 within 1000ms.");
                 }
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
@@ -55,20 +55,18 @@ namespace Neo4j.Driver.Tests.Connector
             [Fact]
             public async Task ShouldThrowExceptionIfConnectionTimedOut()
             {
-                using (var tcpServer = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-                {
-                    tcpServer.Bind(new IPEndPoint(IPAddress.Loopback, 9999));
+                var client = new TcpSocketClientWithDisposeDetection(
+                    new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(1)});
 
-                    var client = new TcpSocketClientWithDisposeDetection(
-                        new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(1)});
-
-                    var exception = await Record.ExceptionAsync(
-                        () => client.ConnectSocketAsync(IPAddress.Parse("127.0.0.1"), 9999));
-                    exception.Should().NotBeNull();
-                    exception.Should().BeOfType<OperationCanceledException>(exception.ToString());
-                    exception.Message.Should().Be("Failed to connect to server 127.0.0.1:9999 within 1000ms.");
-                    client.DisposeCalled.Should().BeTrue();
-                }
+                // ReSharper disable once PossibleNullReferenceException
+                // use non-routable IP address to mimic a connect timeout
+                // https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error
+                var exception = await Record.ExceptionAsync(
+                    () => client.ConnectSocketAsync(IPAddress.Parse("192.168.0.0"), 9999));
+                exception.Should().NotBeNull();
+                exception.Should().BeOfType<OperationCanceledException>(exception.ToString());
+                exception.Message.Should().Be("Failed to connect to server 192.168.0.0:9999 within 1000ms.");
+                client.DisposeCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -103,24 +101,21 @@ namespace Neo4j.Driver.Tests.Connector
             [Fact]
             public async Task ShouldThrowExceptionIfConnectionTimedOut()
             {
-                using (var tcpServer = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-                {
-                    tcpServer.Bind(new IPEndPoint(IPAddress.Loopback, 9998));
+                var client = new TcpSocketClient(new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(1)});
 
-                    var client = new TcpSocketClient(new SocketSettings {ConnectionTimeout = TimeSpan.FromSeconds(1)});
+                // ReSharper disable once PossibleNullReferenceException
+                // use non-routable IP address to mimic a connect timeout
+                // https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error
+                var exception = await Record.ExceptionAsync(
+                    () => client.ConnectAsync(new Uri("bolt://192.168.0.0:9998")));
+                exception.Should().NotBeNull();
+                exception.Should().BeOfType<IOException>();
+                exception.Message.Should().Be(
+                    "Failed to connect to server 'bolt://192.168.0.0:9998/' via IP addresses'[192.168.0.0]' at port '9998'.");
 
-                    // ReSharper disable once PossibleNullReferenceException
-                    var exception = await Record.ExceptionAsync(
-                        () => client.ConnectAsync(new Uri("bolt://127.0.0.1:9998")));
-                    exception.Should().NotBeNull();
-                    exception.Should().BeOfType<IOException>();
-                    exception.Message.Should().Be(
-                        "Failed to connect to server 'bolt://127.0.0.1:9998/' via IP addresses'[127.0.0.1]' at port '9998'.");
-
-                    var baseException = exception.GetBaseException();
-                    baseException.Should().BeOfType<OperationCanceledException>(exception.ToString());
-                    baseException.Message.Should().Be("Failed to connect to server 127.0.0.1:9998 within 1000ms.");
-                }
+                var baseException = exception.GetBaseException();
+                baseException.Should().BeOfType<OperationCanceledException>(exception.ToString());
+                baseException.Message.Should().Be("Failed to connect to server 192.168.0.0:9998 within 1000ms.");
             }
         }
         

--- a/Neo4j.Driver/Neo4j.Driver.sln
+++ b/Neo4j.Driver/Neo4j.Driver.sln
@@ -11,7 +11,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{622A94AD-BC4D-4162-AE43-A5CA055F24FC}"
 	ProjectSection(SolutionItems) = preProject
 		..\LICENSE = ..\LICENSE
-		Neo4j.Driver.nuspec = Neo4j.Driver.nuspec
 		..\NOTICE = ..\NOTICE
 		..\README.md = ..\README.md
 	EndProjectSection

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -274,7 +274,7 @@ namespace Neo4j.Driver.Internal.Connector
                             t =>
                             {
                                 _client.Dispose();
-                                _stream.Dispose();
+                                _stream?.Dispose();
 
                                 _client = null;
                                 _stream = null;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -212,38 +212,31 @@ namespace Neo4j.Driver.Internal.Connector
         {
             InitClient();
 
-            var tcs = new TaskCompletionSource<bool>();
-            using (var cts = new CancellationTokenSource(_connectionTimeout))
-            {
-                using (cts.Token.Register(() => tcs.SetResult(true)))
-                {
 #if NET452
-                    var connectTask = Task.Factory.FromAsync(_client.BeginConnect, _client.EndConnect, address, port, null);
+            var connectTask = Task.Factory.FromAsync(_client.BeginConnect, _client.EndConnect, address, port, null);
 #else
-                    var connectTask = _client.ConnectAsync(address, port);
+            var connectTask = _client.ConnectAsync(address, port);
 #endif
-                    var finishedTask = await Task.WhenAny(connectTask, tcs.Task).ConfigureAwait(false);
-                    if (connectTask != finishedTask) // timed out
-                    {
-                        try
-                        {
-                            // close client immediately when failed to connect within timeout
-                            await DisconnectAsync().ConfigureAwait(false);
-                        }
-                        catch (Exception e)
-                        {
-                            _logger?.Error($"Failed to close connect to the server {address}:{port}" +
-                                           $" after connection timed out {_connectionTimeout.TotalMilliseconds}ms" +
-                                           $" due to error: {e.Message}.", e);
-                        }
-                        
-                        throw new OperationCanceledException(
-                            $"Failed to connect to server {address}:{port} within {_connectionTimeout.TotalMilliseconds}ms.", cts.Token);
-                    }
-
-                    await connectTask.ConfigureAwait(false);
+            var finishedTask = await Task.WhenAny(connectTask, Task.Delay(_connectionTimeout)).ConfigureAwait(false);
+            if (connectTask != finishedTask) // timed out
+            {
+                try
+                {
+                    // close client immediately when failed to connect within timeout
+                    await DisconnectAsync().ConfigureAwait(false);
                 }
+                catch (Exception e)
+                {
+                    _logger?.Error($"Failed to close connect to the server {address}:{port}" +
+                                   $" after connection timed out {_connectionTimeout.TotalMilliseconds}ms" +
+                                   $" due to error: {e.Message}.", e);
+                }
+                
+                throw new OperationCanceledException(
+                    $"Failed to connect to server {address}:{port} within {_connectionTimeout.TotalMilliseconds}ms.");
             }
+
+            await connectTask.ConfigureAwait(false);
         }
 
         public virtual void Disconnect()


### PR DESCRIPTION
This PR tries to improve flakiness in some tests along with a main code fix that can cause a `NullReferenceException`.

* boltkit commands now timeout in 4 mins instead of 2 mins,
* metrics no more override existing metrics and atomically reads counters.