### PR TITLE
testkit: Allow overriding default fetch size with continous stream (-1)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/NewSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/NewSession.cs
@@ -48,8 +48,8 @@ namespace Neo4j.Driver.Tests.TestBackend
             if(!string.IsNullOrEmpty(data.database)) configBuilder.WithDatabase(data.database);            
             if(!string.IsNullOrEmpty(data.accessMode)) configBuilder.WithDefaultAccessMode(GetAccessMode);
             if(data.bookmarks.Count > 0) configBuilder.WithBookmarks(Bookmark.From(data.bookmarks.ToArray()));
-            if(data.fetchSize != -1) configBuilder.WithFetchSize(data.fetchSize);      
-            
+            configBuilder.WithFetchSize(data.fetchSize);
+
             configBuilder.Build();
         }
 


### PR DESCRIPTION
Need to request -1 as fetch size to support continuous streaming of results. data.fetchSize defaults to 1000, any value from request should just override this.