### PR TITLE
Map NotSupportedException as test backend driver error

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs
@@ -55,6 +55,13 @@ namespace Neo4j.Driver.Tests.TestBackend
                                 // Generate "driver" exception something happened within the driver
                                 await responseWriter.WriteResponseAsync(ExceptionManager.GenerateExceptionResponse(ex));
                             }
+                            catch (NotSupportedException ex)
+                            {
+                                // Get this sometimes during protocol handshake, like when connectiong with bolt:// on server
+                                // with TLS. Could be a dirty read in the driver or a write from TLS server that causes strange
+                                // version received..
+                                await responseWriter.WriteResponseAsync(ExceptionManager.GenerateExceptionResponse(ex));
+                            }
                         }
                     }
                     catch (IOException ex)

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Exceptions/ExceptionManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Exceptions/ExceptionManager.cs
@@ -10,7 +10,7 @@ namespace Neo4j.Driver.Tests.TestBackend
         {
             string exceptionMessage = (ex.InnerException != null) ? ex.InnerException.Message : ex.Message;
 
-            if (ex is Neo4jException) {
+            if (ex is Neo4jException || ex is NotSupportedException) {
                 ProtocolException newError = (ProtocolException)ProtocolObjectFactory.CreateObject(Protocol.Types.ProtocolException);
                 newError.ExceptionObj = ex;
                 return new ProtocolResponse("DriverError", new { id = newError.uniqueId, msg = exceptionMessage } );


### PR DESCRIPTION
When driver connects to TLS endpoint believing it shouldn't be TLS it
interprets TLS data from server as Bolt version and throws this
exception. It could also be the effect of a dirty read that triggers
when server closes the connection.