### PR TITLE
4.3   flakey rx test (#459)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DirectDriverTestBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DirectDriverTestBase.cs
@@ -35,7 +35,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         protected DirectDriverTestBase(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
         {
             Output = output;
-            Server = fixture.StandAlone;
+            Server = fixture.StandAloneSharedInstance;
             ServerEndPoint = Server.BoltUri;
             AuthToken = Server.AuthToken;
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Examples.cs
@@ -972,7 +972,7 @@ namespace Neo4j.Driver.Examples
         protected BaseExample(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
         {
             Output = output;
-            Driver = fixture.StandAlone.Driver;
+            Driver = fixture.StandAloneSharedInstance.Driver;
         }
 
         public void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesAsync.cs
@@ -1044,7 +1044,7 @@ namespace Neo4j.Driver.ExamplesAsync
         protected BaseAsyncExample(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
         {
             Output = output;
-            Driver = fixture.StandAlone.Driver;
+            Driver = fixture.StandAloneSharedInstance.Driver;
         }
 
         public void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesRx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesRx.cs
@@ -183,7 +183,7 @@ namespace Neo4j.Driver.ExamplesAsync
 
         protected BaseRxExample(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
         {
-            Driver = fixture.StandAlone.Driver;
+            Driver = fixture.StandAloneSharedInstance.Driver;
         }
 
         public void Dispose()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestFixture.cs
@@ -24,33 +24,13 @@ namespace Neo4j.Driver.IntegrationTests
     public class StandAloneIntegrationTestFixture : IDisposable
     {
         bool _disposed = false;
-        public IStandAlone StandAlone { get; }
-
+        public IStandAlone StandAloneSharedInstance { get; }
+        
         ~StandAloneIntegrationTestFixture() => Dispose(false);
 
         public StandAloneIntegrationTestFixture()
         {
-            if (LocalStandAloneInstance.IsServerProvided())
-            {
-                StandAlone = new LocalStandAloneInstance();
-            }
-            else
-            {
-                if (!BoltkitHelper.IsBoltkitAvailable())
-                {
-                    return;
-                }
-
-                try
-                {
-                    StandAlone = new StandAlone();
-                }
-                catch (Exception)
-                {
-                    Dispose();
-                    throw;
-                }
-            }
+            StandAloneSharedInstance = CreateInstance();
         }
 
         public void Dispose()
@@ -65,11 +45,36 @@ namespace Neo4j.Driver.IntegrationTests
                 return;
 
             if (disposing)
-            {  
-                StandAlone?.Dispose();
+            {
+                StandAloneSharedInstance?.Dispose();
             }
 
             _disposed = true;
+        }
+
+        private IStandAlone CreateInstance()
+        {
+            if (LocalStandAloneInstance.IsServerProvided())
+            {
+                return new LocalStandAloneInstance();
+            }
+            else
+            {
+                if (!BoltkitHelper.IsBoltkitAvailable())
+                {
+                    return null;
+                }
+
+                try
+                {
+                    return new StandAlone();
+                }
+                catch (Exception)
+                {
+                    Dispose();
+                    throw;
+                }
+            }
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/AbstractRxIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/AbstractRxIT.cs
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.IntegrationTests.Reactive
         protected AbstractRxIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
             : base(output)
         {
-            Server = fixture.StandAlone;
+            Server = fixture.StandAloneSharedInstance;
             ServerEndPoint = Server.BoltUri;
             AuthToken = Server.AuthToken;
         }
@@ -72,12 +72,6 @@ namespace Neo4j.Driver.IntegrationTests.Reactive
 			{  
                 _sessions.ForEach(x => x.Close<Unit>().WaitForCompletion());
                 _sessions.Clear();
-
-                // clean database after each test run
-                using (var session = Server.Driver.Session())
-                {
-                    session.Run("MATCH (n) DETACH DELETE n").Consume();
-                }
             }
 
             //Mark as disposed

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/TransactionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/TransactionIT.cs
@@ -42,7 +42,13 @@ namespace Neo4j.Driver.IntegrationTests.Reactive
         public TransactionIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
             : base(output, fixture)
         {
-            session = NewSession();
+            // clean database after each test run
+            using (var tmpSession = Server.Driver.Session())
+            {
+                tmpSession.Run("MATCH (n) DETACH DELETE n").Consume();
+            }
+
+            session = NewSession();           
         }
 
         [RequireServerFact("4.0.0", GreaterThanOrEqualTo)]

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/SingleInstanceStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/SingleInstanceStressTests.cs
@@ -32,14 +32,14 @@ namespace Neo4j.Driver.IntegrationTests.Stress
         private readonly StandAloneIntegrationTestFixture _standalone;
 
         public SingleInstanceStressTests(ITestOutputHelper output, StandAloneIntegrationTestFixture standalone) :
-            base(output, standalone.StandAlone.BoltUri, standalone.StandAlone.AuthToken)
+            base(output, standalone.StandAloneSharedInstance.BoltUri, standalone.StandAloneSharedInstance.AuthToken)
         {
             _standalone = standalone;
         }
 
         protected override Context CreateContext()
         {
-            return new Context(_standalone.StandAlone.BoltUri.Authority);
+            return new Context(_standalone.StandAloneSharedInstance.BoltUri.Authority);
         }
 
         protected override IEnumerable<IBlockingCommand<Context>> CreateTestSpecificBlockingCommands()


### PR DESCRIPTION
* Functionality to create a non-shared standalone instance added.

* Test with removed DB cleanup.

* Moving DB cleanup to the star t of the test that needs it.

By moving this the non-deterministic garbage collection should no longer cause issues with object lifetimes.

* Removed unneeded unique instance functaionality

StandAloneIntegrationTestFixture objects no longer need the unique instance. Will stay with with shared instance.