### PR TITLE
Added support to run cluster stress tests with a remote cluster

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/CausalCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/CausalCluster.cs
@@ -22,18 +22,26 @@ using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using Neo4j.Driver;
+using Neo4j.Driver.TestUtil;
+using Xunit.Abstractions;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
-    public class CausalCluster : IDisposable
+    public class CausalCluster : ICausalCluster
     {
         private static readonly TimeSpan ClusterOnlineTimeout = TimeSpan.FromMinutes(2);
 
         private readonly ExternalBoltkitClusterInstaller _installer = new ExternalBoltkitClusterInstaller();
-        public ISet<ISingleInstance> Members { get; }
+        private ISet<ISingleInstance> Members { get; }
+
+        public Uri BoltRoutingUri => AnyCore()?.BoltRoutingUri;
 
         // Assume the whole cluster use exact the same authToken
-        public IAuthToken AuthToken => Members?.First().AuthToken;
+        public IAuthToken AuthToken => AnyCore()?.AuthToken;
+        public void Configure(ConfigBuilder builder)
+        {
+            // no special modification to driver config
+        }
 
         public CausalCluster()
         {
@@ -59,9 +67,9 @@ namespace Neo4j.Driver.IntegrationTests.Internals
             }
         }
 
-        public ISingleInstance AnyCore()
+        private ISingleInstance AnyCore()
         {
-            return Members.First();
+            return Members?.First();
         }
 
         public bool IsRunning()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ExistingCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ExistingCluster.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) 2002-2020 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Castle.Core.Internal;
+using FluentAssertions;
+using Neo4j.Driver;
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    public class ExistingCluster : ICausalCluster
+    {
+        private const string ClusterUri = "NEO4J_URI";
+        private const string ClusterPassword = "NEO4J_PASSWORD";
+        private const string ClusterUser = "NEO4J_USER";
+
+        public void Dispose()
+        {
+        }
+
+        public static bool IsClusterProvided()
+        {
+            var uri = Environment.GetEnvironmentVariable(ClusterUri);
+            var password = Environment.GetEnvironmentVariable(ClusterPassword);
+            // both of the two above env var should be provided.
+            return !uri.IsNullOrEmpty() && !password.IsNullOrEmpty();
+        }
+
+        private static string GetEnvOrThrow(string env)
+        {
+            var value = Environment.GetEnvironmentVariable(env);
+            if (value.IsNullOrEmpty())
+                throw new ArgumentException($"Missing env variable {env}");
+            return value;
+        }
+
+        private static string GetEnvOrDefault(string env, string defaultValue)
+        {
+            var value = Environment.GetEnvironmentVariable(env);
+            return value.IsNullOrEmpty() ? defaultValue : value;
+        }
+
+        public Uri BoltRoutingUri => new Uri(GetEnvOrThrow(ClusterUri));
+
+        public IAuthToken AuthToken => AuthTokens.Basic(
+            GetEnvOrDefault(ClusterUser, Neo4jDefaultInstallation.User),
+            GetEnvOrThrow(ClusterPassword));
+        public void Configure(ConfigBuilder builder)
+        {
+            builder.WithEncryptionLevel(EncryptionLevel.Encrypted);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ICausalCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ICausalCluster.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2002-2020 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit.Abstractions;
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    public interface ICausalCluster : IDisposable
+    {
+        Uri BoltRoutingUri { get; }
+
+        IAuthToken AuthToken { get; }
+
+        void Configure(ConfigBuilder builder);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/LocalStandAloneInstance.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/LocalStandAloneInstance.cs
@@ -15,12 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Neo4j.Driver;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
     public class LocalStandAloneInstance : SingleInstance, IStandAlone
     {
+        private const string UsingLocalServer = "DOTNET_DRIVER_USING_LOCAL_SERVER";
         public LocalStandAloneInstance() :
             base(Neo4jDefaultInstallation.HttpUri, Neo4jDefaultInstallation.BoltUri, null,
                 Neo4jDefaultInstallation.Password)
@@ -34,5 +36,12 @@ namespace Neo4j.Driver.IntegrationTests.Internals
         }
 
         public IDriver Driver { get; }
+
+        public static bool IsServerProvided()
+        {
+            // If a system flag is set, then we use the local single server instead
+            return bool.TryParse(Environment.GetEnvironmentVariable(UsingLocalServer), out var usingLocalServer) &&
+                   usingLocalServer;
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.IntegrationTests.Routing
         public BoltV4IT(ITestOutputHelper output, CausalClusterIntegrationTestFixture fixture)
             : base(output, fixture)
         {
-            _driver = GraphDatabase.Driver(Cluster.AnyCore().BoltRoutingUri, Cluster.AuthToken,
+            _driver = GraphDatabase.Driver(Cluster.BoltRoutingUri, Cluster.AuthToken,
                 o => o.WithLogger(TestLogger.Create(output)));
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverTestBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverTestBase.cs
@@ -27,10 +27,10 @@ namespace Neo4j.Driver.IntegrationTests.Routing
     public abstract class RoutingDriverTestBase : IDisposable
     {
         protected ITestOutputHelper Output { get; }
-        protected CausalCluster Cluster { get; }
+        protected ICausalCluster Cluster { get; }
         protected IAuthToken AuthToken { get; }
 
-        protected string RoutingServer => Cluster.AnyCore().BoltRoutingUri.ToString();
+        protected string RoutingServer => Cluster.BoltRoutingUri.ToString();
         protected string WrongServer => "neo4j://localhost:1234";
         protected IDriver Driver { get; }
 
@@ -41,7 +41,11 @@ namespace Neo4j.Driver.IntegrationTests.Routing
             AuthToken = Cluster.AuthToken;
 
             Driver = GraphDatabase.Driver(RoutingServer, AuthToken,
-                o => o.WithLogger(new TestLogger(output)));
+                builder =>
+                {
+                    builder.WithLogger(TestLogger.Create(output));
+                    Cluster.Configure(builder);
+                });
         }
 
         public virtual void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
@@ -34,7 +34,7 @@ namespace Neo4j.Driver.IntegrationTests.Stress
         private readonly CausalClusterIntegrationTestFixture _cluster;
 
         public CausalClusterStressTests(ITestOutputHelper output, CausalClusterIntegrationTestFixture cluster) :
-            base(output, cluster.Cluster.AnyCore().BoltRoutingUri, cluster.Cluster.AuthToken)
+            base(output, cluster.Cluster.BoltRoutingUri, cluster.Cluster.AuthToken, cluster.Cluster.Configure)
         {
             _cluster = cluster;
         }


### PR DESCRIPTION
Command to run:
NEO4J_URI=uri_to_remote_cluster NEO4J_PASSWORD=password_to_remote_cluster dotnet test --filter DisplayName~CausalClusterStressTests