### PR TITLE
Config encryption and trust strategy via connection URI scheme

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/CertificateTrustIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/CertificateTrustIT.cs
@@ -148,7 +148,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
 
         private IDriver SetupWithCustomResolver(Uri overridenUri, Config config)
         {
-            var connectionSettings = new ConnectionSettings(Server.AuthToken, config);
+            var connectionSettings = new ConnectionSettings(overridenUri, Server.AuthToken, config);
             connectionSettings.SocketSettings.HostResolver =
                 new CustomHostResolver(Server.BoltUri, connectionSettings.SocketSettings.HostResolver);
             var bufferSettings = new BufferSettings(config);

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/EncryptionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/EncryptionIT.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) 2002-2020 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Neo4j.Driver.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Neo4j.Driver.IntegrationTests.Direct
+{
+    public class EncryptionIT : DirectDriverTestBase
+    {
+        public EncryptionIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
+            : base(output, fixture)
+        {
+        }
+
+        [RequireServerFact]
+        public async Task ShouldBeAbleToConnectWithInsecureConfig()
+        {
+            using (var driver = GraphDatabase.Driver(ServerEndPoint, AuthToken,
+                o => o
+                    .WithEncryptionLevel(EncryptionLevel.Encrypted)
+                    .WithTrustManager(TrustManager.CreateInsecure())))
+            {
+                await VerifyConnectivity(driver);
+            }
+        }
+
+        [RequireServerFact]
+        public async Task ShouldBeAbleToConnectUsingInsecureUri()
+        {
+            var builder = new UriBuilder("bolt+ssc", ServerEndPoint.Host, ServerEndPoint.Port);
+            using (var driver = GraphDatabase.Driver(builder.Uri, AuthToken))
+            {
+                await VerifyConnectivity(driver);
+            }
+        }
+
+        private static async Task VerifyConnectivity(IDriver driver)
+        {
+            var session = driver.AsyncSession();
+
+            try
+            {
+                var cursor = await session.RunAsync("RETURN 2 as Number");
+                var records = await cursor.ToListAsync(r => r["Number"].As<int>());
+
+                records.Should().BeEquivalentTo(2);
+            }
+            finally
+            {
+                await session.CloseAsync();
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/StressTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/StressTest.cs
@@ -593,7 +593,7 @@ namespace Neo4j.Driver.IntegrationTests.Stress
                 Logger = new StressTestLogger(_output, LoggingEnabled)
             };
 
-            var connectionSettings = new ConnectionSettings(_authToken, config);
+            var connectionSettings = new ConnectionSettings(_databaseUri, _authToken, config);
             var bufferSettings = new BufferSettings(config);
             var connectionFactory = new MonitoredPooledConnectionFactory(
                 new PooledConnectionFactory(connectionSettings, bufferSettings, config.Logger));

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -55,6 +55,28 @@ namespace Neo4j.Driver.Tests
                 config.MaxConnectionPoolSize.Should().Be(50);
                 config.MaxIdleConnectionPoolSize.Should().Be(20);
             }
+
+            [Fact]
+            public void ShouldDefaultToNoEncryptionAndNoTrust()
+            {
+                var config = Config.Default;
+                config.NullableEncryptionLevel.Should().BeNull();
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.TrustManager.Should().BeNull();
+            }
+
+            [Fact]
+            public void ShouldSetEncryptionAndTrust()
+            {
+                var config = new Config
+                {
+                    EncryptionLevel = EncryptionLevel.None,
+                    TrustManager = null
+                };
+                config.NullableEncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.TrustManager.Should().BeNull();
+            }
         }
 
         public class ConfigBuilderTests
@@ -107,10 +129,11 @@ namespace Neo4j.Driver.Tests
             }
 
             [Fact]
-            public void WithEncryptionLevelShouldModifyTheSingleValue()
+            public void WithEncryptionLevelShouldModifyTheNullableValue()
             {
                 var config = Config.Builder.WithEncryptionLevel(EncryptionLevel.None).Build();
                 config.EncryptionLevel.Should().Be(EncryptionLevel.None);
+                config.NullableEncryptionLevel.Should().Be(EncryptionLevel.None);
                 config.TrustManager.Should().BeNull();
                 config.Logger.Should().BeOfType<NullLogger>();
                 config.MaxIdleConnectionPoolSize.Should().Be(500);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
@@ -57,7 +57,7 @@ namespace Neo4j.Driver.Tests.Connector
                         ConnectionTimeout = TimeSpan.FromSeconds(1),
                         HostResolver = new SystemHostResolver(),
                         EncryptionManager =
-                            new EncryptionManager(EncryptionLevel.None, null, null)
+                            new EncryptionManager(false, null)
                     });
 
                 // ReSharper disable once PossibleNullReferenceException
@@ -79,7 +79,7 @@ namespace Neo4j.Driver.Tests.Connector
                     ConnectionTimeout = TimeSpan.FromSeconds(10),
                     HostResolver = new SystemHostResolver(),
                     EncryptionManager =
-                        new EncryptionManager(EncryptionLevel.None, null, null)
+                        new EncryptionManager(false, null)
                 };
                 var client = new TcpSocketClient(socketSettings);
 
@@ -113,7 +113,7 @@ namespace Neo4j.Driver.Tests.Connector
                 {
                     ConnectionTimeout = TimeSpan.FromSeconds(1),
                     HostResolver = new SystemHostResolver(),
-                    EncryptionManager = new EncryptionManager(EncryptionLevel.None, null, null)
+                    EncryptionManager = new EncryptionManager(false, null)
                 });
 
                 // ReSharper disable once PossibleNullReferenceException

--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -74,7 +74,13 @@ namespace Neo4j.Driver
         /// <summary>
         /// The use of encryption for all the connections created by the <see cref="IDriver"/>.
         /// </summary>
-        public EncryptionLevel EncryptionLevel { get; internal set; } = EncryptionLevel.None;
+        public EncryptionLevel EncryptionLevel
+        {
+            get => NullableEncryptionLevel.GetValueOrDefault(EncryptionLevel.None);
+            internal set => NullableEncryptionLevel = value;
+        }
+
+        internal EncryptionLevel? NullableEncryptionLevel { get; set; }
 
         /// <summary>
         /// Specifies which <see cref="TrustManager"/> implementation should be used while establishing trust via TLS.
@@ -147,7 +153,7 @@ namespace Neo4j.Driver
         public TimeSpan ConnectionIdleTimeout { get; internal set; } = InfiniteInterval;
 
         /// <summary>
-        /// The maximum connection lifetime on pooled connecitons.
+        /// The maximum connection lifetime on pooled connections.
         /// A connection that has been created for longer than the given time will be closed once it is seen.
         /// Use <see cref="InfiniteInterval"/> to disable connection lifetime checking.
         /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
@@ -50,7 +50,7 @@ namespace Neo4j.Driver
         /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
         public ConfigBuilder WithEncryptionLevel(EncryptionLevel level)
         {
-            _config.EncryptionLevel = level;
+            _config.NullableEncryptionLevel = level;
             return this;
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
@@ -28,9 +28,9 @@ namespace Neo4j.Driver.Internal
         public string UserAgent { get; }
         public SocketSettings SocketSettings { get; }
 
-        public ConnectionSettings(IAuthToken auth, Config config)
-        : this(auth, new EncryptionManager(config.EncryptionLevel, config.TrustManager, config.Logger),
-              config.ConnectionTimeout, config.SocketKeepAlive, config.Ipv6Enabled)
+        public ConnectionSettings(Uri uri, IAuthToken auth, Config config)
+            : this(auth, EncryptionManager.Create(uri, config.NullableEncryptionLevel, config.TrustManager, config.Logger),
+                config.ConnectionTimeout, config.SocketKeepAlive, config.Ipv6Enabled)
         {
         }
 


### PR DESCRIPTION
Added new URI scheme support. Beside `bolt` and `neo4j`, we also support `+s` for connecting with encryption and chain trust strategy.
And `+ssc` for connecting with encyption but insecure trust strategy.

When configuring encryption and trust both via uri and config, an error will be generated instead.