### PR TITLE
Handle handshake errors

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -14,9 +14,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.IO;
@@ -45,7 +47,8 @@ namespace Neo4j.Driver.Internal.Connector
         private readonly IListenerEvent _connEvent;
 
         public SocketClient(Uri uri, SocketSettings socketSettings, BufferSettings bufferSettings,
-            IConnectionListener connMetricsListener = null, IDriverLogger logger = null, ITcpSocketClient socketClient = null)
+            IConnectionListener connMetricsListener = null, IDriverLogger logger = null,
+            ITcpSocketClient socketClient = null)
         {
             _uri = uri;
             _logger = logger;
@@ -83,53 +86,17 @@ namespace Neo4j.Driver.Internal.Connector
             return SelectBoltProtocol(version);
         }
 
-        public Task<IBoltProtocol> ConnectAsync()
+        public async Task<IBoltProtocol> ConnectAsync()
         {
-            TaskCompletionSource<IBoltProtocol> tcs = new TaskCompletionSource<IBoltProtocol>();
-
             _connMetricsListener?.ConnectionConnecting(_connEvent);
-            _tcpSocketClient.ConnectAsync(_uri)
-                .ContinueWith(t =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            tcs.SetException(t.Exception.GetBaseException());
-                        }
-                        else if (t.IsCanceled)
-                        {
-                            tcs.SetCanceled();
-                        }
-                        else
-                        {
-                            SetOpened();
-                            _logger?.Debug($"~~ [CONNECT] {_uri}");
-                            _connMetricsListener?.ConnectionConnected(_connEvent);
-                            return DoHandshakeAsync();
-                        }
-                        return Task.FromResult(-1);
-                    }, TaskContinuationOptions.ExecuteSynchronously).Unwrap()
-                .ContinueWith(t =>
-                {
-                    int version = t.Result;
+            await _tcpSocketClient.ConnectAsync(_uri).ConfigureAwait(false);
 
-                    if (version != -1)
-                    {
-                        try
-                        {
-                            tcs.SetResult(SelectBoltProtocol(version));
-                        }
-                        catch (AggregateException exc)
-                        {
-                            tcs.SetException(exc.GetBaseException());
-                        }
-                        catch (Exception exc)
-                        {
-                            tcs.SetException(exc);
-                        }
-                    }   
-                }, TaskContinuationOptions.ExecuteSynchronously);
+            SetOpened();
+            _logger?.Debug($"~~ [CONNECT] {_uri}");
+            _connMetricsListener?.ConnectionConnected(_connEvent);
 
-            return tcs.Task;
+            var version = await DoHandshakeAsync().ConfigureAwait(false);
+            return SelectBoltProtocol(version);
         }
 
         public void Send(IEnumerable<IRequestMessage> messages)
@@ -141,6 +108,7 @@ namespace Neo4j.Driver.Internal.Connector
                     Writer.Write(message);
                     LogDebug(MessagePattern, message);
                 }
+
                 Writer.Flush();
             }
             catch (Exception ex)
@@ -160,6 +128,7 @@ namespace Neo4j.Driver.Internal.Connector
                     Writer.Write(message);
                     LogDebug(MessagePattern, message);
                 }
+
                 await Writer.FlushAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -172,7 +141,7 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void Receive(IMessageResponseHandler responseHandler)
         {
-            while(responseHandler.UnhandledMessageSize > 0)
+            while (responseHandler.UnhandledMessageSize > 0)
             {
                 ReceiveOne(responseHandler);
             }
@@ -198,9 +167,11 @@ namespace Neo4j.Driver.Internal.Connector
                 Stop();
                 throw;
             }
+
             if (responseHandler.HasProtocolViolationError)
             {
-                _logger?.Warn(responseHandler.Error, $"Received bolt protocol error from server {_uri}, connection will be terminated.");
+                _logger?.Warn(responseHandler.Error,
+                    $"Received bolt protocol error from server {_uri}, connection will be terminated.");
                 Stop();
                 throw responseHandler.Error;
             }
@@ -218,13 +189,15 @@ namespace Neo4j.Driver.Internal.Connector
                 await StopAsync().ConfigureAwait(false);
                 throw;
             }
+
             if (responseHandler.HasProtocolViolationError)
             {
-                _logger?.Warn(responseHandler.Error, $"Received bolt protocol error from server {_uri}, connection will be terminated.");
+                _logger?.Warn(responseHandler.Error,
+                    $"Received bolt protocol error from server {_uri}, connection will be terminated.");
                 await StopAsync().ConfigureAwait(false);
                 throw responseHandler.Error;
             }
-       }
+        }
 
         internal void SetOpened()
         {
@@ -281,7 +254,11 @@ namespace Neo4j.Driver.Internal.Connector
             _logger?.Debug("C: [HANDSHAKE] {0}", data.ToHexString());
 
             data = new byte[4];
-            _tcpSocketClient.ReadStream.Read(data, 0, data.Length);
+            var read = _tcpSocketClient.ReadStream.Read(data, 0, data.Length);
+            if (read <= 0)
+            {
+                throw new IOException($"Unexpected end of stream, read returned {read}");
+            }
 
             var agreedVersion = BoltProtocolFactory.UnpackAgreedVersion(data);
             _logger?.Debug("S: [HANDSHAKE] {0}", agreedVersion);
@@ -296,7 +273,11 @@ namespace Neo4j.Driver.Internal.Connector
             _logger?.Debug("C: [HANDSHAKE] {0}", data.ToHexString());
 
             data = new byte[4];
-            await _tcpSocketClient.ReadStream.ReadAsync(data, 0, data.Length).ConfigureAwait(false);
+            var read = await _tcpSocketClient.ReadStream.ReadAsync(data, 0, data.Length).ConfigureAwait(false);
+            if (read <= 0)
+            {
+                throw new IOException($"Unexpected end of stream, read returned {read}");
+            }
 
             var agreedVersion = BoltProtocolFactory.UnpackAgreedVersion(data);
             _logger?.Debug("S: [HANDSHAKE] {0}", agreedVersion);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -51,7 +52,8 @@ namespace Neo4j.Driver.Internal.Connector
             _id = $"{_idPrefix}{UniqueIdGenerator.GetId()}";
             _logger = new PrefixLogger(logger, FormatPrefix(_id));
 
-            _client = new SocketClient(uri, connectionSettings.SocketSettings, bufferSettings, metricsListener, _logger);
+            _client = new SocketClient(uri, connectionSettings.SocketSettings, bufferSettings, metricsListener,
+                _logger);
             _authToken = connectionSettings.AuthToken;
             _userAgent = connectionSettings.UserAgent;
             Server = new ServerInfo(uri);
@@ -120,6 +122,7 @@ namespace Neo4j.Driver.Internal.Connector
                 // nothing to send
                 return;
             }
+
             // blocking to send
             _client.Send(_messages);
 
@@ -136,7 +139,7 @@ namespace Neo4j.Driver.Internal.Connector
 
             // send
             await _client.SendAsync(_messages).ConfigureAwait(false);
-            
+
             _messages.Clear();
         }
 
@@ -163,7 +166,7 @@ namespace Neo4j.Driver.Internal.Connector
 
             // receive
             await _client.ReceiveAsync(_responseHandler).ConfigureAwait(false);
-            
+
             AssertNoServerFailure();
         }
 
@@ -201,7 +204,9 @@ namespace Neo4j.Driver.Internal.Connector
 
         public void UpdateId(string newConnId)
         {
-            _logger.Debug("Connection '{0}' renamed to '{1}'. The new name identifies the connection uniquely both on the client side and the server side.", _id, newConnId);
+            _logger.Debug(
+                "Connection '{0}' renamed to '{1}'. The new name identifies the connection uniquely both on the client side and the server side.",
+                _id, newConnId);
             _id = newConnId;
             _logger.Prefix = FormatPrefix(_id);
         }
@@ -222,18 +227,24 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 try
                 {
-                    _boltProtocol.Logout(this);
+                    _boltProtocol?.Logout(this);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // we'll ignore this error since the underlying socket is disposed earlier,
+                    // mostly because of an error.
                 }
                 catch (Exception e)
                 {
                     _logger.Debug($"Failed to logout user before closing connection due to error: {e.Message}");
                 }
+
                 _client.Stop();
             }
             catch (Exception e)
             {
                 // only log the exception if failed to close connection
-                _logger.Error(e, "Failed to close connection properly.");
+                _logger.Warn(e, "Failed to close connection properly.");
             }
         }
 
@@ -243,18 +254,27 @@ namespace Neo4j.Driver.Internal.Connector
             {
                 try
                 {
-                    await _boltProtocol.LogoutAsync(this);
+                    if (_boltProtocol != null)
+                    {
+                        await _boltProtocol.LogoutAsync(this);
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // we'll ignore this error since the underlying socket is disposed earlier,
+                    // mostly because of an error.
                 }
                 catch (Exception e)
                 {
                     _logger.Debug($"Failed to logout user before closing connection due to error: {e.Message}");
                 }
+
                 await _client.StopAsync();
             }
             catch (Exception e)
             {
                 // only log the exception if failed to close connection
-                _logger.Error(e, $"Failed to close connection properly.");
+                _logger.Warn(e, $"Failed to close connection properly.");
             }
         }
 
@@ -271,7 +291,6 @@ namespace Neo4j.Driver.Internal.Connector
         public void Enqueue(IRequestMessage requestMessage, IMessageResponseCollector resultBuilder = null,
             IRequestMessage requestStreamingMessage = null)
         {
-
             _messages.Enqueue(requestMessage);
             _responseHandler.EnqueueMessage(requestMessage, resultBuilder);
 


### PR DESCRIPTION
This PR introduces following changes;

1. Check for broken connection during handshake and throw an `IOException` if it's the case,
2. Do not invoke `Logout` if `BoltProtocol` is not assigned on the connection yet,
3. Check for `ObjectDisposedException` on connection `Close` so that it's silently ignored since underlying connection is already closed.