### PR TITLE
Added `SessionConfigBuilder#ForDatabase` method

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BoltV4IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BoltV4IT.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit.Abstractions;
 using static Neo4j.Driver.IntegrationTests.VersionComparison;
+using static Neo4j.Driver.SessionConfigBuilder;
 
 namespace Neo4j.Driver.IntegrationTests.Direct
 {
@@ -230,7 +231,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
 
         private static async Task CreateDatabase(IDriver driver, string name)
         {
-            var session = driver.AsyncSession(o => o.WithDatabase("system"));
+            var session = driver.AsyncSession(ForDatabase("system"));
             try
             {
                 var cursor = await session.RunAsync($"CREATE DATABASE {name}");
@@ -244,7 +245,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
 
         private static async Task DropDatabase(IDriver driver, string name)
         {
-            var session = driver.AsyncSession(o => o.WithDatabase("system"));
+            var session = driver.AsyncSession(ForDatabase("system"));
             try
             {
                 var cursor = await session.RunAsync($"DROP DATABASE {name}");

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/ResultIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/ResultIT.cs
@@ -21,6 +21,7 @@ using FluentAssertions;
 using Neo4j.Driver.Internal.Util;
 using Xunit.Abstractions;
 using static Neo4j.Driver.IntegrationTests.VersionComparison;
+using static Neo4j.Driver.SessionConfigBuilder;
 using static Neo4j.Driver.Tests.ConsumableCursorTests;
 using Record = Xunit.Record;
 
@@ -78,7 +79,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         public async Task ShouldContainsSystemUpdates()
         {
             // Ensure that a constraint exists
-            var session = Driver.AsyncSession(o => o.WithDatabase("system"));
+            var session = Driver.AsyncSession(ForDatabase("system"));
             try
             {
                 var cursor = await session.RunAsync("CREATE USER foo SET PASSWORD 'bar'");

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
@@ -21,6 +21,7 @@ using FluentAssertions;
 using Neo4j.Driver.TestUtil;
 using Xunit.Abstractions;
 using static Neo4j.Driver.IntegrationTests.VersionComparison;
+using static Neo4j.Driver.SessionConfigBuilder;
 
 namespace Neo4j.Driver.IntegrationTests.Routing
 {
@@ -106,7 +107,7 @@ namespace Neo4j.Driver.IntegrationTests.Routing
 
         private static async Task<Bookmark> CreateDatabase(IDriver driver, string name)
         {
-            var session = driver.AsyncSession(o => o.WithDatabase("system"));
+            var session = driver.AsyncSession(ForDatabase("system"));
             try
             {
                 await session.WriteTransactionAsync(txc => txc.RunAndConsumeAsync($"CREATE DATABASE {name}"));

--- a/Neo4j.Driver/Neo4j.Driver/SessionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/SessionConfig.cs
@@ -125,6 +125,16 @@ namespace Neo4j.Driver
         }
 
         /// <summary>
+        /// Returns an action on <see cref="SessionConfigBuilder"/> which will set the database name to the value specified.
+        /// </summary>
+        /// <param name="database">the database name</param>
+        /// <returns>An action of <see cref="SessionConfigBuilder"/></returns>
+        public static Action<SessionConfigBuilder> ForDatabase(string database)
+        {
+            return o => o.WithDatabase(database);
+        }
+
+        /// <summary>
         /// Sets the database the constructed session will connect to.
         /// </summary>
         /// <param name="database">the database name</param>


### PR DESCRIPTION
make it easier to give database name to a session.