### PR TITLE
Ensure stream position to be reset before returning task

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/ChunkReaderTests.cs
@@ -201,6 +201,24 @@ namespace Neo4j.Driver.Tests.IO
                 count.Should().Be(1);
                 logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.AtLeast(size / Constants.ChunkBufferSize));
             }
+
+            [Fact]
+            public void ShouldResetBufferStreamPosition()
+            {
+                var data = IOExtensions.GenerateBoltMessages(1000, 128 * 1024);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var bufferStream = new MemoryStream();
+                bufferStream.Write(IOExtensions.GenerateBoltMessage(1035));
+
+                var bufferPosition = bufferStream.Position;
+
+                var count = reader.ReadNextMessages(bufferStream);
+
+                bufferStream.Position.Should().Be(bufferPosition);
+            }
             
         }
 
@@ -326,6 +344,24 @@ namespace Neo4j.Driver.Tests.IO
 
                 count.Should().Be(1);
                 logger.Verify(l => l.Trace(It.IsRegex("^\\d+ bytes left in chunk buffer.*compacting\\.$"), It.IsAny<object[]>()), Times.AtLeast(size / Constants.ChunkBufferSize));
+            }
+
+            [Fact]
+            public async void ShouldResetBufferStreamPosition()
+            {
+                var data = IOExtensions.GenerateBoltMessages(1000, 128 * 1024);
+
+                var logger = new Mock<ILogger>();
+                var reader = new ChunkReader(new MemoryStream(data.ToArray()), logger.Object);
+
+                var bufferStream = new MemoryStream();
+                bufferStream.Write(IOExtensions.GenerateBoltMessage(1035));
+
+                var bufferPosition = bufferStream.Position;
+
+                var count = await reader.ReadNextMessagesAsync(bufferStream);
+
+                bufferStream.Position.Should().Be(bufferPosition);
             }
 
         }


### PR DESCRIPTION
When handling `ReadNextMessagesAsync` calls, we record message stream buffer position and reset it to that recorded value just after actual read messages operation completes. However, the returned task from `ReadNextMessagesAsync` call does not include the task continuation that resets the position - and returns the original task. This may sometimes cause the message reading operation resume from an incorrect buffer position which causes an unexpected byte sequence and halts with `ProtocolException`.

This PR fixes the issue by returning the expeccted position resetting task continuation as the result from `ReadNextMessagesAsync` method.