### PR TITLE
Make retries to always give a second chance

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
@@ -14,10 +14,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using Neo4j.Driver.IntegrationTests.Internals;
 using System;
 using Xunit;
-using static System.Boolean;
 using static System.Environment;
 
 namespace Neo4j.Driver.IntegrationTests
@@ -31,7 +31,8 @@ namespace Neo4j.Driver.IntegrationTests
         public StandAloneIntegrationTestFixture()
         {
             // If a system flag is set, then we use the local single server instead
-            if (TryParse(GetEnvironmentVariable(UsingLocalServer), out _))
+            if (bool.TryParse(GetEnvironmentVariable(UsingLocalServer), out var usingLocalServer) &&
+                usingLocalServer)
             {
                 StandAlone = new LocalStandAloneInstance();
             }
@@ -82,6 +83,7 @@ namespace Neo4j.Driver.IntegrationTests
                 throw;
             }
         }
+
         public void Dispose()
         {
             Cluster?.Dispose();

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Neo4j.Driver.IntegrationTests.csproj
@@ -54,6 +54,8 @@
     <None Update="Resources\accessmode_writer_explicit.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <None Update="Resources\accessmode_writer_func.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <None Update="Resources\accessmode_writer_implicit.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
+    <None Update="Resources\connection_error_on_commit_v1.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
+    <None Update="Resources\connection_error_on_commit_v3.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <None Update="Resources\get_routing_table.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <None Update="Resources\get_routing_table_only.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <None Update="Resources\get_routing_table_with_context.script" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/connection_error_on_commit_v1.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/connection_error_on_commit_v1.script
@@ -1,0 +1,14 @@
+!: BOLT 1
+!: AUTO INIT
+!: AUTO RESET
+
+C: RUN "BEGIN" {}
+C: PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "CREATE (n {name: 'Bob'})" {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+C: RUN "COMMIT" {}
+S: <EXIT>

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/connection_error_on_commit_v3.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/connection_error_on_commit_v3.script
@@ -1,0 +1,12 @@
+!: BOLT 3
+!: AUTO HELLO
+!: AUTO RESET
+
+C: BEGIN {}
+   RUN "CREATE (n {name: 'Bob'})" {} {}
+   PULL_ALL
+S: SUCCESS {}
+   SUCCESS {}
+   SUCCESS {}
+C: COMMIT
+S: <EXIT>

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/StubTests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/StubTests/TransactionTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) 2002-2019 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Neo4j.Driver.IntegrationTests.Internals;
+using Neo4j.Driver.Internal;
+using Neo4j.Driver.V1;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Neo4j.Driver.IntegrationTests.StubTests
+{
+    public class TransactionTests
+    {
+        private static readonly Config NoEncryptionAndShortRetry =
+            Config.Builder.WithEncryptionLevel(EncryptionLevel.None)
+                .WithMaxTransactionRetryTime(TimeSpan.FromSeconds(2)).ToConfig();
+
+        public class ExplicitTransaction
+        {
+            [Theory]
+            [InlineData("v1")]
+            [InlineData("v3")]
+            public void ShouldFailIfCommitFailsDueToBrokenConnection(string boltVersion)
+            {
+                using (BoltStubServer.Start($"connection_error_on_commit_{boltVersion}", 9001))
+                {
+                    using (var driver =
+                        GraphDatabase.Driver("bolt://localhost:9001", AuthTokens.None, NoEncryptionAndShortRetry))
+                    {
+                        using (var session = driver.Session(AccessMode.Write))
+                        {
+                            var txc = session.BeginTransaction();
+                            var result = txc.Run("CREATE (n {name: 'Bob'})");
+                            txc.Success();
+
+                            var exc = Record.Exception(() => txc.Dispose());
+
+                            exc.Should().BeOfType<ServiceUnavailableException>().Which
+                                .HasCause<IOException>().Should().BeTrue();
+                        }
+                    }
+                }
+            }
+
+            [Theory]
+            [InlineData("v1")]
+            [InlineData("v3")]
+            public async Task ShouldFailIfCommitFailsDueToBrokenConnectionAsync(string boltVersion)
+            {
+                using (BoltStubServer.Start($"connection_error_on_commit_{boltVersion}", 9001))
+                {
+                    using (var driver =
+                        GraphDatabase.Driver("bolt://localhost:9001", AuthTokens.None, NoEncryptionAndShortRetry))
+                    {
+                        var session = driver.Session(AccessMode.Write);
+                        try
+                        {
+                            var txc = await session.BeginTransactionAsync();
+                            var result = await txc.RunAsync("CREATE (n {name: 'Bob'})");
+
+                            var exc = await Record.ExceptionAsync(() => txc.CommitAsync());
+
+                            exc.Should().BeOfType<ServiceUnavailableException>().Which
+                                .HasCause<IOException>().Should().BeTrue();
+                        }
+                        finally
+                        {
+                            await session.CloseAsync();
+                        }
+                    }
+                }
+            }
+        }
+
+        public class TransactionFunction
+        {
+            private readonly ITestOutputHelper _testOutputHelper;
+
+            public TransactionFunction(ITestOutputHelper testOutputHelper)
+            {
+                _testOutputHelper = testOutputHelper;
+            }
+
+            [Theory]
+            [InlineData("v1")]
+            [InlineData("v3")]
+            public void ShouldFailIfCommitFailsDueToBrokenConnection(string boltVersion)
+            {
+                using (BoltStubServer.Start($"connection_error_on_commit_{boltVersion}", 9001))
+                {
+                    using (var driver =
+                        GraphDatabase.Driver("bolt://localhost:9001", AuthTokens.None, NoEncryptionAndShortRetry))
+                    {
+                        var session = driver.Session(AccessMode.Write);
+                        try
+                        {
+                            var exc = Record.Exception(() =>
+                                session.WriteTransaction(txc => txc.Run("CREATE (n {name: 'Bob'})"))
+                            );
+                            exc.Should().BeOfType<ServiceUnavailableException>().Which
+                                .HasCause<IOException>().Should().BeTrue();
+                        }
+                        finally
+                        {
+                            session.Dispose();
+                        }
+                    }
+                }
+            }
+
+            [Theory]
+            [InlineData("v1")]
+            [InlineData("v3")]
+            public async Task ShouldFailIfCommitFailsDueToBrokenConnectionAsync(string boltVersion)
+            {
+                using (BoltStubServer.Start($"connection_error_on_commit_{boltVersion}", 9001))
+                {
+                    using (var driver =
+                        GraphDatabase.Driver("bolt://localhost:9001", AuthTokens.None, NoEncryptionAndShortRetry))
+                    {
+                        var session = driver.Session(AccessMode.Write);
+
+                        try
+                        {
+                            var exc = await Record.ExceptionAsync(() =>
+                            {
+                                return session.WriteTransactionAsync(
+                                    txc => txc.RunAsync("CREATE (n {name: 'Bob'})"));
+                            });
+                            exc.Should().BeOfType<ServiceUnavailableException>().Which
+                                .HasCause<IOException>().Should().BeTrue();
+                        }
+                        finally
+                        {
+                            await session.CloseAsync();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -348,15 +348,15 @@ namespace Neo4j.Driver.Tests
                 ex.Should().BeNull();
             }
 
-            [Fact]
-            public void ShouldNotThrowAndLogIfSocketDisposed()
+            [Theory]
+            [MemberData(nameof(GenerateObjectDisposedExceptions))]
+            public void ShouldNotThrowAndLogIfSocketDisposed(Exception exc)
             {
                 // Given
                 var logger = new Mock<IDriverLogger>();
 
                 var protocol = new Mock<IBoltProtocol>();
-                protocol.Setup(x => x.Logout(It.IsAny<IConnection>()))
-                    .Throws(new ObjectDisposedException("client"));
+                protocol.Setup(x => x.Logout(It.IsAny<IConnection>())).Throws(exc);
 
                 var mockClient = new Mock<ISocketClient>();
                 var conn = NewSocketConnection(mockClient.Object, logger: logger.Object);
@@ -370,15 +370,15 @@ namespace Neo4j.Driver.Tests
                     Times.Never);
             }
 
-            [Fact]
-            public async void ShouldNotThrowAndLogIfSocketDisposedAsync()
+            [Theory]
+            [MemberData(nameof(GenerateObjectDisposedExceptions))]
+            public async void ShouldNotThrowAndLogIfSocketDisposedAsync(Exception exc)
             {
                 // Given
                 var logger = new Mock<IDriverLogger>();
 
                 var protocol = new Mock<IBoltProtocol>();
-                protocol.Setup(x => x.LogoutAsync(It.IsAny<IConnection>()))
-                    .ThrowsAsync(new ObjectDisposedException("client"));
+                protocol.Setup(x => x.LogoutAsync(It.IsAny<IConnection>())).ThrowsAsync(exc);
 
                 var mockClient = new Mock<ISocketClient>();
                 var conn = NewSocketConnection(mockClient.Object, logger: logger.Object);
@@ -390,6 +390,16 @@ namespace Neo4j.Driver.Tests
                 logger.Verify(x => x.Debug(It.IsAny<string>(), It.IsAny<object[]>()), Times.Never);
                 logger.Verify(x => x.Warn(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<object[]>()),
                     Times.Never);
+            }
+
+            public static TheoryData<Exception> GenerateObjectDisposedExceptions()
+            {
+                return new TheoryData<Exception>()
+                {
+                    new ObjectDisposedException("socket"),
+                    new IOException("io", new ObjectDisposedException("socket")),
+                    new AggregateException(new IOException("io", new ObjectDisposedException("socket")))
+                };
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Helpers/ExceptionHelperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Helpers/ExceptionHelperTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2002-2019 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using Neo4j.Driver.Internal;
+using System;
+using System.IO;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Helpers
+{
+    public class ExceptionHelperTests
+    {
+        [Theory]
+        [MemberData(nameof(ObjectDisposedExceptions))]
+        public void ShouldReturnTrue(Exception exc)
+        {
+            exc.HasCause<ObjectDisposedException>().Should().BeTrue();
+        }
+
+        [Theory]
+        [MemberData(nameof(ObjectDisposedExceptions))]
+        public void ShouldReturnFalse(Exception exc)
+        {
+            exc.HasCause<SocketException>().Should().BeFalse();
+        }
+
+        public static TheoryData<Exception> ObjectDisposedExceptions()
+        {
+            return new TheoryData<Exception>
+            {
+                new ObjectDisposedException("socket"),
+                new IOException("some message", new ObjectDisposedException("socket")),
+                new InvalidOperationException("invalid",
+                    new IOException("io", new IOException("io", new ObjectDisposedException("socket")))),
+                new AggregateException(new ObjectDisposedException("socket")),
+                new AggregateException(new InvalidOperationException(), new ObjectDisposedException("socket")),
+                new AggregateException(new IOException("io", new ObjectDisposedException("socket"))),
+                new AggregateException(new AggregateException(new ObjectDisposedException("socket"))),
+                new AggregateException(new AggregateException(new ObjectDisposedException("socket")),
+                    new IOException("io")),
+                new AggregateException(new ArgumentException("name"), new InvalidOperationException("io"),
+                    new InvalidOperationException("io", new ObjectDisposedException("socket"))),
+                new AggregateException(new AggregateException(new IOException("io")),
+                    new AggregateException(new InvalidOperationException()),
+                    new AggregateException(new InvalidOperationException("io", new ObjectDisposedException("socket")))),
+            };
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
@@ -51,11 +51,8 @@ namespace Neo4j.Driver.Tests
             var retryLogic = new ExponentialBackoffRetryLogic(TimeSpan.FromSeconds(5), mockLogger.Object);
             Parallel.For(0, numberOfParallelRetries, i => Retry(i, retryLogic));
 
-            // we don't log last loop of failed retries, so let's recompute our expectation
-            var warningsLogged = Interlocked.Read(ref _globalCounter) - (1 * numberOfParallelRetries);
-
             mockLogger.Verify(l => l.Warn(It.IsAny<Exception>(), It.IsAny<string>()),
-                Times.Exactly((int) warningsLogged));
+                Times.Exactly((int) Interlocked.Read(ref _globalCounter)));
         }
 
         private void Retry(int index, IRetryLogic retryLogic)

--- a/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/RetryLogicTests.cs
@@ -44,15 +44,18 @@ namespace Neo4j.Driver.Tests
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(20)]
-        public void ShouldRetry(int index)
+        public void ShouldRetry(int numberOfParallelRetries)
         {
             var mockLogger = new Mock<IDriverLogger>();
 
             var retryLogic = new ExponentialBackoffRetryLogic(TimeSpan.FromSeconds(5), mockLogger.Object);
-            Parallel.For(0, index, i => Retry(i, retryLogic));
+            Parallel.For(0, numberOfParallelRetries, i => Retry(i, retryLogic));
+
+            // we don't log last loop of failed retries, so let's recompute our expectation
+            var warningsLogged = Interlocked.Read(ref _globalCounter) - (1 * numberOfParallelRetries);
 
             mockLogger.Verify(l => l.Warn(It.IsAny<Exception>(), It.IsAny<string>()),
-                Times.Exactly((int) Interlocked.Read(ref _globalCounter)));
+                Times.Exactly((int) warningsLogged));
         }
 
         private void Retry(int index, IRetryLogic retryLogic)
@@ -69,11 +72,9 @@ namespace Neo4j.Driver.Tests
             }));
             timer.Stop();
 
-            e.Should().BeOfType<ServiceUnavailableException>();
-            var error = e.InnerException as AggregateException;
-            var innerErrors = error.Flatten().InnerExceptions;
-
-            innerErrors.Count.Should().Be(runCounter);
+            e.Should().BeOfType<ServiceUnavailableException>()
+                .Which.InnerException.Should().BeOfType<AggregateException>()
+                .Which.Flatten().InnerExceptions.Should().HaveCount(runCounter);
             timer.Elapsed.TotalSeconds.Should().BeGreaterOrEqualTo(5);
         }
 
@@ -92,10 +93,59 @@ namespace Neo4j.Driver.Tests
                 throw ParseServerException(errorCode, "an error");
             }));
 
-            e.Should().BeOfType<TransientException>();
-            (e as TransientException).Code.Should().Be(errorCode);
+            e.Should().BeOfType<TransientException>().Which.Code.Should().Be(errorCode);
             count.Should().Be(1);
             mockLogger.Verify(l => l.Warn(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void ShouldRetryEvenOriginalTaskTakesLongerThanMaxRetryDuration()
+        {
+            var logger = new Mock<IDriverLogger>();
+            var retryLogic = new ExponentialBackoffRetryLogic(TimeSpan.FromSeconds(2), logger.Object);
+
+            var counter = 0;
+            var result = retryLogic.Retry(() =>
+            {
+                if (counter == 0)
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(3));
+                    counter++;
+                    throw new SessionExpiredException("session expired");
+                }
+
+                return counter;
+            });
+
+            result.Should().Be(1);
+            logger.Verify(
+                l => l.Warn(It.IsAny<SessionExpiredException>(),
+                    It.Is<string>(s => s.StartsWith("Transaction failed and will be retried"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task ShouldRetryEvenOriginalTaskTakesLongerThanMaxRetryDurationAsync()
+        {
+            var logger = new Mock<IDriverLogger>();
+            var retryLogic = new ExponentialBackoffRetryLogic(TimeSpan.FromSeconds(2), logger.Object);
+
+            var counter = 0;
+            var result = await retryLogic.RetryAsync(async () =>
+            {
+                if (counter == 0)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(3));
+                    counter++;
+                    throw new SessionExpiredException("session expired");
+                }
+
+                return counter;
+            });
+
+            result.Should().Be(1);
+            logger.Verify(
+                l => l.Warn(It.IsAny<SessionExpiredException>(),
+                    It.Is<string>(s => s.StartsWith("Transaction failed and will be retried"))), Times.Once);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -229,7 +229,7 @@ namespace Neo4j.Driver.Internal.Connector
                 {
                     _boltProtocol?.Logout(this);
                 }
-                catch (ObjectDisposedException)
+                catch (Exception e) when (e.HasCause<ObjectDisposedException>())
                 {
                     // we'll ignore this error since the underlying socket is disposed earlier,
                     // mostly because of an error.
@@ -259,7 +259,7 @@ namespace Neo4j.Driver.Internal.Connector
                         await _boltProtocol.LogoutAsync(this);
                     }
                 }
-                catch (ObjectDisposedException)
+                catch (Exception e) when (e.HasCause<ObjectDisposedException>())
                 {
                     // we'll ignore this error since the underlying socket is disposed earlier,
                     // mostly because of an error.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/ExceptionHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/ExceptionHelper.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2002-2019 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Neo4j.Driver.Internal
+{
+    internal static class ExceptionHelper
+    {
+        private static readonly TypeInfo ExceptionType = typeof(Exception).GetTypeInfo();
+
+        private static bool HasCause(this Exception exc, Func<Exception, bool> predicate)
+        {
+            // First check exception itself
+            if (predicate(exc))
+            {
+                return true;
+            }
+
+            var innerExceptions = default(Exception[]);
+
+            // Check if this is AggregateException
+            if (exc is AggregateException aggExc)
+            {
+                innerExceptions = aggExc.Flatten().InnerExceptions.ToArray();
+            }
+            else if (exc.InnerException != null)
+            {
+                innerExceptions = new[] {exc.InnerException};
+            }
+
+            // Now go through inner exceptions
+            if (innerExceptions != null)
+            {
+                foreach (var innerExc in innerExceptions)
+                {
+                    if (HasCause(innerExc, predicate))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool HasCause<T>(this Exception exc) where T : Exception
+        {
+            return HasCause(exc, cause => cause is T);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/RetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/RetryLogic.cs
@@ -58,40 +58,30 @@ namespace Neo4j.Driver.Internal
         {
             var exceptions = new List<Exception>();
             var timer = new Stopwatch();
+            timer.Start();
             var delayMs = _initialRetryDelayMs;
-            var counter = 0;
-            while (true)
+            var retryCount = 0;
+            do
             {
-                counter++;
+                retryCount++;
                 try
                 {
                     return runTxFunc();
                 }
                 catch (Exception e) when (e.IsRetriableError())
                 {
-                    if (!timer.IsRunning)
-                    {
-                        timer.Start();
-                    }
-
-                    if (timer.ElapsedMilliseconds < _maxRetryTimeMs)
-                    {
-                        var delay = TimeSpan.FromMilliseconds(ComputeDelayWithJitter(delayMs));
-                        _logger?.Warn(e, $"Transaction failed and will be retried in {delay}ms.");
-                        Thread.Sleep(delay);
-                        delayMs = delayMs * _multiplier;
-                        exceptions.Add(e);
-                        continue;
-                    }
-
                     exceptions.Add(e);
-                    break;
+
+                    var delay = TimeSpan.FromMilliseconds(ComputeDelayWithJitter(delayMs));
+                    _logger?.Warn(e, $"Transaction failed and will be retried in {delay}ms.");
+                    Thread.Sleep(delay);
+                    delayMs *= _multiplier;
                 }
-            }
+            } while (retryCount < 2 || timer.ElapsedMilliseconds < _maxRetryTimeMs);
 
             timer.Stop();
             throw new ServiceUnavailableException(
-                $"Failed after retried for {counter} times in {_maxRetryTimeMs}ms. " +
+                $"Failed after retried for {retryCount} times in {_maxRetryTimeMs}ms. " +
                 "Make sure that your database is online and retry again.", new AggregateException(exceptions));
         }
 
@@ -99,42 +89,33 @@ namespace Neo4j.Driver.Internal
         {
             var exceptions = new List<Exception>();
             var timer = new Stopwatch();
+            timer.Start();
             var delayMs = _initialRetryDelayMs;
-            var counter = 0;
-            while (true)
+            var retryCount = 0;
+            do
             {
-                counter++;
+                retryCount++;
                 try
                 {
                     return await runTxAsyncFunc().ConfigureAwait(false);
                 }
                 catch (Exception e) when (e.IsRetriableError())
                 {
-                    if (!timer.IsRunning)
-                    {
-                        timer.Start();
-                    }
-
-                    if (timer.ElapsedMilliseconds < _maxRetryTimeMs)
-                    {
-                        var delay = TimeSpan.FromMilliseconds(ComputeDelayWithJitter(delayMs));
-                        _logger?.Warn(e, $"Transaction failed and will be retried in {delay} ms.");
-                        await Task.Delay(delay).ConfigureAwait(false); // blocking for this delay
-                        delayMs = delayMs * _multiplier;
-                        exceptions.Add(e);
-                        continue;
-                    }
-
                     exceptions.Add(e);
-                    break;
+
+                    var delay = TimeSpan.FromMilliseconds(ComputeDelayWithJitter(delayMs));
+                    _logger?.Warn(e, $"Transaction failed and will be retried in {delay} ms.");
+                    await Task.Delay(delay).ConfigureAwait(false); // blocking for this delay
+                    delayMs = delayMs * _multiplier;
                 }
-            }
+            } while (retryCount < 2 || timer.Elapsed.TotalMilliseconds < _maxRetryTimeMs);
 
             timer.Stop();
             throw new ServiceUnavailableException(
-                $"Failed after retried for {counter} times in {_maxRetryTimeMs} ms. " +
+                $"Failed after retried for {retryCount} times in {_maxRetryTimeMs} ms. " +
                 "Make sure that your database is online and retry again.", new AggregateException(exceptions));
         }
+
 
         private double ComputeDelayWithJitter(double delayMs)
         {


### PR DESCRIPTION
This PR changes the retry logic so that a failed (and retryable) action will be retried at least another time even if the first run of the action took more time than the configured maximum retry duration.