### PR TITLE
Fixing the internal classes that is leaked to public API.

### DIFF
--- a/Neo4j.Driver.Docs.shfbproj
+++ b/Neo4j.Driver.Docs.shfbproj
@@ -51,7 +51,7 @@
     <CopyrightHref>http://neo4j.com</CopyrightHref>
     <ContentPlacement>AboveNamespaces</ContentPlacement>
     <NamespaceSummaries>
-      <NamespaceSummaryItem name="Neo4j.Driver.V1" isDocumented="True">The base namespace for interaction with the Neo4j .NET Driver.</NamespaceSummaryItem>
+      <NamespaceSummaryItem name="Neo4j.Driver" isDocumented="True">The base namespace for interaction with the Neo4j .NET Driver.</NamespaceSummaryItem>
     </NamespaceSummaries>
     <SaveComponentCacheCapacity>100</SaveComponentCacheCapacity>
     <PlugInConfigurations>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/FetchSizeUtil.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/FetchSizeUtil.cs
@@ -22,7 +22,7 @@ namespace Neo4j.Driver.Internal
     /// <summary>
     /// A util class for handling fetch size.
     /// </summary>
-    public static class FetchSizeUtil
+    internal static class FetchSizeUtil
     {
         /// <summary>
         /// Validate the fetch size.


### PR DESCRIPTION
Adding the missing summary for `Neo4j.Driver` namespace