### PR TITLE
Adding IAsyncSession#SessionConfig

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Reactive/IRxSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/IRxSession.cs
@@ -154,5 +154,10 @@ namespace Neo4j.Driver
         /// <typeparam name="T">the desired return type</typeparam>
         /// <returns>an empty reactive stream</returns>
         IObservable<T> Close<T>();
+
+        /// <summary>
+        /// Gets the session configuration
+        /// </summary>
+        SessionConfig SessionConfig { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxSession.cs
@@ -36,6 +36,7 @@ namespace Neo4j.Driver.Internal
         }
 
         public Bookmark LastBookmark => _session.LastBookmark;
+        public SessionConfig SessionConfig => _session.SessionConfig;
 
         #region Run Methods
 

--- a/Neo4j.Driver/Neo4j.Driver.Simple/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/ISession.cs
@@ -149,5 +149,10 @@ namespace Neo4j.Driver
         /// <param name="action">Given a <see cref="TransactionConfigBuilder"/>, defines how to set the configurations for the new transaction.</param>
         /// <returns>A stream of result values and associated metadata.</returns>
         IResult Run(Query query, Action<TransactionConfigBuilder> action);
+
+        /// <summary>
+        /// Gets the session configuration back
+        /// </summary>
+        SessionConfig SessionConfig { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalSession.cs
@@ -36,6 +36,7 @@ namespace Neo4j.Driver.Internal
         }
 
         public Bookmark LastBookmark => _session.LastBookmark;
+        public SessionConfig SessionConfig => _session.SessionConfig;
 
         public IResult Run(string Query)
         {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/BookmarkTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/BookmarkTests.cs
@@ -22,7 +22,7 @@ using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver;
 using Xunit;
-using static Neo4j.Driver.Tests.SessionTests;
+using static Neo4j.Driver.Tests.AsyncSessionTests;
 
 namespace Neo4j.Driver.Tests
 {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/BeginMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/BeginMessageSerializerTests.cs
@@ -48,7 +48,7 @@ namespace Neo4j.Driver.Internal.IO.MessageSerializers.V3
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer();
 
-            writer.Write(new BeginMessage(null, Bookmark.From(SessionTests.FakeABookmark(123)), TimeSpan.FromMinutes(1),
+            writer.Write(new BeginMessage(null, Bookmark.From(AsyncSessionTests.FakeABookmark(123)), TimeSpan.FromMinutes(1),
                 new Dictionary<string, object>
                 {
                     {"username", "MollyMostlyWhite"}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/RunWithMetadataMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/RunWithMetadataMessageSerializerTests.cs
@@ -54,7 +54,7 @@ namespace Neo4j.Driver.Internal.IO.MessageSerializers.V3
             });
 
             writer.Write(new RunWithMetadataMessage(query, null,
-                Bookmark.From(SessionTests.FakeABookmark(123)), TimeSpan.FromMinutes(1),
+                Bookmark.From(AsyncSessionTests.FakeABookmark(123)), TimeSpan.FromMinutes(1),
                 new Dictionary<string, object>
                 {
                     {"username", "MollyMostlyWhite"}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/RunWithMetadataMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/RunWithMetadataMessageSerializerTests.cs
@@ -43,7 +43,7 @@ namespace Neo4j.Driver.Internal.IO.MessageSerializers.V4
             });
 
             writer.Write(new RunWithMetadataMessage(query, "my-database",
-                Bookmark.From(SessionTests.FakeABookmark(123)), TimeSpan.FromMinutes(1),
+                Bookmark.From(AsyncSessionTests.FakeABookmark(123)), TimeSpan.FromMinutes(1),
                 new Dictionary<string, object>
                 {
                     {"username", "MollyMostlyWhite"}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV3Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV3Tests.cs
@@ -213,7 +213,7 @@ namespace Neo4j.Driver.Internal.Protocol
             public async Task ShouldSyncIfValidBookmarkGiven()
             {
                 var mockConn = NewConnectionWithMode();
-                var bookmark = Bookmark.From(SessionTests.FakeABookmark(234));
+                var bookmark = Bookmark.From(AsyncSessionTests.FakeABookmark(234));
 
                 await BoltV3.BeginTransactionAsync(mockConn.Object, null, bookmark, null);
 
@@ -296,7 +296,7 @@ namespace Neo4j.Driver.Internal.Protocol
             [Fact]
             public async Task ShouldRunPullAllSync()
             {
-                var mockConn = SessionTests.MockedConnectionWithSuccessResponse();
+                var mockConn = AsyncSessionTests.MockedConnectionWithSuccessResponse();
                 var query = new Query("lalala");
 
                 await BoltV3.RunInExplicitTransactionAsync(mockConn.Object, query, true);
@@ -312,7 +312,7 @@ namespace Neo4j.Driver.Internal.Protocol
             [Fact]
             public async Task ResultBuilderShouldObtainServerInfoFromConnection()
             {
-                var mockConn = SessionTests.MockedConnectionWithSuccessResponse();
+                var mockConn = AsyncSessionTests.MockedConnectionWithSuccessResponse();
                 var query = new Query("lalala");
 
                 await BoltV3.RunInExplicitTransactionAsync(mockConn.Object, query, true);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4Tests.cs
@@ -157,7 +157,7 @@ namespace Neo4j.Driver.Internal.Protocol
             [Fact]
             public async Task ShouldRunPullAllSync()
             {
-                var mockConn = SessionTests.MockedConnectionWithSuccessResponse();
+                var mockConn = AsyncSessionTests.MockedConnectionWithSuccessResponse();
                 var query = new Query("lalala");
 
                 await BoltV4.RunInExplicitTransactionAsync(mockConn.Object, query, true);
@@ -172,7 +172,7 @@ namespace Neo4j.Driver.Internal.Protocol
             [Fact]
             public async Task ResultBuilderShouldObtainServerInfoFromConnection()
             {
-                var mockConn = SessionTests.MockedConnectionWithSuccessResponse();
+                var mockConn = AsyncSessionTests.MockedConnectionWithSuccessResponse();
                 var query = new Query("lalala");
 
                 await BoltV4.RunInExplicitTransactionAsync(mockConn.Object, query, true);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -49,7 +49,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Logging" />
-  </ItemGroup>
 </Project>

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxSessionTests.cs
@@ -230,5 +230,33 @@ namespace Neo4j.Driver.Reactive.Internal
                 asyncSession.Verify(x => x.CloseAsync(), Times.Once);
             }
         }
+
+        public class LastBookmark
+        {
+            [Fact]
+            public void ShouldDelegateToAsyncSession()
+            {
+                var asyncSession = new Mock<IInternalAsyncSession>();
+                var rxSession = new InternalRxSession(asyncSession.Object, Mock.Of<IRxRetryLogic>());
+
+                var bookmark = rxSession.LastBookmark;
+
+                asyncSession.Verify(x => x.LastBookmark, Times.Once);
+            }
+        }
+
+        public class SessionConfig
+        {
+            [Fact]
+            public void ShouldDelegateToAsyncSession()
+            {
+                var asyncSession = new Mock<IInternalAsyncSession>();
+                var rxSession = new InternalRxSession(asyncSession.Object, Mock.Of<IRxRetryLogic>());
+
+                var bookmark = rxSession.SessionConfig;
+
+                asyncSession.Verify(x => x.SessionConfig, Times.Once);
+            }
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Simple/Internal/InternalSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Simple/Internal/InternalSessionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2002-2020 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Neo4j.Driver.Internal;
+using Neo4j.Driver.Reactive;
+using Neo4j.Driver.Tests;
+using Xunit;
+using static Microsoft.Reactive.Testing.ReactiveAssert;
+using static Neo4j.Driver.Tests.Assertions;
+
+namespace Neo4j.Driver.Simple.Internal
+{
+    public static class InternalSessionTests
+    {
+        public class LastBookmark
+        {
+            [Fact]
+            public void ShouldDelegateToAsyncSession()
+            {
+                var asyncSession = new Mock<IInternalAsyncSession>();
+                var session = new InternalSession(asyncSession.Object, Mock.Of<IRetryLogic>(),
+                    Mock.Of<BlockingExecutor>());
+
+                var bookmark = session.LastBookmark;
+
+                asyncSession.Verify(x => x.LastBookmark, Times.Once);
+            }
+        }
+
+        public class SessionConfig
+        {
+            [Fact]
+            public void ShouldDelegateToAsyncSession()
+            {
+                var asyncSession = new Mock<IInternalAsyncSession>();
+                var session = new InternalSession(asyncSession.Object, Mock.Of<IRetryLogic>(),
+                    Mock.Of<BlockingExecutor>());
+
+                var bookmark = session.SessionConfig;
+
+                asyncSession.Verify(x => x.SessionConfig, Times.Once);
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -23,7 +23,7 @@ using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Protocol;
 using Neo4j.Driver;
 using Xunit;
-using static Neo4j.Driver.Tests.SessionTests;
+using static Neo4j.Driver.Tests.AsyncSessionTests;
 using static Xunit.Record;
 
 namespace Neo4j.Driver.Tests

--- a/Neo4j.Driver/Neo4j.Driver/IAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IAsyncSession.cs
@@ -187,5 +187,10 @@ namespace Neo4j.Driver
         /// </param>
         /// <returns>A task of a stream of result values and associated metadata.</returns>
         Task<IResultCursor> RunAsync(Query query, Action<TransactionConfigBuilder> action);
+
+        /// <summary>
+        /// Gets the session configurations back
+        /// </summary>
+        SessionConfig SessionConfig { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -50,15 +50,15 @@ namespace Neo4j.Driver.Internal
         private readonly long _fetchSize;
 
         public AsyncSession(IConnectionProvider provider, ILogger logger, IAsyncRetryLogic retryLogic = null,
-            AccessMode defaultMode = AccessMode.Write, string database = null, Bookmark bookmark = null,
-            bool reactive = false, long fetchSize = Config.Infinite)
+            string database = null, AccessMode defaultMode = AccessMode.Write,
+            Bookmark bookmark = null, long fetchSize = Config.Infinite, bool reactive = false)
         {
-            _logger = logger;
             _connectionProvider = provider;
+            _logger = logger;
             _retryLogic = retryLogic;
             _reactive = reactive;
-            _database = database;
 
+            _database = database;
             _defaultMode = defaultMode;
             _fetchSize = fetchSize;
             UpdateBookmark(bookmark);
@@ -68,6 +68,9 @@ namespace Neo4j.Driver.Internal
         {
             return RunAsync(query, action, true);
         }
+
+        public SessionConfig SessionConfig { internal set; get; }
+
         public Task<IResultCursor> RunAsync(string query, Action<TransactionConfigBuilder> action)
         {
             return RunAsync(new Query(query), action);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -75,9 +75,10 @@ namespace Neo4j.Driver.Internal
 
             var sessionConfig = ConfigBuilders.BuildSessionConfig(action);
 
-            var session = new AsyncSession(_connectionProvider, _logger, _retryLogic, sessionConfig.DefaultAccessMode,
-                sessionConfig.Database, Bookmark.From(sessionConfig.Bookmarks ?? Array.Empty<Bookmark>()), reactive,
-                ParseFetchSize(sessionConfig.FetchSize));
+            var session = new AsyncSession(_connectionProvider, _logger, _retryLogic,
+                sessionConfig.Database, sessionConfig.DefaultAccessMode,
+                Bookmark.From(sessionConfig.Bookmarks ?? Array.Empty<Bookmark>()),
+                ParseFetchSize(sessionConfig.FetchSize), reactive) {SessionConfig = sessionConfig};
 
             if (IsClosed)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
@@ -65,7 +65,7 @@ namespace Neo4j.Driver.Internal.Routing
             var multiDb = connection.SupportsMultidatabase();
             var sessionAccessMode = multiDb ? AccessMode.Read : AccessMode.Write;
             var sessionDb = multiDb ? "system" : null;
-            var session = new AsyncSession(provider, _logger, null, sessionAccessMode, sessionDb, bookmark);
+            var session = new AsyncSession(provider, _logger, null, sessionDb, sessionAccessMode, bookmark);
             try
             {
                 var stmt = DiscoveryProcedure(connection, database);


### PR DESCRIPTION
to retrieve configuration back after a session is created.
However this field is read-only. It also cannot be used as a configuration for another session.
In order to use the "same configuration" among different sessions, a user should use a function such as
```
void ConfigureSession(SessionConfigBuilder builder) =>
    builder.WithDefaultAccessMode(AccessMode.Read)
           .WithDatabase("neo4j");

driver.Session(ConfigureSession);
```