### PR TITLE
Added a `Values.As<T>(T defaultValue)` extension method

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BoltV3IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BoltV3IT.cs
@@ -127,7 +127,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
                     : await session.WriteTransactionAsync(tx => tx.RunAsync("CALL dbms.listTransactions()"), txConfig);
 
                 // Then
-                var value = (await result.SingleAsync())["metaData"].ValueAs<IDictionary<string, object>>();
+                var value = (await result.SingleAsync())["metaData"].As<IDictionary<string, object>>();
                 value.Should().HaveCount(1).And.Contain(new KeyValuePair<string, object>("name", "Molly"));
             }
             finally

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverAsyncIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverAsyncIT.cs
@@ -66,7 +66,7 @@ namespace Neo4j.Driver.IntegrationTests.Routing
                     var result = await session.RunAsync("UNWIND range(1,10000) AS x RETURN sum(x)");
                     var read = await result.FetchAsync();
                     read.Should().BeTrue();
-                    result.Current[0].ValueAs<int>().Should().Be(10001 * 10000 / 2);
+                    result.Current[0].As<int>().Should().Be(10001 * 10000 / 2);
                     read = await result.FetchAsync();
                     read.Should().BeFalse();
                 }
@@ -107,7 +107,7 @@ namespace Neo4j.Driver.IntegrationTests.Routing
             var session = driver.AsyncSession();
             var result = await session.RunAsync("RETURN 1");
             await result.FetchAsync();
-            result.Current[0].ValueAs<int>().Should().Be(1);
+            result.Current[0].As<int>().Should().Be(1);
 
             driver.Dispose();
             var error = await Record.ExceptionAsync(() => session.RunAsync("RETURN 1"));
@@ -123,7 +123,7 @@ namespace Neo4j.Driver.IntegrationTests.Routing
             var session = driver.AsyncSession();
             var result = await session.RunAsync("RETURN 1");
             await result.FetchAsync();
-            result.Current[0].ValueAs<int>().Should().Be(1);
+            result.Current[0].As<int>().Should().Be(1);
 
             driver.Dispose();
             await session.CloseAsync();

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/BoltStubServerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/BoltStubServerTests.cs
@@ -53,8 +53,8 @@ namespace Neo4j.Driver.IntegrationTests.Stub
                         var records = await cursor.ToListAsync();
 
                         records.Count.Should().Be(2);
-                        records[0]["name"].ValueAs<string>().Should().Be("Alice");
-                        records[1]["name"].ValueAs<string>().Should().Be("Bob");
+                        records[0]["name"].As<string>().Should().Be("Alice");
+                        records[1]["name"].As<string>().Should().Be("Bob");
                     }
                     finally
                     {
@@ -118,9 +118,9 @@ namespace Neo4j.Driver.IntegrationTests.Stub
                         var records = await cursor.ToListAsync();
 
                         records.Count.Should().Be(3);
-                        records[0]["name"].ValueAs<string>().Should().Be("Alice");
-                        records[1]["name"].ValueAs<string>().Should().Be("Bob");
-                        records[2]["name"].ValueAs<string>().Should().Be("Eve");
+                        records[0]["name"].As<string>().Should().Be("Alice");
+                        records[1]["name"].As<string>().Should().Be("Bob");
+                        records[2]["name"].As<string>().Should().Be("Eve");
                     }
                     finally
                     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
@@ -562,7 +562,7 @@ namespace Neo4j.Driver.IntegrationTests.Types
             {
                 var cursor = await session.RunAsync(query);
                 var record = await cursor.SingleAsync();
-                var received = record[0].ValueAs<T>();
+                var received = record[0].As<T>();
 
                 received.Should().Be(expected);
             }
@@ -620,7 +620,7 @@ namespace Neo4j.Driver.IntegrationTests.Types
 
                 record.Keys.Should().HaveCount(1);
                 record[0].Should().Be(actual);
-                record[0].ValueAs<TSent>().Should().Be(value);
+                record[0].As<TSent>().Should().Be(value);
             }
             finally
             {
@@ -663,7 +663,7 @@ namespace Neo4j.Driver.IntegrationTests.Types
 
                 record.Keys.Should().HaveCount(1);
                 record[0].Should().BeEquivalentTo(actualAsList);
-                record[0].ValueAs<IList<TSent>>().Should().BeEquivalentTo(valueAsList);
+                record[0].As<IList<TSent>>().Should().BeEquivalentTo(valueAsList);
             }
             finally
             {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
@@ -98,7 +98,7 @@ namespace Neo4j.Driver.Tests
                 dict["credentials"].Should().Be("toufu");
                 dict["realm"].Should().Be("foo");
 
-                var nums = dict["parameters"].ValueAs<Dictionary<string, object>>();
+                var nums = dict["parameters"].As<Dictionary<string, object>>();
                 nums["One"].Should().Be(1);
                 nums["Two"].Should().Be(2);
                 nums["Three"].Should().Be(3);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
@@ -149,7 +149,7 @@ namespace Neo4j.Driver.Tests
                 int i = 0;
                 while (await cursor.FetchAsync())
                 {
-                    cursor.Current[0].ValueAs<string>().Should().Be($"record{i++}:key0");
+                    cursor.Current[0].As<string>().Should().Be($"record{i++}:key0");
                 }
 
                 i.Should().Be(5);
@@ -169,7 +169,7 @@ namespace Neo4j.Driver.Tests
                 int i = 0;
                 while (await cursor.FetchAsync())
                 {
-                    cursor.Current[0].ValueAs<string>().Should().Be($"record{i++}:key0");
+                    cursor.Current[0].As<string>().Should().Be($"record{i++}:key0");
                 }
 
                 i.Should().Be(6);
@@ -186,12 +186,12 @@ namespace Neo4j.Driver.Tests
 
                 var record = await cursor.PeekAsync();
                 record.Should().NotBeNull();
-                record[0].ValueAs<string>().Should().Be("record0:key0");
+                record[0].As<string>().Should().Be("record0:key0");
 
                 // not moving further no matter how many times are called
                 record = await cursor.PeekAsync();
                 record.Should().NotBeNull();
-                record[0].ValueAs<string>().Should().Be("record0:key0");
+                record[0].As<string>().Should().Be("record0:key0");
             }
 
             [Fact]
@@ -204,12 +204,12 @@ namespace Neo4j.Driver.Tests
 
                 var record = await cursor.PeekAsync();
                 record.Should().NotBeNull();
-                record[0].ValueAs<string>().Should().Be("record1:key0");
+                record[0].As<string>().Should().Be("record1:key0");
 
                 // not moving further no matter how many times are called
                 record = await cursor.PeekAsync();
                 record.Should().NotBeNull();
-                record[0].ValueAs<string>().Should().Be("record1:key0");
+                record[0].As<string>().Should().Be("record1:key0");
             }
 
             [Fact]
@@ -226,13 +226,13 @@ namespace Neo4j.Driver.Tests
 
                 var record = await cursor.PeekAsync();
                 record.Should().NotBeNull();
-                record[0].ValueAs<string>().Should().Be("record4:key0");
+                record[0].As<string>().Should().Be("record4:key0");
 
                 var moveNext = await cursor.FetchAsync();
                 moveNext.Should().BeTrue();
 
                 record.Should().NotBeNull();
-                record[0].ValueAs<string>().Should().Be("record4:key0");
+                record[0].As<string>().Should().Be("record4:key0");
 
                 record = await cursor.PeekAsync();
                 record.Should().BeNull();
@@ -250,13 +250,13 @@ namespace Neo4j.Driver.Tests
                 {
                     record = await cursor.PeekAsync();
                     record.Should().NotBeNull();
-                    record[0].ValueAs<string>().Should().Be($"record{i}:key0");
+                    record[0].As<string>().Should().Be($"record{i}:key0");
 
                     hasNext = await cursor.FetchAsync();
                     hasNext.Should().BeTrue();
 
                     // peeked record = current
-                    cursor.Current[0].ValueAs<string>().Should().Be($"record{i}:key0");
+                    cursor.Current[0].As<string>().Should().Be($"record{i}:key0");
                 }
 
                 record = await cursor.PeekAsync();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultCursorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultCursorTests.cs
@@ -289,12 +289,12 @@ namespace Neo4j.Driver.Tests
                 var read = await result.FetchAsync();
                 read.Should().BeTrue();
                 var record = result.Current;
-                record[0].ValueAs<string>().Should().Be("record0:key0");
+                record[0].As<string>().Should().Be("record0:key0");
 
                 read = await result.FetchAsync();
                 read.Should().BeTrue();
                 record = result.Current;
-                record[0].ValueAs<string>().Should().Be("record1:key0");
+                record[0].As<string>().Should().Be("record1:key0");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/StatementResultTests.cs
@@ -277,10 +277,10 @@ namespace Neo4j.Driver.Tests
             {
                 var result = ResultCreator.CreateResult(1, 3);
                 var record = result.First();
-                record[0].ValueAs<string>().Should().Be("record0:key0");
+                record[0].As<string>().Should().Be("record0:key0");
 
                 record = result.First();
-                record[0].ValueAs<string>().Should().Be("record1:key0");
+                record[0].As<string>().Should().Be("record1:key0");
             }
 
             [Fact]
@@ -290,11 +290,11 @@ namespace Neo4j.Driver.Tests
                 var enumerable = result.Take(1);
                 var records = result.Take(2).ToList();
 
-                records[0][0].ValueAs<string>().Should().Be("record0:key0");
-                records[1][0].ValueAs<string>().Should().Be("record1:key0");
+                records[0][0].As<string>().Should().Be("record0:key0");
+                records[1][0].As<string>().Should().Be("record1:key0");
 
                 records = enumerable.ToList();
-                records[0][0].ValueAs<string>().Should().Be("record2:key0");
+                records[0][0].As<string>().Should().Be("record2:key0");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
@@ -27,13 +27,41 @@ namespace Neo4j.Driver.Tests
 {
     public class ValueExtensionsTests
     {
+        public class AsWithDefaultPrimaryTypeMethod
+        {
+            [Fact]
+            public void ShouldConvertNullable()
+            {
+                object value = null;
+                var actual = value.As<bool?>(false);
+                actual.Value.Should().BeFalse();
+            }
+
+            [Fact]
+            public void ShouldConvertToDefault()
+            {
+                object value = null;
+                var actual = value.As(false);
+                actual.Should().BeFalse();
+            }
+
+            [Fact]
+            public void ShouldThrowExceptionWhenCastFromIntToList()
+            {
+                object value = 10;
+                var ex = Record.Exception(() => value.As(new List<int>()));
+                ex.Should().BeOfType<InvalidCastException>();
+                ex.Message.Should().StartWith("Invalid cast from 'System.Int32' to 'System.Collections.Generic.List`1[[System.Int32");
+            }
+        }
+
         public class AsPrimaryTypeMethod
         {
             [Fact]
             public void ShouldHandleLists()
             {
                 object value = new List<object> {"a", "b"};
-                var actual = value.ValueAs<List<string>>();
+                var actual = value.As<List<string>>();
                 actual.ToList().Should().HaveCount(2);
             }
 
@@ -41,7 +69,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldConvertNullToNullable()
             {
                 object value = null;
-                var actual = value.ValueAs<bool?>();
+                var actual = value.As<bool?>();
                 actual.HasValue.Should().BeFalse();
             }
 
@@ -49,7 +77,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldConvertNullToString()
             {
                 object value = null;
-                var actual = value.ValueAs<string>();
+                var actual = value.As<string>();
                 actual.Should().BeNull();
             }
 
@@ -57,7 +85,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldConvertNullToClass()
             {
                 object value = null;
-                var actual = value.ValueAs<INode>();
+                var actual = value.As<INode>();
                 actual.Should().BeNull();
             }
 
@@ -65,7 +93,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldThrowExceptionWhenConvertingFromNullToNotNullable()
             {
                 object value = null;
-                var ex = Record.Exception(() => value.ValueAs<bool>());
+                var ex = Record.Exception(() => value.As<bool>());
                 ex.Should().BeOfType<InvalidCastException>();
                 ex.Message.Should().Be("Unable to cast `null` to `System.Boolean`.");
             }
@@ -85,7 +113,7 @@ namespace Neo4j.Driver.Tests
             [InlineData(false, false)]
             public void ShouldConvertToNullable(object input, bool expected)
             {
-                var actual = input.ValueAs<bool?>();
+                var actual = input.As<bool?>();
                 actual.HasValue.Should().BeTrue();
                 actual.Value.Should().Be(expected);
             }
@@ -105,7 +133,7 @@ namespace Neo4j.Driver.Tests
             [InlineData(false, false)]
             public void ShouldConvertToBool(object input, bool expected)
             {
-                var actual = input.ValueAs<bool>();
+                var actual = input.As<bool>();
                 actual.Should().Be(expected);
             }
 
@@ -125,7 +153,7 @@ namespace Neo4j.Driver.Tests
             [InlineData(true, 1)]
             public void ShouldConvertToInt(object input, int expected)
             {
-                var actual = input.ValueAs<int>();
+                var actual = input.As<int>();
                 actual.Should().Be(expected);
             }
 
@@ -145,7 +173,7 @@ namespace Neo4j.Driver.Tests
             [InlineData(true, 1)]
             public void ShouldConvertToLong(object input, long expected)
             {
-                var actual = input.ValueAs<long>();
+                var actual = input.As<long>();
                 actual.Should().Be(expected);
             }
 
@@ -164,7 +192,7 @@ namespace Neo4j.Driver.Tests
             [InlineData(true, 1)]
             public void ShouldConvertToDouble(object input, double expected)
             {
-                var actual = input.ValueAs<double>();
+                var actual = input.As<double>();
                 (actual - expected).Should().BeLessThan(0.01);
             }
 
@@ -184,7 +212,7 @@ namespace Neo4j.Driver.Tests
             [InlineData(true, 1)]
             public void ShouldConvertToByte(object input, byte expected)
             {
-                var actual = input.ValueAs<byte>();
+                var actual = input.As<byte>();
                 actual.Should().Be(expected);
             }
 
@@ -196,7 +224,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldThrowExceptionWhenCastFromIntToList()
             {
                 object value = 10;
-                var ex = Record.Exception(() => value.ValueAs<List<int>>());
+                var ex = Record.Exception(() => value.As<List<int>>());
                 ex.Should().BeOfType<InvalidCastException>();
                 ex.Message.Should().StartWith("Invalid cast from 'System.Int32' to 'System.Collections.Generic.List`1[[System.Int32");
             }
@@ -204,7 +232,7 @@ namespace Neo4j.Driver.Tests
             public void ShouldThrowExceptionWhenCastFromListToInt()
             {
                 object value = new List<object> { "string", 2, true, "lala" };
-                var ex = Record.Exception(() => value.ValueAs<int>());
+                var ex = Record.Exception(() => value.As<int>());
                 ex.Should().BeOfType<InvalidCastException>();
             }
         }
@@ -216,7 +244,7 @@ namespace Neo4j.Driver.Tests
             {
                 IReadOnlyList<object> list = new List<object> { "string", 2, true, "lala" };
                 object obj = list;
-                var actual = obj.ValueAs<List<string>>();
+                var actual = obj.As<List<string>>();
                 actual.Count.Should().Be(4);
                 actual[0].Should().Be("string");
                 actual[1].Should().Be("2");
@@ -235,7 +263,7 @@ namespace Neo4j.Driver.Tests
                     new List<object> {31, 32, 33}
                 };
                 object obj = list;
-                var actual = obj.ValueAs<List<List<int>>>();
+                var actual = obj.As<List<List<int>>>();
                 actual.Count.Should().Be(4);
                 actual[0][0].Should().Be(1);
                 actual[1][1].Should().Be(12);
@@ -249,12 +277,12 @@ namespace Neo4j.Driver.Tests
                 IReadOnlyDictionary<string, object> dict =
                     new Dictionary<string, object> {{"key1", "string"}, {"key2", 2}, {"key3", true}, {"key4", "lala"}};
                 object obj = dict;
-                var actual = obj.ValueAs<Dictionary<string, string>>();
+                var actual = obj.As<Dictionary<string, string>>();
                 actual.Count.Should().Be(4);
-                actual["key1"].ValueAs<string>().Should().Be("string");
-                actual["key2"].ValueAs<string>().Should().Be("2");
-                actual["key3"].ValueAs<string>().Should().Be("True");
-                actual["key4"].ValueAs<string>().Should().Be("lala");
+                actual["key1"].As<string>().Should().Be("string");
+                actual["key2"].As<string>().Should().Be("2");
+                actual["key3"].As<string>().Should().Be("True");
+                actual["key4"].As<string>().Should().Be("lala");
             }
         }
 
@@ -267,15 +295,15 @@ namespace Neo4j.Driver.Tests
                     1L, 
                     new List<string> {"l1", "l2"}, 
                     new Dictionary<string, object> { {"key1", "value1"}, {"key2", 2 } });
-                var actual = obj.ValueAs<INode>();
+                var actual = obj.As<INode>();
                 actual.Id.Should().Be(1);
                 actual.Labels.Count.Should().Be(2);
                 actual.Labels[0].Should().Be("l1");
                 actual.Labels[1].Should().Be("l2");
-                actual.Properties["key1"].ValueAs<string>().Should().Be("value1");
-                actual.Properties["key2"].ValueAs<string>().Should().Be("2");
+                actual.Properties["key1"].As<string>().Should().Be("value1");
+                actual.Properties["key2"].As<string>().Should().Be("2");
 
-                obj.ValueAs<string>().Should().Be($"{obj.GetType()}");
+                obj.As<string>().Should().Be($"{obj.GetType()}");
             }
 
             [Fact]
@@ -284,13 +312,13 @@ namespace Neo4j.Driver.Tests
                 object obj = new Relationship(1, -2, -3, "Type",
                     new Dictionary<string, object> {{"key1", "value1"}, {"key2", 2}});
 
-                var actual = obj.ValueAs<IRelationship>();
+                var actual = obj.As<IRelationship>();
                 actual.Id.Should().Be(1);
                 actual.Type.Should().Be("Type");
-                actual.Properties["key1"].ValueAs<string>().Should().Be("value1");
-                actual.Properties["key2"].ValueAs<string>().Should().Be("2");
+                actual.Properties["key1"].As<string>().Should().Be("value1");
+                actual.Properties["key2"].As<string>().Should().Be("2");
 
-                obj.ValueAs<string>().Should().Be($"{obj.GetType()}");
+                obj.As<string>().Should().Be($"{obj.GetType()}");
             }
 
             [Fact]
@@ -307,14 +335,14 @@ namespace Neo4j.Driver.Tests
                     },
                     new List<IRelationship>());
 
-                var actual = obj.ValueAs<IPath>();
+                var actual = obj.As<IPath>();
                 actual.Start.Id.Should().Be(1);
                 actual.End.Id.Should().Be(1);
                 var node = actual.Nodes[0];
-                node.Properties["key1"].ValueAs<string>().Should().Be("value1");
-                node.Properties["key2"].ValueAs<string>().Should().Be("2");
+                node.Properties["key1"].As<string>().Should().Be("value1");
+                node.Properties["key2"].As<string>().Should().Be("2");
 
-                obj.ValueAs<string>().Should().Be($"{obj.GetType()}");
+                obj.As<string>().Should().Be($"{obj.GetType()}");
             }
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/ValueExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/ValueExtensions.cs
@@ -32,6 +32,41 @@ namespace Neo4j.Driver
         private static readonly TypeInfo DictionaryTypeInfo = typeof(IDictionary).GetTypeInfo();
 
         /// <summary>
+        /// A helper method to explicitly cast the value streamed back via Bolt to a local type,
+        /// with default fallback value.
+        /// </summary>
+        /// <param name="value">The value that streamed back via Bolt protocol, e.g.<see cref="IEntity.Properties"/>.</param>
+        /// <param name="defaultValue">Returns this value if the the value is null</param>
+        /// <typeparam name="T">
+        /// Supports for the following types (or nullable version of the following types if applies):
+        /// <see cref="short"/>,
+        /// <see cref="int"/>,
+        /// <see cref="long"/>,
+        /// <see cref="float"/>,
+        /// <see cref="double"/>,
+        /// <see cref="sbyte"/>,
+        /// <see cref="ushort"/>,
+        /// <see cref="uint"/>,
+        /// <see cref="ulong"/>,
+        /// <see cref="byte"/>,
+        /// <see cref="char"/>,
+        /// <see cref="bool"/>,
+        /// <see cref="string"/>,
+        /// <see cref="List{T}"/>,
+        /// <see cref="INode"/>,
+        /// <see cref="IRelationship"/>,
+        /// <see cref="IPath"/>.
+        /// Undefined support for other types that are not listed above.
+        /// No support for user-defined types, e.g. Person, Movie.
+        /// </typeparam>
+        /// <returns>The value of specified return type.</returns>
+        /// <remarks>Throws <see cref="InvalidCastException"/> if the specified cast is not possible.</remarks>
+        public static T As<T>(this object value, T defaultValue)
+        {
+            return value == null ? defaultValue : value.As<T>();
+        }
+
+        /// <summary>
         /// A helper method to explicitly cast the value streamed back via Bolt to a local type.
         /// </summary>
         /// <typeparam name="T">
@@ -147,11 +182,6 @@ namespace Neo4j.Driver
             }
 
             throw new InvalidCastException($"Unable to cast object of type `{sourceType}` to type `{typeof(T)}`.");
-        }
-
-        internal static T ValueAs<T>(this object value)
-        {
-            return As<T>(value);
         }
 
         private static T AsDictionary<T>(this IDictionary dict, TypeInfo typeInfo)


### PR DESCRIPTION
Removed `ValueAs` method as it is just a alias of `As`.