### PR TITLE
Modified the back pressure logic.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxSession.cs
@@ -66,7 +66,7 @@ namespace Neo4j.Driver.Internal
 
         public IRxResult Run(Query query, Action<TransactionConfigBuilder> action)
         {
-            return new InternalRxResult(Observable.FromAsync(() => _session.RunAsync(query, action, false))
+            return new RxResult(Observable.FromAsync(() => _session.RunAsync(query, action, false))
                 .Cast<IInternalResultCursor>());
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxTransaction.cs
@@ -47,7 +47,7 @@ namespace Neo4j.Driver.Internal
 
         public IRxResult Run(Query query)
         {
-            return new InternalRxResult(Observable.FromAsync(() => _transaction.RunAsync(query))
+            return new RxResult(Observable.FromAsync(() => _transaction.RunAsync(query))
                 .Cast<IInternalResultCursor>());
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxResult.cs
@@ -26,7 +26,7 @@ using static Neo4j.Driver.Internal.ErrorExtensions;
 
 namespace Neo4j.Driver.Internal
 {
-    internal class InternalRxResult : IRxResult
+    internal class RxResult : IRxResult
     {
         private enum StreamingState
         {
@@ -43,7 +43,7 @@ namespace Neo4j.Driver.Internal
         private volatile int _streaming = (int) StreamingState.Ready;
         private readonly ILogger _logger;
 
-        public InternalRxResult(IObservable<IInternalResultCursor> resultCursor,
+        public RxResult(IObservable<IInternalResultCursor> resultCursor,
             ILogger logger = null)
         {
             _resultCursor = resultCursor.Replay().AutoConnect();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxResultTests.cs
@@ -46,7 +46,7 @@ namespace Neo4j.Driver.Reactive.Internal
             public void ShouldReturnKeys()
             {
                 var cursor = CreateResultCursor(3, 0);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyKeys(result, "key01", "key02", "key03");
             }
@@ -56,7 +56,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 0);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecords(result, keys, 0);
                 VerifyKeys(result, keys);
@@ -67,7 +67,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 0);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifySummary(result);
                 VerifyKeys(result, keys);
@@ -77,7 +77,7 @@ namespace Neo4j.Driver.Reactive.Internal
             public void ShouldReturnKeysRepeatable()
             {
                 var cursor = CreateResultCursor(3, 0);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyKeys(result, "key01", "key02", "key03");
                 VerifyKeys(result, "key01", "key02", "key03");
@@ -90,7 +90,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecords(result, keys, 5);
             }
@@ -100,7 +100,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecords(result, keys, 5);
                 VerifyResultConsumedError(result.Records());
@@ -110,7 +110,7 @@ namespace Neo4j.Driver.Reactive.Internal
             public void ShouldReturnSummary()
             {
                 var cursor = CreateResultCursor(3, 0, "my query");
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifySummary(result, "my query");
             }
@@ -119,7 +119,7 @@ namespace Neo4j.Driver.Reactive.Internal
             public void ShouldNotReturnRecordsIfSummaryIsObserved()
             {
                 var cursor = CreateResultCursor(3, 0, "my query");
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifySummary(result, "my query");
                 VerifyResultConsumedError(result.Records());
@@ -129,7 +129,7 @@ namespace Neo4j.Driver.Reactive.Internal
             public void ShouldReturnSummaryRepeatable()
             {
                 var cursor = CreateResultCursor(3, 0, "my query");
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifySummary(result, "my query");
                 VerifySummary(result, "my query");
@@ -142,7 +142,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 5, "my query");
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyKeys(result, keys);
                 VerifyRecords(result, keys, 5);
@@ -154,7 +154,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 5, "my query");
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecords(result, keys, 5);
                 VerifySummary(result, "my query");
@@ -165,7 +165,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var keys = new[] {"key01", "key02", "key03"};
                 var cursor = CreateResultCursor(3, 5, "my query");
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyKeys(result, keys);
                 VerifySummary(result, "my query");
@@ -175,7 +175,7 @@ namespace Neo4j.Driver.Reactive.Internal
             public void ShouldNotAllowConcurrentRecordObservers()
             {
                 var cursor = CreateResultCursor(3, 20, "my query", 1000);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 result.Records()
                     .Merge(result.Records())
@@ -196,7 +196,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Keys(), exc);
             }
@@ -206,7 +206,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Keys(), exc);
                 VerifyError(result.Keys(), exc);
@@ -218,7 +218,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Records(), exc);
             }
@@ -228,7 +228,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor), new TestLogger(Output.WriteLine));
+                var result = new RxResult(Observable.Return(cursor), new TestLogger(Output.WriteLine));
 
                 VerifyError(result.Records(), exc);
 
@@ -241,7 +241,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), exc);
             }
@@ -251,7 +251,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), exc);
                 VerifyError(result.Consume(), exc);
@@ -263,7 +263,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var exc = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(exc);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Keys(), exc);
                 VerifyError(result.Records(), exc);
@@ -278,7 +278,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new AuthenticationException("unauthenticated");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyKeys(result, "key01", "key02");
             }
@@ -289,7 +289,7 @@ namespace Neo4j.Driver.Reactive.Internal
                 var keys = new[] {"key01", "key02"};
                 var failure = new DatabaseException("code", "message");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecordsAndError(result, keys, 5, failure);
             }
@@ -300,7 +300,7 @@ namespace Neo4j.Driver.Reactive.Internal
                 var keys = new[] {"key01", "key02"};
                 var failure1 = new DatabaseException("code", "message");
                 var cursor = CreateFailingResultCursor(failure1, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecordsAndError(result, keys, 5, failure1);
                 VerifyResultConsumedError(result.Records());
@@ -312,7 +312,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new DatabaseException("code", "message");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), failure);
             }
@@ -322,7 +322,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new DatabaseException("code", "message");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), failure);
                 VerifyError(result.Consume(), failure);
@@ -335,7 +335,7 @@ namespace Neo4j.Driver.Reactive.Internal
                 var keys = new[] {"key01", "key02"};
                 var failure = new DatabaseException("code", "message");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecordsAndError(result, keys, 5, failure);
                 VerifyNoError(result.Consume());
@@ -349,7 +349,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new AuthenticationException("unauthenticated");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyKeys(result, "key01", "key02");
             }
@@ -360,7 +360,7 @@ namespace Neo4j.Driver.Reactive.Internal
                 var keys = new[] {"key01", "key02"};
                 var failure = new DatabaseException("code", "message");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyRecordsAndError(result, keys, 5, failure);
             }
@@ -370,7 +370,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), failure);
             }
@@ -380,7 +380,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new ClientException("some error");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), failure);
                 VerifyError(result.Consume(), failure);
@@ -391,7 +391,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var failure = new AuthenticationException("unauthenticated");
                 var cursor = CreateFailingResultCursor(failure, 2, 5);
-                var result = new InternalRxResult(Observable.Return(cursor));
+                var result = new RxResult(Observable.Return(cursor));
 
                 VerifyError(result.Consume(), failure);
                 VerifyKeys(result, "key01", "key02");

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxSessionTests.cs
@@ -40,7 +40,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var rxSession = new InternalRxSession(Mock.Of<IInternalAsyncSession>(), Mock.Of<IRxRetryLogic>());
 
-                rxSession.Run("RETURN 1").Should().BeOfType<InternalRxResult>();
+                rxSession.Run("RETURN 1").Should().BeOfType<RxResult>();
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxTransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxTransactionTests.cs
@@ -35,7 +35,7 @@ namespace Neo4j.Driver.Reactive.Internal
             {
                 var rxTxc = new InternalRxTransaction(Mock.Of<IInternalAsyncTransaction>());
 
-                rxTxc.Run("RETURN 1").Should().BeOfType<InternalRxResult>();
+                rxTxc.Run("RETURN 1").Should().BeOfType<RxResult>();
             }
 
             [Fact]

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4.cs
@@ -129,7 +129,7 @@ namespace Neo4j.Driver.Internal.Protocol
             return BoltProtocolFactory.ProtocolVersion.Version4;
         }
 
-        private static Func<ResultCursorBuilder, long, long, Task> RequestMore(IConnection connection,
+        private static Func<IResultStreamBuilder, long, long, Task> RequestMore(IConnection connection,
             SummaryBuilder summaryBuilder, IBookmarkTracker bookmarkTracker)
         {
             return async (streamBuilder, id, n) =>
@@ -142,7 +142,7 @@ namespace Neo4j.Driver.Internal.Protocol
             };
         }
 
-        private static Func<ResultCursorBuilder, long, Task> CancelRequest(IConnection connection,
+        private static Func<IResultStreamBuilder, long, Task> CancelRequest(IConnection connection,
             SummaryBuilder summaryBuilder, IBookmarkTracker bookmarkTracker)
         {
             return async (streamBuilder, id) =>


### PR DESCRIPTION
The result builder impl originally will only pull more records when the recordsreceived on the client are fully consumed.
Thus without consuming the records locally, there will be no more records auto pulled from server.
This PR loose the auto pull logic to fetch from server when there are not too many records (70*fetchSize).
When there are too many records, then the auto pull will be disabled until enough records have been consumed (30%*fetchSize).