### PR TITLE
Fixed #413 for `4.1`

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
@@ -22,7 +22,7 @@ namespace Neo4j.Driver.Internal
 {
     internal class ConnectionSettings
     {
-        internal const string DefaultUserAgent = "neo4j-dotnet/1.7";
+        internal const string DefaultUserAgent = "neo4j-dotnet/4.1";
 
         public IAuthToken AuthToken { get; }
         public string UserAgent { get; }


### PR DESCRIPTION
Sets the `DefaultUserAgent` to be `neo4j-dotnet/4.1`