### PR TITLE
Relax discovery logic

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.Tests.Routing
             }
 
             [Fact]
-            public void ShouldServiceUnavailableWhenProcedureNotFound()
+            public void ShouldThrowWhenProcedureNotFound()
             {
                 // Given
                 var pairs = new List<Tuple<IRequestMessage, IResponseMessage>>
@@ -166,14 +166,13 @@ namespace Neo4j.Driver.Tests.Routing
                 var exception = Record.Exception(() => manager.Discover(connMock.Object));
 
                 // Then
-                exception.Should().BeOfType<ServiceUnavailableException>().Which.Message.Should()
-                    .StartWith("Error performing discovery: ").And
+                exception.Should().BeOfType<ClientException>().Which.Message.Should()
                     .Contain("not found");
                 connMock.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
-            public void ShouldProtocolErrorWhenNoRecord()
+            public void ShouldThrowWhenNoRecord()
             {
                 // Given
                 var connMock = SetupSocketConnection(new List<object[]>());
@@ -183,13 +182,13 @@ namespace Neo4j.Driver.Tests.Routing
                 var exception = Record.Exception(() => manager.Discover(connMock.Object));
 
                 // Then
-                exception.Should().BeOfType<ServiceUnavailableException>().Which.Message.Should()
-                    .Be("Error performing discovery: Sequence contains no elements.");
+                exception.Should().BeOfType<InvalidOperationException>().Which.Message.Should()
+                    .Be("Sequence contains no elements");
                 connMock.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
-            public void ShouldProtocolErrorWhenMultipleRecord()
+            public void ShouldThrowWhenMultipleRecord()
             {
                 // Given
                 var connMock = SetupSocketConnection(new List<object[]>
@@ -203,13 +202,13 @@ namespace Neo4j.Driver.Tests.Routing
                 var exception = Record.Exception(() => manager.Discover(connMock.Object));
 
                 // Then
-                exception.Should().BeOfType<ServiceUnavailableException>().Which.Message.Should()
-                    .Be("Error performing discovery: Sequence contains more than one element.");
+                exception.Should().BeOfType<InvalidOperationException>().Which.Message.Should()
+                    .Be("Sequence contains more than one element");
                 connMock.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
-            public void ShouldProtocolErrorWhenRecordUnparsable()
+            public void ShouldThrowWhenRecordUnparsable()
             {
                 // Given
                 var connMock = SetupSocketConnection(new object[] {1});
@@ -219,13 +218,13 @@ namespace Neo4j.Driver.Tests.Routing
                 var exception = Record.Exception(() => manager.Discover(connMock.Object));
 
                 // Then
-                exception.Should().BeOfType<ServiceUnavailableException>().Which.Message.Should()
-                    .Be("Error performing discovery: keys (2) does not equal to values (1).");
+                exception.Should().BeOfType<ProtocolException>().Which.Message.Should()
+                    .Be("keys (2) does not equal to values (1)");
                 connMock.Verify(x => x.Close(), Times.Once);
             }
 
             [Fact]
-            public void ShouldThrowExceptionIfRouterIsEmpty()
+            public void ShouldThrowIfRouterIsEmpty()
             {
                 // Given
                 var recordFields = CreateGetServersResponseRecordFields(0, 2, 1);
@@ -236,8 +235,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var exception = Record.Exception(() => manager.Discover(connMock.Object));
 
                 // Then
-                exception.Should().BeOfType<ServiceUnavailableException>().Which.Message.Should()
-                    .StartWith("Error performing discovery:").And
+                exception.Should().BeOfType<ProtocolException>().Which.Message.Should()
                     .Contain("0 routers, 2 writers and 1 readers.");
                 connMock.Verify(x => x.Close(), Times.Once);
             }
@@ -254,8 +252,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var exception = Record.Exception(() => manager.Discover(connMock.Object));
 
                 // Then
-                exception.Should().BeOfType<ServiceUnavailableException>().Which.Message.Should()
-                    .StartWith("Error performing discovery:").And
+                exception.Should().BeOfType<ProtocolException>().Which.Message.Should()
                     .Contain("3 routers, 1 writers and 0 readers.");
                 connMock.Verify(x => x.Close(), Times.Once);
             }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
@@ -34,7 +34,7 @@ using Record = Xunit.Record;
 
 namespace Neo4j.Driver.Tests.Routing
 {
-    public class ClusterDiscoveryManagerTests
+    public class ClusterDiscoveryTests
     {
         public class Constructor
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,45 +24,48 @@ using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal.Routing
 {
-    internal class ClusterDiscoveryManager
+    internal class ClusterDiscovery : IDiscovery
     {
-        private readonly IConnection _conn;
         private readonly IDriverLogger _logger;
-        public IEnumerable<Uri> Readers { get; internal set; } = new Uri[0];
-        public IEnumerable<Uri> Writers { get; internal set; } = new Uri[0];
-        public IEnumerable<Uri> Routers { get; internal set; } = new Uri[0];
-        public long ExpireAfterSeconds { get; internal set; }
+        private readonly IDictionary<string, string> _context;
 
         private const string GetServersProcedure = "dbms.cluster.routing.getServers";
         private const string GetRoutingTableProcedure = "dbms.cluster.routing.getRoutingTable";
-        public Statement DiscoveryProcedure { get; }
-        public ClusterDiscoveryManager(IConnection connection, IDictionary<string, string> context, IDriverLogger logger)
+
+        public ClusterDiscovery(IDictionary<string, string> context, IDriverLogger logger)
         {
-            _conn = connection;
+            _context = context;
             _logger = logger;
-            if (ServerVersion.Version(_conn.Server.Version) >= ServerVersion.V3_2_0)
+        }
+
+        internal Statement DiscoveryProcedure(IConnection connection)
+        {
+            if (ServerVersion.Version(connection.Server.Version) >= ServerVersion.V3_2_0)
             {
-                DiscoveryProcedure = new Statement($"CALL {GetRoutingTableProcedure}({{context}})",
-                    new Dictionary<string, object> {{"context", context}});
+                return new Statement($"CALL {GetRoutingTableProcedure}({{context}})",
+                    new Dictionary<string, object> {{"context", _context}});
             }
             else
             {
-                DiscoveryProcedure = new Statement($"CALL {GetServersProcedure}");
+                return new Statement($"CALL {GetServersProcedure}");
             }
         }
 
         /// <remarks>Throws <see cref="ProtocolException"/> if the discovery result is invalid.</remarks>
         /// <remarks>Throws <see cref="ServiceUnavailableException"/> if the no discovery procedure could be found in the server.</remarks>
-        public void Rediscovery()
+        public IRoutingTable Discover(IConnection connection)
         {
+            var table = default(RoutingTable);
+
             try
             {
-                using (var provider = new SingleConnectionBasedConnectionProvider(_conn))
+                using (var provider = new SingleConnectionBasedConnectionProvider(connection))
                 using (var session = new Session(provider, _logger))
                 {
-                    var result = session.Run(DiscoveryProcedure);
+                    var result = session.Run(DiscoveryProcedure(connection));
                     var record = result.Single();
-                    ParseDiscoveryResult(record);
+
+                    table = ParseDiscoveryResult(record);
                 }
             }
             catch (Exception e)
@@ -69,24 +73,21 @@ namespace Neo4j.Driver.Internal.Routing
                 HandleDiscoveryException(e);
             }
 
-            if (!Readers.Any() || !Routers.Any())
-            {
-                throw new ProtocolException(
-                    $"Invalid discovery result: discovered {Routers.Count()} routers, " +
-                    $"{Writers.Count()} writers and {Readers.Count()} readers.");
-            }
+            return table;
         }
 
-        public async Task RediscoveryAsync()
+        public async Task<IRoutingTable> DiscoverAsync(IConnection connection)
         {
-            var provider = new SingleConnectionBasedConnectionProvider(_conn);
+            var table = default(RoutingTable);
+
+            var provider = new SingleConnectionBasedConnectionProvider(connection);
             var session = new Session(provider, _logger);
             try
             {
-                var result = await session.RunAsync(DiscoveryProcedure).ConfigureAwait(false);
+                var result = await session.RunAsync(DiscoveryProcedure(connection)).ConfigureAwait(false);
                 var record = await result.SingleAsync().ConfigureAwait(false);
 
-                ParseDiscoveryResult(record);
+                table = ParseDiscoveryResult(record);
             }
             catch (Exception e)
             {
@@ -102,35 +103,24 @@ namespace Neo4j.Driver.Internal.Routing
                 {
                     // ignore any exception
                 }
+
                 await provider.CloseAsync().ConfigureAwait(false);
             }
 
-            if (!Readers.Any() || !Routers.Any())
-            {
-                throw new ProtocolException(
-                    $"Invalid discovery result: discovered {Routers.Count()} routers, " +
-                    $"{Writers.Count()} writers and {Readers.Count()} readers.");
-            }
+            return table;
         }
 
         private void HandleDiscoveryException(Exception e)
         {
-            if (e is ClientException)
-            {
-                throw new ServiceUnavailableException(
-                    $"Error when calling `getServers` procedure: {e.Message}. " +
-                    "Please make sure that there is a Neo4j 3.1+ causal cluster up running.", e);
-            }
-            else
-            {
-                // for any reason we failed to do a discovery
-                throw new ProtocolException(
-                    $"Error when parsing `getServers` result: {e.Message}.");
-            }
+            throw new ServiceUnavailableException($"Error performing discovery: {e.Message}.", e);
         }
 
-        private void ParseDiscoveryResult(IRecord record)
+        private static RoutingTable ParseDiscoveryResult(IRecord record)
         {
+            var routers = default(Uri[]);
+            var readers = default(Uri[]);
+            var writers = default(Uri[]);
+
             foreach (var servers in record["servers"].As<List<Dictionary<string, object>>>())
             {
                 var addresses = servers["addresses"].As<List<string>>();
@@ -138,23 +128,33 @@ namespace Neo4j.Driver.Internal.Routing
                 switch (role)
                 {
                     case "READ":
-                        Readers = addresses.Select(BoltRoutingUri).ToArray();
+                        readers = addresses.Select(BoltRoutingUri).ToArray();
                         break;
                     case "WRITE":
-                        Writers = addresses.Select(BoltRoutingUri).ToArray();
+                        writers = addresses.Select(BoltRoutingUri).ToArray();
                         break;
                     case "ROUTE":
-                        Routers = addresses.Select(BoltRoutingUri).ToArray();
+                        routers = addresses.Select(BoltRoutingUri).ToArray();
                         break;
+                    default:
+                        throw new ProtocolException(
+                            $"Role '{role}' returned from discovery procedure is not recognized by the driver");
                 }
             }
-            ExpireAfterSeconds = record["ttl"].As<long>();
+
+            if ((readers == null || readers.Length == 0) || (routers == null || routers.Length == 0))
+            {
+                throw new ProtocolException(
+                    $"Invalid discovery result: discovered {routers?.Length ?? 0} routers, {writers?.Length ?? 0} writers and {readers?.Length ?? 0} readers.");
+            }
+
+            return new RoutingTable(routers, readers, writers, record["ttl"].As<long>());
         }
 
         public static Uri BoltRoutingUri(string address)
         {
             UriBuilder builder = new UriBuilder("bolt+routing://" + address);
-            
+
             // If scheme is not registered and no port is specified, then the port is assigned as -1
             if (builder.Port == -1)
             {
@@ -172,6 +172,7 @@ namespace Neo4j.Driver.Internal.Routing
             {
                 _connection = connection;
             }
+
             public void Dispose()
             {
                 _connection?.Close();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
@@ -57,20 +57,13 @@ namespace Neo4j.Driver.Internal.Routing
         {
             var table = default(RoutingTable);
 
-            try
+            using (var provider = new SingleConnectionBasedConnectionProvider(connection))
+            using (var session = new Session(provider, _logger))
             {
-                using (var provider = new SingleConnectionBasedConnectionProvider(connection))
-                using (var session = new Session(provider, _logger))
-                {
-                    var result = session.Run(DiscoveryProcedure(connection));
-                    var record = result.Single();
+                var result = session.Run(DiscoveryProcedure(connection));
+                var record = result.Single();
 
-                    table = ParseDiscoveryResult(record);
-                }
-            }
-            catch (Exception e)
-            {
-                HandleDiscoveryException(e);
+                table = ParseDiscoveryResult(record);
             }
 
             return table;
@@ -89,10 +82,6 @@ namespace Neo4j.Driver.Internal.Routing
 
                 table = ParseDiscoveryResult(record);
             }
-            catch (Exception e)
-            {
-                HandleDiscoveryException(e);
-            }
             finally
             {
                 try
@@ -108,11 +97,6 @@ namespace Neo4j.Driver.Internal.Routing
             }
 
             return table;
-        }
-
-        private void HandleDiscoveryException(Exception e)
-        {
-            throw new ServiceUnavailableException($"Error performing discovery: {e.Message}.", e);
         }
 
         private static RoutingTable ParseDiscoveryResult(IRecord record)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IDiscovery.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2019 "Neo4j,"
+﻿// Copyright (c) 2002-2019 "Neo4j,"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.
@@ -14,23 +14,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
-using System.Collections.Generic;
-using Neo4j.Driver.V1;
+
+using System.Threading.Tasks;
+using Neo4j.Driver.Internal.Connector;
 
 namespace Neo4j.Driver.Internal.Routing
 {
-    internal interface IRoutingTable
+    internal interface IDiscovery
     {
-        bool IsStale(AccessMode mode);
-        IList<Uri> Readers { get; }
-        IList<Uri> Writers { get; }
-        IList<Uri> Routers { get; }
-        long ExpireAfterSeconds { get; }
-        void Remove(Uri uri);
-        void RemoveWriter(Uri uri);
-        ISet<Uri> All();
-        void Clear();
-        void PrependRouters(IEnumerable<Uri> uris);
+        IRoutingTable Discover(IConnection connection);
+
+        Task<IRoutingTable> DiscoverAsync(IConnection connection);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.Internal.Routing
 
             _clusterConnectionPool =
                 new ClusterConnectionPool(Enumerable.Empty<Uri>(), connectionFactory, poolSettings, logger);
-            _routingTableManager = new RoutingTableManager(routingSettings, this, logger);
+            _routingTableManager = new RoutingTableManager(routingSettings, this,  logger);
             _loadBalancingStrategy =
                 CreateLoadBalancingStrategy(routingSettings.Strategy, _clusterConnectionPool, _logger);
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTable.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTable.cs
@@ -28,13 +28,14 @@ namespace Neo4j.Driver.Internal.Routing
         private readonly AddressSet<Uri> _routers = new AddressSet<Uri>();
         private readonly AddressSet<Uri> _readers = new AddressSet<Uri>();
         private readonly AddressSet<Uri> _writers = new AddressSet<Uri>();
+        private readonly long _expireAfterSeconds;
 
         public IList<Uri> Routers => _routers.Snaphost;
         public IList<Uri> Readers => _readers.Snaphost;
         public IList<Uri> Writers => _writers.Snaphost;
+        public long ExpireAfterSeconds => _expireAfterSeconds;
 
         private readonly Stopwatch _stopwatch;
-        private readonly long _expireAfterSeconds;
 
         public RoutingTable(IEnumerable<Uri> routers, long expireAfterSeconds = 0)
         :this(routers, Enumerable.Empty<Uri>(), Enumerable.Empty<Uri>(), expireAfterSeconds)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
@@ -278,6 +278,12 @@ namespace Neo4j.Driver.Internal.Routing
                         }
                     }
                 }
+                catch (SecurityException e)
+                {
+                    _logger?.Error(e,
+                        "Failed to update routing table from server '{0}' because of a security exception.", router);
+                    throw;
+                }
                 catch (Exception e)
                 {
                     _logger?.Warn(e, "Failed to update routing table from server '{0}'.", router);
@@ -308,6 +314,12 @@ namespace Neo4j.Driver.Internal.Routing
                             return newRoutingTable;
                         }
                     }
+                }
+                catch (SecurityException e)
+                {
+                    _logger?.Error(e,
+                        "Failed to update routing table from server '{0}' because of a security exception.", router);
+                    throw;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Currently, discovery process is very picky on what exceptions are treated as a `try-next-router` or `abort-discovery`. This PR relaxes the existing logic, and treats _any_ exception as a `try-next-router` action and logs those exceptions at `WARNING` level.