### PR TITLE
Fix a typo in a test.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
@@ -286,7 +286,7 @@ namespace Neo4j.Driver.IntegrationTests.Stress
             public ClusterAddresses(IEnumerable<string> followers, IEnumerable<string> readReplicas)
             {
                 Followers = followers.ToHashSet();
-                ReadReplicas = followers.ToHashSet();
+                ReadReplicas = readReplicas.ToHashSet();
             }
 
             public ISet<string> Followers { get; }


### PR DESCRIPTION
Two tests would fail in cultures like the Greek one where decimal points are represented by commas, instead of dots.