### PR TITLE
Update tests to run also with 4.0 servers

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/BoltTypesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/BoltTypesIT.cs
@@ -144,7 +144,7 @@ namespace Neo4j.Driver.IntegrationTests
         {
             using (var session = Driver.Session())
             {
-                var record = session.Run("RETURN {x} as y", new Dictionary<string, object> {{"x", input}}).Single();
+                var record = session.Run("RETURN $x as y", new Dictionary<string, object> {{"x", input}}).Single();
                 AssertEqual(record["y"], input);
             }
         }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/BookmarkIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/BookmarkIT.cs
@@ -111,7 +111,7 @@ namespace Neo4j.Driver.IntegrationTests
                 // Config the default server bookmark_ready_timeout to be something smaller than 30s to speed up this test
                 var exception = Record.Exception(() => session.BeginTransaction(session.LastBookmark + "0"));
                 exception.Should().BeOfType<TransientException>();
-                exception.Message.Should().Contain("Database not up to the requested version:");
+                exception.Message.Should().Contain("not up to the requested version:");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/CypherParametersIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/CypherParametersIT.cs
@@ -199,7 +199,7 @@ namespace Neo4j.Driver.IntegrationTests.DirectDriver
             }
         }
 
-        [RequireServerFact]
+        [RequireServerVersionLessThanFact("4.0.0")] // jmx procedure is not accessible
         public void ShouldHandleCallingProcedures()
         {
             using (var session = Driver.Session())

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/DirectDriver/DriverIT.cs
@@ -46,7 +46,7 @@ namespace Neo4j.Driver.IntegrationTests
             using (var session = Server.Driver.Session())
             {
                 var result = session.Run(
-                    "CREATE (a {value:{value}}) RETURN a.value", new Dictionary<string, object> {{"value", byteArray}});
+                    "CREATE (a {value:$value}) RETURN a.value", new Dictionary<string, object> {{"value", byteArray}});
                 // Then
                 foreach (var record in result)
                 {

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/ExternalBoltkitClusterInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/ExternalBoltkitClusterInstaller.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Neo4j.Driver.Internal.Routing;
+using static Neo4j.Driver.IntegrationTests.Internals.Neo4jSettingsHelper;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
@@ -40,7 +42,7 @@ namespace Neo4j.Driver.IntegrationTests.Internals
             if (Directory.Exists(ClusterDir))
             {
                 _commandRunner.Debug($"Found and using cluster installed at `{ClusterDir}`.");
-                // no need to redownload and change the password if already downloaded locally
+                // no need to re-download and change the password if already downloaded locally
                 return;
             }
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/ExternalBoltkitInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/ExternalBoltkitInstaller.cs
@@ -73,6 +73,14 @@ namespace Neo4j.Driver.IntegrationTests.Internals
                     {MaxThreadPoolSize, Pool500}
                 });
             }
+            // 4.0 servers by default have encryption off.
+            if (ServerVersion.Version(BoltkitHelper.ServerVersion()) >= ServerVersion.V4_0_0)
+            {
+                UpdateSettings(new Dictionary<string, string>
+                {
+                    {BoltTlsLevel, BoltTlsOptional}
+                });
+            }
         }
 
         public ISet<ISingleInstance> Start()

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/Neo4jSettingsHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/Neo4jSettingsHelper.cs
@@ -27,6 +27,9 @@ namespace Neo4j.Driver.IntegrationTests.Internals
         public const string MaxThreadPoolSize = "dbms.connector.bolt.thread_pool_max_size";
         public const string Pool500 = "500";
 
+        public const string BoltTlsLevel = "dbms.connector.bolt.tls_level";
+        public const string BoltTlsOptional = "OPTIONAL";
+
         /// <summary>
         ///     Updates the settings of the Neo4j server
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_reader_explicit.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_reader_explicit.script
@@ -1,16 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C:  RUN "BEGIN" {}
+C:  BEGIN {"mode":"r"}
+C:	RUN "RETURN $x" {"x": 1} {"mode": "r"}
     PULL_ALL
 S:	SUCCESS {}
-    SUCCESS {}
-C:	RUN "RETURN $x" {"x": 1}
-    PULL_ALL
-S:	SUCCESS {"fields": ["x"]}
+S:  SUCCESS {"fields": ["x"]}
     RECORD [1]
     SUCCESS {}
-C:  RUN "COMMIT" {}
-    PULL_ALL
-S:  SUCCESS {}
-    SUCCESS {}
+C:  COMMIT
+S:  SUCCESS {"bookmark": "aBookmark"}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_reader_func.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_reader_func.script
@@ -1,16 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C:  RUN "BEGIN" {}
-    PULL_ALL
-	RUN "RETURN $x" {"x": 1}
+C:  BEGIN {"mode":"r"}
+	RUN "RETURN $x" {"x": 1} {"mode":"r"}
     PULL_ALL
 S:	SUCCESS {}
-    SUCCESS {}
 	SUCCESS {"fields": ["x"]}
     RECORD [1]
     SUCCESS {}
-C:  RUN "COMMIT" {}
-    PULL_ALL
+C:  COMMIT
 S:  SUCCESS {}
-    SUCCESS {}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_reader_implicit.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_reader_implicit.script
@@ -1,7 +1,8 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C:  RUN "RETURN $x" {"x": 1}
+C:  RUN "RETURN $x" {"x": 1} {"mode": "r"}
     PULL_ALL
 S:  SUCCESS {"fields": ["x"]}
     RECORD [1]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_router.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_router.script
@@ -1,9 +1,9 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
-!: AUTO PULL_ALL
 
-S: SUCCESS {"server": "Neo4j/3.2.2"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+S: SUCCESS {"server": "Neo4j/3.5.12"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9003"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_writer_explicit.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_writer_explicit.script
@@ -1,16 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C:  RUN "BEGIN" {}
-    PULL_ALL
+C:  BEGIN {}
 S:	SUCCESS {}
-    SUCCESS {}
-C:	RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1}
+C:	RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1} {}
     PULL_ALL
 S:	SUCCESS {"fields": ["x"]}
     RECORD [1]
     SUCCESS {}
-C:  RUN "COMMIT" {}
-    PULL_ALL
+C:  COMMIT
 S:  SUCCESS {}
-    SUCCESS {}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_writer_func.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_writer_func.script
@@ -1,16 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C:  RUN "BEGIN" {}
-    PULL_ALL
-	RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1}
+C:  BEGIN {}
+	RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1} {}
     PULL_ALL
 S:	SUCCESS {}
-    SUCCESS {}
 	SUCCESS {"fields": ["x"]}
     RECORD [1]
     SUCCESS {}
-C:  RUN "COMMIT" {}
-    PULL_ALL
+C:  COMMIT
 S:  SUCCESS {}
-    SUCCESS {}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_writer_implicit.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/accessmode_writer_implicit.script
@@ -1,7 +1,8 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C:  RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1}
+C:  RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1} {}
     PULL_ALL
 S:  SUCCESS {"fields": ["x"]}
     RECORD [1]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/get_routing_table.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/get_routing_table.script
@@ -1,14 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-S: SUCCESS {"server": "Neo4j/3.2.2"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+S: SUCCESS {"server": "Neo4j/3.5.12"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Alice"]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/get_routing_table_only.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/get_routing_table_only.script
@@ -1,9 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-S: SUCCESS {"server": "Neo4j/3.2.2"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {}}
+S: SUCCESS {"server": "Neo4j/3.5.12"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001"], "role": "ROUTE"}]]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/get_routing_table_with_context.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/get_routing_table_with_context.script
@@ -1,14 +1,15 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-S: SUCCESS {"server": "Neo4j/3.2.3"}
-C: RUN "CALL dbms.cluster.routing.getRoutingTable({context})" {"context": {"policy": "my_policy", "region": "china"}}
+S: SUCCESS {"server": "Neo4j/3.5.12"}
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"policy": "my_policy", "region": "china"}} {}
    PULL_ALL
 S: SUCCESS {"fields": ["ttl", "servers"]}
    RECORD [9223372036854775807, [{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"],"role": "WRITE"}, {"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "READ"},{"addresses": ["127.0.0.1:9001", "127.0.0.1:9002"], "role": "ROUTE"}]]
    SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {}
+C: RUN "MATCH (n) RETURN n.name AS name" {} {}
    PULL_ALL
 S: SUCCESS {"fields": ["name"]}
    RECORD ["Alice"]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/multiple_bookmarks.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/multiple_bookmarks.script
@@ -1,16 +1,13 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
 
-C: RUN "BEGIN" {"bookmark": "neo4j:bookmark:v1:tx94", "bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+S: SUCCESS {}
+C: RUN "CREATE (n {name:'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
    SUCCESS {}
-C: RUN "CREATE (n {name:'Bob'})" {}
-   PULL_ALL
-S: SUCCESS {}
-   SUCCESS {}
-C: RUN "COMMIT" {}
-   PULL_ALL
-S: SUCCESS {}
-   SUCCESS {"bookmark": "neo4j:bookmark:v1:tx95"}
+C: COMMIT
+S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx95"}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/return_1.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/return_1.script
@@ -1,11 +1,12 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 !: AUTO PULL_ALL
-!: AUTO RUN "COMMIT" {}
-!: AUTO RUN "ROLLBACK" {}
-!: AUTO RUN "BEGIN" {}
+!: AUTO COMMIT
+!: AUTO ROLLBACK
+!: AUTO BEGIN {}
 
-C: RUN "RETURN 1" {}
+C: RUN "RETURN 1" {} {"mode": "r"}
    PULL_ALL
 S: SUCCESS {"fields": ["1"]}
    RECORD [1]

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/rollback_error.script
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Resources/rollback_error.script
@@ -1,11 +1,10 @@
-!: AUTO INIT
+!: BOLT 3
+!: AUTO HELLO
 !: AUTO RESET
 
-C: RUN "BEGIN" {}
-   PULL_ALL
+C: BEGIN {}
 S: SUCCESS {}
-   SUCCESS {}
-C: RUN "CREATE (n {name:'Alice'}) RETURN n.name AS name" {}
+C: RUN "CREATE (n {name:'Alice'}) RETURN n.name AS name" {} {}
    PULL_ALL
 S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to run any"}
    IGNORED

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverStressIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverStressIT.cs
@@ -130,7 +130,8 @@ namespace Neo4j.Driver.IntegrationTests
                 ConnectionAcquisitionTimeout = TimeSpan.FromMinutes(5),
                 ConnectionTimeout = Config.InfiniteInterval,
                 MaxConnectionPoolSize = 100,
-                DriverLogger = new TestDriverLogger(Output)
+                DriverLogger = new TestDriverLogger(Output),
+                EncryptionLevel = EncryptionLevel.None
             };
 
             var connectionSettings = new ConnectionSettings(AuthToken, config);

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverTestBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/RoutingDriver/RoutingDriverTestBase.cs
@@ -28,6 +28,7 @@ namespace Neo4j.Driver.IntegrationTests
     [Collection(CCIntegrationCollection.CollectionName)]
     public abstract class RoutingDriverTestBase : IDisposable
     {
+        protected static Config NoEncryption = new Config {EncryptionLevel = EncryptionLevel.None};
         protected ITestOutputHelper Output { get; }
         protected CausalCluster Cluster { get; }
         protected IAuthToken AuthToken { get; }
@@ -44,7 +45,8 @@ namespace Neo4j.Driver.IntegrationTests
 
             var config = new Config
             {
-                DriverLogger = new TestDriverLogger(output)
+                DriverLogger = new TestDriverLogger(output),
+                EncryptionLevel = EncryptionLevel.None
             };
             Driver = GraphDatabase.Driver(RoutingServer, AuthToken, config);
         }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/StubTests/AccessModeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/StubTests/AccessModeTests.cs
@@ -21,8 +21,10 @@ using System.Linq;
 using System.Text;
 using FluentAssertions;
 using Neo4j.Driver.IntegrationTests.Internals;
+using Neo4j.Driver.IntegrationTests.Shared;
 using Neo4j.Driver.V1;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Neo4j.Driver.IntegrationTests.StubTests
 {

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Types/PointsIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Types/PointsIT.cs
@@ -85,7 +85,7 @@ namespace Neo4j.Driver.IntegrationTests.Types
         public void ShouldSendAndReceive()
         {
             TestSendAndReceive(new Point(WGS84SrId, 51.24923585, 0.92723724));
-            TestSendAndReceive(new Point(WGS843DSrId, 22.86211019, 171.61820439, 0.1230987));
+            TestSendAndReceive(new Point(WGS843DSrId, 22.86211019, 71.61820439, 0.1230987));
             TestSendAndReceive(new Point(CartesianSrId, 39.111748, -76.775635));
             TestSendAndReceive(new Point(Cartesian3DSrId, 39.111748, -76.775635, 19.2937302840));
         }
@@ -138,24 +138,38 @@ namespace Neo4j.Driver.IntegrationTests.Types
             switch (sequence % 4)
             {
                 case 0:
-                    return new Point(WGS84SrId, GenerateRandomDouble(), GenerateRandomDouble());
+                    return new Point(WGS84SrId, GenerateRandomX(), GenerateRandomY());
                 case 1:
-                    return new Point(WGS843DSrId, GenerateRandomDouble(), GenerateRandomDouble(),
-                        GenerateRandomDouble());
+                    return new Point(WGS843DSrId, GenerateRandomX(), GenerateRandomY(),
+                        GenerateRandomZ());
                 case 2:
-                    return new Point(CartesianSrId, GenerateRandomDouble(), GenerateRandomDouble());
+                    return new Point(CartesianSrId, GenerateRandomX(), GenerateRandomY());
                 case 3:
-                    return new Point(Cartesian3DSrId, GenerateRandomDouble(), GenerateRandomDouble(),
-                        GenerateRandomDouble());
+                    return new Point(Cartesian3DSrId, GenerateRandomX(), GenerateRandomY(),
+                        GenerateRandomZ());
                 default:
                     throw new ArgumentOutOfRangeException();
             }
         }
 
-        private double GenerateRandomDouble()
+        private double GenerateRandomX()
         {
-            return _random.Next(-179, 179) + _random.NextDouble();
+            return GenerateRandomDouble(-179, 179);
         }
 
+        private double GenerateRandomY()
+        {
+            return GenerateRandomDouble(-89, 89);
+        }
+
+        private double GenerateRandomZ()
+        {
+            return GenerateRandomDouble(0, 100);
+        }
+
+        private double GenerateRandomDouble(int min, int max)
+        {
+            return _random.Next(min, max) + _random.NextDouble();
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -14,6 +14,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
 using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Logging;
@@ -35,6 +37,7 @@ namespace Neo4j.Driver.Tests
                 config.DriverLogger.Should().BeOfType<NullLogger>();
                 config.MaxIdleConnectionPoolSize.Should().Be(500);
                 config.LoadBalancingStrategy.Should().Be(LoadBalancingStrategy.LeastConnected);
+                config.ConnectionTimeout.Should().Be(TimeSpan.FromSeconds(30));
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
@@ -76,7 +76,7 @@ namespace Neo4j.Driver.Tests.Routing
                 var statement = discovery.DiscoveryProcedure(mock.Object);
                 // Then
                 statement.Text.Should()
-                    .Be("CALL dbms.cluster.routing.getRoutingTable({context})");
+                    .Be("CALL dbms.cluster.routing.getRoutingTable($context)");
                 statement.Parameters["context"].Should().Be(context);
             }
         }
@@ -336,7 +336,7 @@ namespace Neo4j.Driver.Tests.Routing
         {
             var pairs = new List<Tuple<IRequestMessage, IResponseMessage>>
             {
-                MessagePair(new RunMessage("CALL dbms.cluster.routing.getRoutingTable({context})",
+                MessagePair(new RunMessage("CALL dbms.cluster.routing.getRoutingTable($context)",
                         new Dictionary<string, object> {{"context", routingContext}}),
                     SuccessMessage(new List<object> {"ttl", "servers"})),
                 MessagePair(new RecordMessage(recordFields)),

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
@@ -25,7 +25,6 @@ namespace Neo4j.Driver.Internal
 {
     internal class ConnectionSettings
     {
-        internal const int DefaultDnsTtl = 30 * 1000;
         internal const string DefaultUserAgent = "neo4j-dotnet/1.7";
 
         public IAuthToken AuthToken { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
@@ -42,7 +42,7 @@ namespace Neo4j.Driver.Internal.Routing
         {
             if (ServerVersion.Version(connection.Server.Version) >= ServerVersion.V3_2_0)
             {
-                return new Statement($"CALL {GetRoutingTableProcedure}({{context}})",
+                return new Statement($"CALL {GetRoutingTableProcedure}($context)",
                     new Dictionary<string, object> {{"context", _context}});
             }
             else

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ServerVersion.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ServerVersion.cs
@@ -33,6 +33,7 @@ namespace Neo4j.Driver.Internal.Routing
         public static readonly ServerVersion V3_2_0 = new ServerVersion(3, 2, 0);
         public static readonly ServerVersion V3_3_0 = new ServerVersion(3, 3, 0);
         public static readonly ServerVersion V3_4_0 = new ServerVersion(3, 4, 0);
+        public static readonly ServerVersion V4_0_0 = new ServerVersion(4, 0, 0);
 
         private static readonly Regex VersionRegex = new Regex(@"(Neo4j/)?(\d+)\.(\d+)(?:\.)?(\d*)(\.|-|\+)?([0-9A-Za-z-.]*)?", RegexOptions.IgnoreCase);
 

--- a/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Config.cs
@@ -102,7 +102,7 @@ namespace Neo4j.Driver.V1
         /// <list type="bullet">
         /// <item><see cref="EncryptionLevel"/> : <c><see cref="EncryptionLevel"/> Encrypted</c> </item>
         /// <item><see cref="TrustStrategy"/> : <c><see cref="TrustStrategy"/>TrustAllCertificates</c> </item>
-        /// <item><see cref="ConnectionTimeout"/>: <c>5s</c> </item>
+        /// <item><see cref="ConnectionTimeout"/>: <c>30s</c> </item>
         /// <item><see cref="SocketKeepAlive"/>: <c>true</c></item>
         /// <item><see cref="Ipv6Enabled"/>: <c>true</c></item>
         /// <br></br>
@@ -219,7 +219,7 @@ namespace Neo4j.Driver.V1
         /// <summary>
         /// Gets or sets the connection timeout when establishing a connection with a server.
         /// </summary>
-        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(5);
+        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Gets or sets the socket keep alive option.


### PR DESCRIPTION
The 1.7 driver should be able to run against 4.0 servers using BoltV3.
This PR changes some tests that fails on 4.0 servers due to cypher syntax change in 4.0.
Also we updated boltkit scripts to using BoltV3.