### PR TITLE
Pass AccessMode in BEGIN and RUN messages

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DelegatedConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DelegatedConnectionTests.cs
@@ -22,6 +22,7 @@ using FluentAssertions;
 using Moq;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Connector;
+using Neo4j.Driver.V1;
 using Xunit;
 
 namespace Neo4j.Driver.Tests.Connector
@@ -69,7 +70,7 @@ namespace Neo4j.Driver.Tests.Connector
                 var connMock = new Mock<IConnection>();
                 var conn = new TestDelegatedConnection(connMock.Object);
 
-                await Record.ExceptionAsync(()=>conn.TaskWithErrorHandling(FaultedTask));
+                await Record.ExceptionAsync(() => conn.TaskWithErrorHandling(FaultedTask));
 
                 conn.ErrorList.Count.Should().Be(1);
                 conn.ErrorList[0].Should().BeOfType<InvalidOperationException>();
@@ -83,13 +84,45 @@ namespace Neo4j.Driver.Tests.Connector
                 var conn = new TestDelegatedConnection(connMock.Object);
 
                 FaultedTask().IsFaulted.Should().BeTrue();
-                await Record.ExceptionAsync(()=>conn.TaskWithErrorHandling(FaultedOutsideTask));
+                await Record.ExceptionAsync(() => conn.TaskWithErrorHandling(FaultedOutsideTask));
 
                 conn.ErrorList.Count.Should().Be(1);
                 conn.ErrorList[0].Should().BeOfType<InvalidOperationException>();
                 conn.ErrorList[0].Message.Should().Be("Molly ate too much today!");
             }
+        }
 
+        public class ModeProperty
+        {
+            [Theory]
+            [InlineData(AccessMode.Read)]
+            [InlineData(AccessMode.Write)]
+            public void ShouldGetModeFromDelegate(AccessMode mode)
+            {
+                var connMock = new Mock<IConnection>();
+                connMock.Setup(x => x.Mode).Returns(mode);
+
+                var delegateConnection = new TestDelegatedConnection(connMock.Object);
+
+                delegateConnection.Mode.Should().Be(mode);
+
+                connMock.VerifyGet(x => x.Mode);
+            }
+
+            [Theory]
+            [InlineData(AccessMode.Read)]
+            [InlineData(AccessMode.Write)]
+            public void ShouldSetModeOnDelegate(AccessMode mode)
+            {
+                var connMock = new Mock<IConnection>();
+                connMock.Setup(x => x.Mode).Returns(mode);
+
+                var delegateConnection = new TestDelegatedConnection(connMock.Object);
+
+                delegateConnection.Mode = mode;
+
+                connMock.VerifySet(c => c.Mode = mode);
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/MessageHandlers/V3/BeginMessageHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/MessageHandlers/V3/BeginMessageHandlerTests.cs
@@ -56,7 +56,7 @@ namespace Neo4j.Driver.Tests.IO.MessageHandlers.V3
                 new Dictionary<string, object>
                 {
                     {"username", "MollyMostlyWhite"}
-                }));
+                }, AccessMode.Write));
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
             var reader = readerMachine.Reader();
@@ -85,7 +85,7 @@ namespace Neo4j.Driver.Tests.IO.MessageHandlers.V3
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer();
 
-            writer.Write(new BeginMessage(null, null));
+            writer.Write(new BeginMessage(null, null, AccessMode.Write));
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
             var reader = readerMachine.Reader();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/IO/MessageHandlers/V3/RunWithMetadataMessageHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/IO/MessageHandlers/V3/RunWithMetadataMessageHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Neo4j.Driver.Tests.IO.MessageHandlers.V3
                 new Dictionary<string, object>
                 {
                     {"username", "MollyMostlyWhite"}
-                }));
+                }, AccessMode.Write));
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
             var reader = readerMachine.Reader();
@@ -98,7 +98,7 @@ namespace Neo4j.Driver.Tests.IO.MessageHandlers.V3
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer();
 
-            writer.Write(new RunWithMetadataMessage(new Statement("RETURN 1")));
+            writer.Write(new RunWithMetadataMessage(new Statement("RETURN 1"), AccessMode.Write));
 
             var readerMachine = CreateReaderMachine(writerMachine.GetOutput());
             var reader = readerMachine.Reader();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
@@ -104,8 +104,9 @@ namespace Neo4j.Driver.Tests.Routing
                 var clusterPoolMock = new Mock<IClusterConnectionPool>();
                 var mockedConn = new Mock<IConnection>();
                 mockedConn.Setup(x => x.Server.Address).Returns(uri.ToString);
+                mockedConn.Setup(x => x.Mode).Returns(mode);
                 var conn = mockedConn.Object;
-                clusterPoolMock.Setup(x => x.Acquire(uri)).Returns(conn);
+                clusterPoolMock.Setup(x => x.Acquire(uri, mode)).Returns(conn);
                 var balancer = new LoadBalancer(clusterPoolMock.Object, mock.Object);
 
                 // When
@@ -127,7 +128,7 @@ namespace Neo4j.Driver.Tests.Routing
                 mock.Setup(x => x.RoutingTable).Returns(routingTableMock.Object);
 
                 var clusterConnPoolMock = new Mock<IClusterConnectionPool>();
-                clusterConnPoolMock.Setup(x => x.Acquire(uri))
+                clusterConnPoolMock.Setup(x => x.Acquire(uri, mode))
                     .Callback(() => throw new ServiceUnavailableException("failed init"));
 
                 var balancer = new LoadBalancer(clusterConnPoolMock.Object, mock.Object);
@@ -156,7 +157,7 @@ namespace Neo4j.Driver.Tests.Routing
                 mock.Setup(x => x.RoutingTable).Returns(routingTableMock.Object);
 
                 var clusterConnPoolMock = new Mock<IClusterConnectionPool>();
-                clusterConnPoolMock.Setup(x => x.Acquire(uri))
+                clusterConnPoolMock.Setup(x => x.Acquire(uri, mode))
                     .Callback(() => throw new SecurityException("Failed to establish ssl connection with the server"));
 
                 var balancer = new LoadBalancer(clusterConnPoolMock.Object, mock.Object);
@@ -185,7 +186,7 @@ namespace Neo4j.Driver.Tests.Routing
                 mock.Setup(x => x.RoutingTable).Returns(routingTableMock.Object);
 
                 var clusterConnPoolMock = new Mock<IClusterConnectionPool>();
-                clusterConnPoolMock.Setup(x => x.Acquire(uri)).Returns(() => null)
+                clusterConnPoolMock.Setup(x => x.Acquire(uri, mode)).Returns(() => null)
                     .Callback(() => throw new ProtocolException("do not understand struct 0x01"));
 
                 var balancer = new LoadBalancer(clusterConnPoolMock.Object, mock.Object);
@@ -216,8 +217,8 @@ namespace Neo4j.Driver.Tests.Routing
                 routingTableManager.Setup(x => x.RoutingTable).Returns(routingTable);
 
                 var clusterPoolMock = new Mock<IClusterConnectionPool>();
-                clusterPoolMock.Setup(x => x.Acquire(It.IsAny<Uri>()))
-                    .Returns((Uri uri) => NewConnectionMock(uri));
+                clusterPoolMock.Setup(x => x.Acquire(It.IsAny<Uri>(), It.IsAny<AccessMode>()))
+                    .Returns((Uri u, AccessMode m) => NewConnectionMock(u, m));
 
                 var balancer = new LoadBalancer(clusterPoolMock.Object, routingTableManager.Object);
 
@@ -245,10 +246,11 @@ namespace Neo4j.Driver.Tests.Routing
                 }
             }
 
-            private static IConnection NewConnectionMock(Uri uri)
+            private static IConnection NewConnectionMock(Uri uri, AccessMode mode)
             {
                 var mockedConn = new Mock<IConnection>();
                 mockedConn.Setup(x => x.Server.Address).Returns(uri.ToString);
+                mockedConn.Setup(x => x.Mode).Returns(mode);
                 return mockedConn.Object;
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionTests.cs
@@ -534,6 +534,7 @@ namespace Neo4j.Driver.Tests
             }
 
             mockConn.Setup(x => x.BoltProtocol).Returns(protocol);
+            mockConn.SetupGet(x => x.Mode).Returns(AccessMode.Write);
             return mockConn;
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -31,6 +32,12 @@ namespace Neo4j.Driver.Internal.Connector
         protected DelegatedConnection(IConnection connection)
         {
             Delegate = connection;
+        }
+
+        public AccessMode? Mode
+        {
+            get => Delegate.Mode;
+            set => Delegate.Mode = value;
         }
 
         public abstract void OnError(Exception error);
@@ -55,7 +62,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public Task SyncAsync()
         {
-            return TaskWithErrorHandling(()=>Delegate.SyncAsync());
+            return TaskWithErrorHandling(() => Delegate.SyncAsync());
         }
 
         public void Send()
@@ -72,7 +79,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public Task SendAsync()
         {
-            return TaskWithErrorHandling(()=>Delegate.SendAsync());
+            return TaskWithErrorHandling(() => Delegate.SendAsync());
         }
 
         public void ReceiveOne()
@@ -89,7 +96,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public Task ReceiveOneAsync()
         {
-            return TaskWithErrorHandling(()=>Delegate.ReceiveOneAsync());
+            return TaskWithErrorHandling(() => Delegate.ReceiveOneAsync());
         }
 
         public void Init()
@@ -106,10 +113,11 @@ namespace Neo4j.Driver.Internal.Connector
 
         public Task InitAsync()
         {
-            return TaskWithErrorHandling(()=>Delegate.InitAsync());
+            return TaskWithErrorHandling(() => Delegate.InitAsync());
         }
 
-        public void Enqueue(IRequestMessage message1, IMessageResponseCollector responseCollector, IRequestMessage message2 = null)
+        public void Enqueue(IRequestMessage message1, IMessageResponseCollector responseCollector,
+            IRequestMessage message2 = null)
         {
             try
             {
@@ -137,6 +145,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public IServerInfo Server => Delegate.Server;
         public IBoltProtocol BoltProtocol => Delegate.BoltProtocol;
+
         public void ResetMessageReaderAndWriterForServerV3_1()
         {
             Delegate.ResetMessageReaderAndWriterForServerV3_1();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -45,7 +46,8 @@ namespace Neo4j.Driver.Internal.Connector
 
         Task ReceiveOneAsync();
 
-        void Enqueue(IRequestMessage message1, IMessageResponseCollector responseCollector, IRequestMessage message2 = null);
+        void Enqueue(IRequestMessage message1, IMessageResponseCollector responseCollector,
+            IRequestMessage message2 = null);
 
         // Enqueue a reset message
         void Reset();
@@ -81,6 +83,11 @@ namespace Neo4j.Driver.Internal.Connector
         /// The Bolt protocol that the connection is talking with.
         /// </summary>
         IBoltProtocol BoltProtocol { get; }
+
+        /// <summary>
+        /// The AccessMode this connection is operating in.
+        /// </summary>
+        AccessMode? Mode { get; set; }
 
         /// <summary>
         /// Downgrade message reader and writer to not be able to read and write byte array

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -79,6 +79,8 @@ namespace Neo4j.Driver.Internal.Connector
             _responseHandler = messageResponseHandler ?? new MessageResponseHandler(logger);
         }
 
+        public AccessMode? Mode { get; set; }
+
         public void Init()
         {
             try

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ConnectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ConnectionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2019 "Neo4j,"
+﻿// Copyright (c) 2002-2019 "Neo4j,"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.
@@ -16,26 +16,17 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
+using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.V1;
 
-namespace Neo4j.Driver.Internal.Messaging.V3
+namespace Neo4j.Driver.Internal
 {
-    internal class BeginMessage : TransactionStartingMessage
+    internal static class ConnectionExtensions
     {
-        public BeginMessage(Bookmark bookmark, TransactionConfig txConfig, AccessMode mode)
-            : this(bookmark, txConfig?.Timeout, txConfig?.Metadata, mode)
+        public static AccessMode GetEnforcedAccessMode(this IConnection connection)
         {
-        }
-
-        public BeginMessage(Bookmark bookmark, TimeSpan? txTimeout, IDictionary<string, object> txMetadata, AccessMode mode)
-            : base(bookmark, txTimeout, txMetadata, mode)
-        {
-        }
-
-        public override string ToString()
-        {
-            return $"BEGIN {Metadata.ToContentString()}";
+            return connection.Mode ??
+                   throw new InvalidOperationException("Connection should have its Mode property set.");
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/RunWithMetadataMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/RunWithMetadataMessage.cs
@@ -23,21 +23,19 @@ namespace Neo4j.Driver.Internal.Messaging.V3
 {
     internal class RunWithMetadataMessage : TransactionStartingMessage
     {
-        public RunWithMetadataMessage(Statement statement, Bookmark bookmark, TimeSpan txTimeout,
-            IDictionary<string, object> txMetadata)
-            : base(bookmark, txTimeout, txMetadata)
+        public RunWithMetadataMessage(Statement statement, AccessMode mode)
+            : this(statement, null, null, null, mode)
         {
-            Statement = statement;
         }
 
-        public RunWithMetadataMessage(Statement statement)
-            : base(null, null)
+        public RunWithMetadataMessage(Statement statement, Bookmark bookmark, TransactionConfig txConfig, AccessMode mode)
+            : this(statement, bookmark, txConfig?.Timeout, txConfig?.Metadata, mode)
         {
-            Statement = statement;
         }
 
-        public RunWithMetadataMessage(Statement statement, Bookmark bookmark, TransactionConfig txConfig)
-            : base(bookmark, txConfig)
+        public RunWithMetadataMessage(Statement statement, Bookmark bookmark, TimeSpan? txTimeout,
+            IDictionary<string, object> txMetadata, AccessMode mode)
+            : base(bookmark, txTimeout, txMetadata, mode)
         {
             Statement = statement;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
@@ -67,7 +67,7 @@ namespace Neo4j.Driver.Internal.Protocol
         {
             var resultBuilder = new ResultBuilder(NewSummaryCollector(statement, connection.Server),
                 connection.ReceiveOne, resultResourceHandler);
-            connection.Enqueue(new RunWithMetadataMessage(statement, bookmark, txConfig), resultBuilder, PullAll);
+            connection.Enqueue(new RunWithMetadataMessage(statement, bookmark, txConfig, connection.GetEnforcedAccessMode()), resultBuilder, PullAll);
             connection.Send();
             return resultBuilder.PreBuild();
         }
@@ -77,14 +77,14 @@ namespace Neo4j.Driver.Internal.Protocol
         {
             var resultBuilder = new ResultCursorBuilder(NewSummaryCollector(statement, connection.Server),
                 connection.ReceiveOneAsync, resultResourceHandler);
-            connection.Enqueue(new RunWithMetadataMessage(statement, bookmark, txConfig), resultBuilder, PullAll);
+            connection.Enqueue(new RunWithMetadataMessage(statement, bookmark, txConfig, connection.GetEnforcedAccessMode()), resultBuilder, PullAll);
             await connection.SendAsync().ConfigureAwait(false);
             return await resultBuilder.PreBuildAsync().ConfigureAwait(false);
         }
 
         public void BeginTransaction(IConnection connection, Bookmark bookmark, TransactionConfig txConfig)
         {
-            connection.Enqueue(new BeginMessage(bookmark, txConfig), null);
+            connection.Enqueue(new BeginMessage(bookmark, txConfig, connection.GetEnforcedAccessMode()), null);
             if (bookmark != null && !bookmark.IsEmpty())
             {
                 connection.Sync();
@@ -93,7 +93,7 @@ namespace Neo4j.Driver.Internal.Protocol
 
         public async Task BeginTransactionAsync(IConnection connection, Bookmark bookmark, TransactionConfig txConfig)
         {
-            connection.Enqueue(new BeginMessage(bookmark, txConfig), null);
+            connection.Enqueue(new BeginMessage(bookmark, txConfig, connection.GetEnforcedAccessMode()), null);
             if (bookmark != null && !bookmark.IsEmpty())
             {
                 await connection.SyncAsync().ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace Neo4j.Driver.Internal.Protocol
         {
             var resultBuilder = new ResultBuilder(
                 NewSummaryCollector(statement, connection.Server), connection.ReceiveOne);
-            connection.Enqueue(new RunWithMetadataMessage(statement), resultBuilder, PullAll);
+            connection.Enqueue(new RunWithMetadataMessage(statement, connection.GetEnforcedAccessMode()), resultBuilder, PullAll);
             connection.Send();
             return resultBuilder.PreBuild();
         }
@@ -113,7 +113,7 @@ namespace Neo4j.Driver.Internal.Protocol
         {
             var resultBuilder = new ResultCursorBuilder(
                 NewSummaryCollector(statement, connection.Server), connection.ReceiveOneAsync);
-            connection.Enqueue(new RunWithMetadataMessage(statement), resultBuilder, PullAll);
+            connection.Enqueue(new RunWithMetadataMessage(statement, connection.GetEnforcedAccessMode()), resultBuilder, PullAll);
             await connection.SendAsync().ConfigureAwait(false);
 
             return await resultBuilder.PreBuildAsync().ConfigureAwait(false);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnection.cs
@@ -25,14 +25,12 @@ namespace Neo4j.Driver.Internal.Routing
     internal class ClusterConnection : DelegatedConnection
     {
         private readonly Uri _uri;
-        private readonly AccessMode _mode;
         private readonly IClusterErrorHandler _errorHandler;
 
-        public ClusterConnection(IConnection connection, Uri uri, AccessMode mode, IClusterErrorHandler errorHandler)
-        :base(connection)
+        public ClusterConnection(IConnection connection, Uri uri, IClusterErrorHandler errorHandler)
+            : base(connection)
         {
             _uri = uri;
-            _mode = mode;
             _errorHandler = errorHandler;
         }
 
@@ -52,6 +50,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 HandleClusterError(error);
             }
+
             throw error;
         }
 
@@ -71,6 +70,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 HandleClusterError(error);
             }
+
             throw error;
         }
 
@@ -78,7 +78,7 @@ namespace Neo4j.Driver.Internal.Routing
         {
             if (error.IsClusterError())
             {
-                switch (_mode)
+                switch (Mode)
                 {
                     case AccessMode.Read:
                         // The user was trying to run a write in a read session
@@ -91,7 +91,7 @@ namespace Neo4j.Driver.Internal.Routing
                         _errorHandler.OnWriteError(_uri);
                         throw new SessionExpiredException($"Server at {_uri} no longer accepts writes");
                     default:
-                        throw new ArgumentOutOfRangeException($"Unsupported mode type {_mode}");
+                        throw new ArgumentOutOfRangeException($"Unsupported mode type {Mode}");
                 }
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -69,26 +69,24 @@ namespace Neo4j.Driver.Internal.Routing
 
         private bool IsClosed => _closedMarker > 0;
 
-        public IConnection Acquire(Uri uri)
+        public IConnection Acquire(Uri uri, AccessMode mode = AccessMode.Write)
         {
             if (!_pools.TryGetValue(uri, out var pool))
             {
                 return null;
             }
 
-            AccessMode ignored = AccessMode.Write;
-            return pool.Acquire(ignored);
+            return pool.Acquire(mode);
         }
 
-        public Task<IConnection> AcquireAsync(Uri uri)
+        public Task<IConnection> AcquireAsync(Uri uri, AccessMode mode = AccessMode.Write)
         {
             if (!_pools.TryGetValue(uri, out var pool))
             {
-                return Task.FromResult((IConnection)null);
+                return Task.FromResult((IConnection) null);
             }
 
-            AccessMode ignored = AccessMode.Write;
-            return pool.AcquireAsync(ignored);
+            return pool.AcquireAsync(mode);
         }
 
         public void Add(IEnumerable<Uri> servers)
@@ -113,6 +111,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 _pools.AddOrUpdate(uri, _poolFactory.Create, ActivateConnectionPool);
             }
+
             if (IsClosed)
             {
                 // Anything added after dispose should be directly cleaned.
@@ -168,6 +167,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 return pool.DeactivateAsync();
             }
+
             return TaskHelper.GetCompletedTask();
         }
 
@@ -177,6 +177,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 return pool.NumberOfInUseConnections;
             }
+
             return 0;
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscoveryManager.cs
@@ -180,6 +180,7 @@ namespace Neo4j.Driver.Internal.Routing
             public IConnection Acquire(AccessMode mode)
             {
                 var conn = _connection;
+                conn.Mode = mode;
                 _connection = null;
                 return conn;
             }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -14,27 +14,37 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
+using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Routing
 {
     internal interface IClusterConnectionPool : IDisposable
     {
         // Try to acquire a connection with the server specified by the uri
-        IConnection Acquire(Uri uri);
-        Task<IConnection> AcquireAsync(Uri uri);
+        IConnection Acquire(Uri uri, AccessMode mode);
+
+        Task<IConnection> AcquireAsync(Uri uri, AccessMode mode);
+
         // Add a set of uri to this pool
         void Add(IEnumerable<Uri> uris);
+
         Task AddAsync(IEnumerable<Uri> uris);
+
         // Update the pool keys with the new server uris
         void Update(IEnumerable<Uri> added, IEnumerable<Uri> removed);
+
         Task UpdateAsync(IEnumerable<Uri> added, IEnumerable<Uri> removed);
+
         // Deactivate all the connection pool with the server specified by the uri
         void Deactivate(Uri uri);
+
         Task DeactivateAsync(Uri uri);
+
         // Get number of in-use connections for the uri
         int NumberOfInUseConnections(Uri uri);
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -43,9 +43,11 @@ namespace Neo4j.Driver.Internal.Routing
         {
             _logger = logger;
 
-            _clusterConnectionPool = new ClusterConnectionPool(Enumerable.Empty<Uri>(), connectionFactory, poolSettings, logger);
+            _clusterConnectionPool =
+                new ClusterConnectionPool(Enumerable.Empty<Uri>(), connectionFactory, poolSettings, logger);
             _routingTableManager = new RoutingTableManager(routingSettings, this, logger);
-            _loadBalancingStrategy = CreateLoadBalancingStrategy(routingSettings.Strategy, _clusterConnectionPool, _logger);
+            _loadBalancingStrategy =
+                CreateLoadBalancingStrategy(routingSettings.Strategy, _clusterConnectionPool, _logger);
         }
 
         // for test only
@@ -58,7 +60,8 @@ namespace Neo4j.Driver.Internal.Routing
 
             _clusterConnectionPool = clusterConnPool;
             _routingTableManager = routingTableManager;
-            _loadBalancingStrategy = CreateLoadBalancingStrategy(config.LoadBalancingStrategy, clusterConnPool, _logger);
+            _loadBalancingStrategy =
+                CreateLoadBalancingStrategy(config.LoadBalancingStrategy, clusterConnPool, _logger);
         }
 
         private bool IsClosed => _closedMarker > 0;
@@ -76,6 +79,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 ThrowObjectDisposedException();
             }
+
             return conn;
         }
 
@@ -92,6 +96,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 ThrowObjectDisposedException();
             }
+
             return conn;
         }
 
@@ -142,7 +147,8 @@ namespace Neo4j.Driver.Internal.Routing
         public Task<IConnection> CreateClusterConnectionAsync(Uri uri)
         {
             return CreateClusterConnectionAsync(uri, AccessMode.Write);
-;       }
+            ;
+        }
 
         public void Close()
         {
@@ -205,13 +211,16 @@ namespace Neo4j.Driver.Internal.Routing
                     // no server known to routingTable
                     break;
                 }
+
                 IConnection conn = CreateClusterConnection(uri, mode);
                 if (conn != null)
                 {
                     return conn;
                 }
+
                 //else  connection already removed by clusterConnection onError method
             }
+
             throw new SessionExpiredException($"Failed to connect to any {mode.ToString().ToLower()} server.");
         }
 
@@ -239,13 +248,16 @@ namespace Neo4j.Driver.Internal.Routing
                     // no server known to routingTable
                     break;
                 }
+
                 IConnection conn = await CreateClusterConnectionAsync(uri, mode).ConfigureAwait(false);
                 if (conn != null)
                 {
                     return conn;
                 }
+
                 //else  connection already removed by clusterConnection onError method
             }
+
             throw new SessionExpiredException($"Failed to connect to any {mode.ToString().ToLower()} server.");
         }
 
@@ -253,11 +265,12 @@ namespace Neo4j.Driver.Internal.Routing
         {
             try
             {
-                IConnection conn = _clusterConnectionPool.Acquire(uri);
+                IConnection conn = _clusterConnectionPool.Acquire(uri, mode);
                 if (conn != null)
                 {
-                    return new ClusterConnection(conn, uri, mode, this);
+                    return new ClusterConnection(conn, uri, this);
                 }
+
                 OnConnectionError(uri, new ArgumentException(
                     $"Routing table {_routingTableManager.RoutingTable} contains a server '{uri}' " +
                     $"that is not known to cluster connection pool {_clusterConnectionPool}."));
@@ -266,6 +279,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 OnConnectionError(uri, e);
             }
+
             return null;
         }
 
@@ -273,11 +287,12 @@ namespace Neo4j.Driver.Internal.Routing
         {
             try
             {
-                IConnection conn = await _clusterConnectionPool.AcquireAsync(uri).ConfigureAwait(false);
+                IConnection conn = await _clusterConnectionPool.AcquireAsync(uri, mode).ConfigureAwait(false);
                 if (conn != null)
                 {
-                    return new ClusterConnection(conn, uri, mode, this);
+                    return new ClusterConnection(conn, uri, this);
                 }
+
                 await OnConnectionErrorAsync(uri, new ArgumentException(
                     $"Routing table {_routingTableManager.RoutingTable} contains a server {uri} " +
                     $"that is not known to cluster connection pool {_clusterConnectionPool}.")).ConfigureAwait(false);
@@ -286,6 +301,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 await OnConnectionErrorAsync(uri, e).ConfigureAwait(false);
             }
+
             return null;
         }
 
@@ -300,7 +316,8 @@ namespace Neo4j.Driver.Internal.Routing
                    $"{nameof(_clusterConnectionPool)}: {{{_clusterConnectionPool}}}";
         }
 
-        private static ILoadBalancingStrategy CreateLoadBalancingStrategy(LoadBalancingStrategy strategy, IClusterConnectionPool pool,
+        private static ILoadBalancingStrategy CreateLoadBalancingStrategy(LoadBalancingStrategy strategy,
+            IClusterConnectionPool pool,
             IDriverLogger logger)
         {
             if (strategy == LoadBalancingStrategy.LeastConnected)


### PR DESCRIPTION
This PR makes the `AccessMode` set on client side available on messages `BEGIN` and `RUN` in Bolt V3.

No `mode` parameter in statement metadata means that the access mode set by client is `Write`, whereas a value of `r` means it is set as `Read`.