### PR TITLE
Run cluster tests with remote servers

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/CausalCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/CausalCluster.cs
@@ -21,13 +21,19 @@ using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
-    public class CausalCluster : IDisposable
+    public class CausalCluster : ICausalCluster
     {
         private readonly ExternalBoltkitClusterInstaller _installer = new ExternalBoltkitClusterInstaller();
-        public ISet<ISingleInstance> Members { get; }
+        private ISet<ISingleInstance> Members { get; }
+        public Uri BoltRoutingUri => AnyCore()?.BoltRoutingUri;
 
         // Assume the whole cluster use exact the same authToken
-        public IAuthToken AuthToken => Members?.First().AuthToken;
+        public IAuthToken AuthToken => AnyCore()?.AuthToken;
+
+        public void Configure(IConfigBuilder builder)
+        {
+            builder.WithEncryptionLevel(EncryptionLevel.None);
+        }
 
         public CausalCluster()
         {
@@ -51,9 +57,9 @@ namespace Neo4j.Driver.IntegrationTests.Internals
             }
         }
 
-        public ISingleInstance AnyCore()
+        private ISingleInstance AnyCore()
         {
-            return Members.First();
+            return Members?.First();
         }
 
         public bool IsRunning()

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/ExistingCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/ExistingCluster.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2002-2020 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Castle.Core.Internal;
+using Neo4j.Driver.V1;
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    public class ExistingCluster : ICausalCluster
+    {
+        private const string ClusterUri = "NEO4J_URI";
+        private const string ClusterPassword = "NEO4J_PASSWORD";
+        private const string ClusterUser = "NEO4J_USER";
+
+        public void Dispose()
+        {
+        }
+
+        public static bool IsClusterProvided()
+        {
+            var uri = Environment.GetEnvironmentVariable(ClusterUri);
+            var password = Environment.GetEnvironmentVariable(ClusterPassword);
+            // both of the two above env var should be provided.
+            return !uri.IsNullOrEmpty() && !password.IsNullOrEmpty();
+        }
+
+        private static string GetEnvOrThrow(string env)
+        {
+            var value = Environment.GetEnvironmentVariable(env);
+            if (value.IsNullOrEmpty())
+                throw new ArgumentException($"Missing env variable {env}");
+            return value;
+        }
+
+        private static string GetEnvOrDefault(string env, string defaultValue)
+        {
+            var value = Environment.GetEnvironmentVariable(env);
+            return value.IsNullOrEmpty() ? defaultValue : value;
+        }
+
+        public Uri BoltRoutingUri => new Uri(GetEnvOrThrow(ClusterUri));
+
+        public IAuthToken AuthToken => AuthTokens.Basic(
+            GetEnvOrDefault(ClusterUser, Neo4jDefaultInstallation.User),
+            GetEnvOrThrow(ClusterPassword));
+        public void Configure(IConfigBuilder builder)
+        {
+            builder.WithEncryptionLevel(EncryptionLevel.Encrypted);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/ICausalCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/Cluster/ICausalCluster.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2002-2020 "Neo4j,"
+// Neo4j Sweden AB [http://neo4j.com]
+//
+// This file is part of Neo4j.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Neo4j.Driver.V1;
+
+namespace Neo4j.Driver.IntegrationTests.Internals
+{
+    public interface ICausalCluster : IDisposable
+    {
+        Uri BoltRoutingUri { get; }
+
+        IAuthToken AuthToken { get; }
+
+        void Configure(IConfigBuilder builder);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/IntegrationTestFixture.cs
@@ -26,13 +26,10 @@ namespace Neo4j.Driver.IntegrationTests
     {
         public IStandAlone StandAlone { get; }
 
-        private const string UsingLocalServer = "DOTNET_DRIVER_USING_LOCAL_SERVER";
-
         public StandAloneIntegrationTestFixture()
         {
             // If a system flag is set, then we use the local single server instead
-            if (bool.TryParse(GetEnvironmentVariable(UsingLocalServer), out var usingLocalServer) &&
-                usingLocalServer)
+            if (LocalStandAloneInstance.IsServerProvided())
             {
                 StandAlone = new LocalStandAloneInstance();
             }
@@ -63,24 +60,31 @@ namespace Neo4j.Driver.IntegrationTests
 
     public class CausalClusterIntegrationTestFixture : IDisposable
     {
-        public CausalCluster Cluster { get; }
+        public ICausalCluster Cluster { get; }
 
         public CausalClusterIntegrationTestFixture()
         {
-            var isClusterSupported = BoltkitHelper.IsClusterSupported();
-            if (!isClusterSupported.Item1)
+            if (ExistingCluster.IsClusterProvided())
             {
-                return;
+                Cluster = new ExistingCluster();
             }
+            else
+            {
+                var isClusterSupported = BoltkitHelper.IsClusterSupported();
+                if (!isClusterSupported.Item1)
+                {
+                    return;
+                }
 
-            try
-            {
-                Cluster = new CausalCluster();
-            }
-            catch (Exception)
-            {
-                Dispose();
-                throw;
+                try
+                {
+                    Cluster = new CausalCluster();
+                }
+                catch (Exception)
+                {
+                    Dispose();
+                    throw;
+                }
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/LocalStandAloneInstance.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/LocalStandAloneInstance.cs
@@ -15,12 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.IntegrationTests.Internals
 {
     public class LocalStandAloneInstance : SingleInstance, IStandAlone
     {
+        private const string UsingLocalServer = "DOTNET_DRIVER_USING_LOCAL_SERVER";
         public LocalStandAloneInstance() :
             base(Neo4jDefaultInstallation.HttpUri, Neo4jDefaultInstallation.BoltUri, null, Neo4jDefaultInstallation.Password)
         {
@@ -33,5 +35,12 @@ namespace Neo4j.Driver.IntegrationTests.Internals
         }
 
         public IDriver Driver { get; }
+
+        public static bool IsServerProvided()
+        {
+            // If a system flag is set, then we use the local single server instead
+            return bool.TryParse(Environment.GetEnvironmentVariable(UsingLocalServer), out var usingLocalServer) &&
+                   usingLocalServer;
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/Neo4jDefaultInstallation.cs
+++ b/Neo4j.Driver/Neo4j.Driver.IntegrationTests/Internals/StandAlone/Neo4jDefaultInstallation.cs
@@ -24,6 +24,7 @@ namespace Neo4j.Driver.IntegrationTests.Internals
 {
     public class Neo4jDefaultInstallation
     {
+        public const string User = "neo4j";
         public const string Password = "neo4j";
         public const string HttpUri = "http://localhost:7474";
         public const string BoltUri = "bolt://localhost:7687";

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -33,11 +33,13 @@ namespace Neo4j.Driver.Internal
         private readonly IMetrics _metrics;
         public Uri Uri { get; }
 
+        public Config Config { get; }
+
         private const AccessMode DefaultAccessMode = AccessMode.Write;
         private const string NullBookmark = null;
 
         internal Driver(Uri uri, IConnectionProvider connectionProvider, IRetryLogic retryLogic, IDriverLogger logger,
-            IMetrics metrics=null)
+            IMetrics metrics = null, Config config = null)
         {
             Throw.ArgumentNullException.IfNull(connectionProvider, nameof(connectionProvider));
 
@@ -46,6 +48,7 @@ namespace Neo4j.Driver.Internal
             _connectionProvider = connectionProvider;
             _retryLogic = retryLogic;
             _metrics = metrics;
+            Config = config;
         }
 
         private bool IsClosed => _closedMarker > 0;

--- a/Neo4j.Driver/Neo4j.Driver/V1/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/GraphDatabase.cs
@@ -236,7 +236,7 @@ namespace Neo4j.Driver.V1
                     throw new NotSupportedException($"Unsupported URI scheme: {parsedUri.Scheme}");
             }
 
-            return new Internal.Driver(parsedUri, connectionProvider, retryLogic, logger, metrics);
+            return new Internal.Driver(parsedUri, connectionProvider, retryLogic, logger, metrics, config);
         }
 
         private static void EnsureNoRoutingContext(Uri uri, IDictionary<string, string> routingContext)


### PR DESCRIPTION
This PR backports the changes to 4.0 to enable running cluster stress tests.
However as this version of driver does not have a cluster stress test, we enable the cluster test to run with remote cluster instead.