### PR TITLE
Fixes potential race when checking if connection pool full (#455)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -344,7 +344,7 @@ namespace Neo4j.Driver.Internal
 
         private bool IsConnectionPoolFull()
         {
-            return _maxPoolSize != Config.Infinite && _poolSize >= _maxPoolSize;
+            return _maxPoolSize != Config.Infinite && PoolSize >= _maxPoolSize;
         }
 
         private bool IsIdlePoolFull()
@@ -362,7 +362,6 @@ namespace Neo4j.Driver.Internal
                     return;
                 }
 
-                // Remove from idle
                 if (!_inUseConnections.TryRemove(connection))
                 {
                     // pool already disposed


### PR DESCRIPTION
Private function that compares size of pool with max size uses a
variable that might be written to by another thread. If multiple cores
are used the variable change might not be detected when acquiring new
connection (checks that variable in loop).