### PR TITLE
Do not close testkit connection upon driver error

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Exceptions/ExceptionManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Exceptions/ExceptionManager.cs
@@ -6,40 +6,17 @@ namespace Neo4j.Driver.Tests.TestBackend
 {
     internal static class ExceptionManager
     {
-        private static Dictionary<Type, string> TypeMap { get; set; } = new Dictionary<Type, string>()
-        {
-            { typeof(Neo4jException),                   "Neo4jError" },
-            { typeof(ClientException),                  "ClientError" },
-            { typeof(TransientException),               "DriverError" },        //Should maybe Transient error, talk to Peter or Martin
-            { typeof(DatabaseException),                "DatabaseError" },
-            { typeof(ServiceUnavailableException),      "ServiceUnavailableError" },
-            { typeof(SessionExpiredException),          "SessionExpiredError" },
-            { typeof(ProtocolException),                "ProtocolError" },
-            { typeof(SecurityException),                "SecurityError" },
-            { typeof(AuthenticationException),          "AuthenticationError" },
-            { typeof(ValueTruncationException),         "ValueTruncationError" },
-            { typeof(ValueOverflowException),           "ValueOverflowError" },
-            { typeof(FatalDiscoveryException),          "FatalDiscoveryError" },
-            { typeof(ResultConsumedException),          "ResultConsumedError" }
-        };
-             
-
         internal static ProtocolResponse GenerateExceptionResponse(Exception ex)
-        {   
-            string exceptionName;
+        {
             string exceptionMessage = (ex.InnerException != null) ? ex.InnerException.Message : ex.Message;
 
-            if (!TypeMap.ContainsKey(ex.GetType()))
-                exceptionName = "BackendError";             //This handles all system exceptions.
-            else
-                exceptionName = TypeMap[ex.GetType()];
-
-            ProtocolException newError = (ProtocolException)ProtocolObjectFactory.CreateObject(Protocol.Types.ProtocolException);
-            newError.ExceptionObj = ex;
-
+            if (ex is Neo4jException) {
+                ProtocolException newError = (ProtocolException)ProtocolObjectFactory.CreateObject(Protocol.Types.ProtocolException);
+                newError.ExceptionObj = ex;
+                return new ProtocolResponse("DriverError", new { id = newError.uniqueId, msg = exceptionMessage } );
+            }
             Trace.WriteLine($"Exception thrown {exceptionMessage}\n{ex.StackTrace}");
-
-            return new ProtocolResponse(exceptionName, new { id = newError.uniqueId, msg = exceptionMessage } );
+            return new ProtocolResponse("BackendError", new { msg = exceptionMessage } );
         }
-    }    
+    }
 }


### PR DESCRIPTION
It is legal for testkit frontend to generate errors in driver,
connection should not be closed after that.

Only two types of errors supported by frontend, BackendError and
DriverError. Sending anything else from backend will cause exceptions on
the frontend, remap all neo4j errors to DriverError, the rest to
BackendError.