### PR TITLE
Copyright change to remove dates.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Reactive/DriverExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/DriverExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/IRxResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/IRxResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/IRxRunnable.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/IRxRunnable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/IRxSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/IRxSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/IRxTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/IRxTransaction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/InternalRxTransaction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxRetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxRetryLogic.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/DriverExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/DriverExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/IQueryRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/IQueryRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/IResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/IResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/ISession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/ITransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/ITransaction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/BlockingExecutor.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/BlockingExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalResult.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/InternalTransaction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/RecordSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/RecordSet.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/RetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/RetryLogic.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/AuthenticationIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/AuthenticationIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BoltV4IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BoltV4IT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BookmarkIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/BookmarkIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/CertificateTrustIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/CertificateTrustIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/CypherParametersIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/CypherParametersIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DirectDriverTestBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DirectDriverTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/EncryptionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/EncryptionIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/ErrorIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/ErrorIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/NestedQueriesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/NestedQueriesIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/ResultIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/ResultIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/SessionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/SessionIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/TransactionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/TransactionIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Examples.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Examples.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesAsync.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesRx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesRx.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Extensions/CollectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Extensions/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Extensions/DatabaseExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Extensions/DatabaseExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Extensions/SessionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Extensions/SessionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/BoltStubServer.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/BoltStubServer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/BoltkitHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/BoltkitHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/CertificateUtils.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/CertificateUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/CausalCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/CausalCluster.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ExistingCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ExistingCluster.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ExternalBoltkitClusterInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ExternalBoltkitClusterInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ICausalCluster.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/ICausalCluster.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/SingleInstance.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/Cluster/SingleInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IShellCommandRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IShellCommandRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/ISingleInstance.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/ISingleInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestFixture.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/ProcessBasedCommandRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/ProcessBasedCommandRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/ShellCommandRunnerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/ShellCommandRunnerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/ExternalBoltkitInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/ExternalBoltkitInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/LocalStandAloneInstance.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/LocalStandAloneInstance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/Neo4jDefaultInstallation.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/Neo4jDefaultInstallation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/Neo4jSettingsHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/Neo4jSettingsHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/StandAlone.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/StandAlone.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/AbstractRxIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/AbstractRxIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/NavigationIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/NavigationIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/NestedQueriesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/NestedQueriesIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/SessionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/SessionIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/SummaryIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/SummaryIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/TransactionIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/TransactionIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverAsyncIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverAsyncIT.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverTestBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncFailingCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncFailingCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncFailingCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncFailingCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncReadCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncReadCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncReadCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncReadCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandUsingReadSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandUsingReadSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandUsingReadSessionInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandUsingReadSessionInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWrongCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWrongCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWrongCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWrongCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/AsyncCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/AsyncCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingFailingCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingFailingCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingFailingCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingFailingCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingReadCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingReadCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingReadCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingReadCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandUsingReadSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandUsingReadSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandUsingReadSessionInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandUsingReadSessionInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWrongCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWrongCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWrongCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWrongCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/BlockingCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/BlockingCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/IAsyncCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/IAsyncCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/IBlockingCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/IBlockingCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/IRxCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/IRxCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxFailingCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxFailingCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxReadCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxReadCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxReadCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxReadCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommandUsingReadSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommandUsingReadSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommandUsingReadSessionInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWriteCommandUsingReadSessionInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWrongCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWrongCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWrongCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxWrongCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/RxCommand.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/RxCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/SingleInstanceStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/SingleInstanceStressTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/StressTestContext.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/StressTestContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/AccessModeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/AccessModeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/DirectDriverTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/DirectDriverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/MultiDatabasesTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/MultiDatabasesTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/ResultStreamingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/ResultStreamingTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/RoutingDriverTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/RoutingDriverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/TransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/PointsIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/PointsIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncRetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncRetryLogicTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/BookmarkTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/BookmarkTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionValidatorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/CachingResolverTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/CachingResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DefaultResolverTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DefaultResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DelegatedConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/DelegatedConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/EncryptionManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/EncryptionManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MockedMessagingClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/MockedMessagingClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/TcpSocketClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/DriverTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/DriverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/EntityTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/EntityTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Filters/OSFilters.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Filters/OSFilters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Filters/RuntimeFilters.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Filters/RuntimeFilters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Helpers/ExceptionHelperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Helpers/ExceptionHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/BoltTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/BoltTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkReaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkWriterTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkWriterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/DiscardAllMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/DiscardAllMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/FailureMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/FailureMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/IgnoredMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/IgnoredMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/PullAllMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/PullAllMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/RecordMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/RecordMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/ResetMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/ResetMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/SuccessMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/SuccessMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/BeginMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/BeginMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/CommitMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/CommitMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/GoodbyeMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/GoodbyeMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/HellloMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/HellloMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/RollbackMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/RollbackMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/RunWithMetadataMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V3/RunWithMetadataMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/DiscardMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/DiscardMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/PullMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/PullMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/RunWithMetadataMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4/RunWithMetadataMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_1/HelloMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_1/HelloMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_2/HelloMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_2/HelloMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_3/HelloMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_3/HelloMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_3/RouteMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_3/RouteMessageSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/PackStreamSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/PackStreamSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/PackStreamTestSpecs.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/PackStreamTestSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/PackStreamTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/PackStreamTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/Utils/Machines.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/Utils/Machines.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/Utils/Streams.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/Utils/Streams.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/NodeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/NodeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/PathSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/PathSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/PointSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/PointSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/RelationshipSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/RelationshipSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/DurationSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/DurationSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/LocalDateSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/LocalDateSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/LocalDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/LocalDateTimeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/LocalTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/LocalTimeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/OffsetTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/OffsetTimeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/SystemDateTimeOffsetHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/SystemDateTimeOffsetHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/SystemDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/SystemDateTimeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/SystemTimeSpanSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/SystemTimeSpanSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/ZonedDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/ZonedDateTimeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/UnboundRelationshipSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/UnboundRelationshipSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/BookmarkCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/BookmarkCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ConnectionIdCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ConnectionIdCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/CountersCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/CountersCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/DatabaseInfoCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/DatabaseInfoCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/DurationCollectorsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/DurationCollectorsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/FieldsCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/FieldsCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/HasMoreCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/HasMoreCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/NotificationsCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/NotificationsCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/PlanCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/PlanCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ProfiledPlanCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ProfiledPlanCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/QueryIdCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/QueryIdCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/RoutingTableCollectorTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/RoutingTableCollectorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ServerVersionCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ServerVersionCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/TypeCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/TypeCollectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/MetadataCollectingResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/MetadataCollectingResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/NoOpResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/NoOpResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/ResponsePipelineErrorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/ResponsePipelineErrorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/ResponsePipelineTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/ResponsePipelineTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/CommitResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/CommitResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/HelloResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/HelloResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/PullResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/PullResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/RunResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V3/RunResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4/HelloResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4/HelloResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4/PullResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4/PullResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4/RunResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4/RunResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4_1/HelloResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4_1/HelloResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4_2/HelloResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4_2/HelloResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4_3/HelloResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/V4_3/HelloResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolFactoryTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolUtils.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV3Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV3Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_0Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_0Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_1Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_1Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_2Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_2Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_3Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_3Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ConcurrentOrderedSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ConcurrentOrderedSetTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ConfigBuildersTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ConfigBuildersTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/AbstractRxTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/AbstractRxTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/DriverExtensionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/DriverExtensionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxResultTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxSessionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxTransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/InternalRxTransactionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/RxRetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/RxRetryLogicTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Utils/Extensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Utils/Extensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Utils/Utils.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Utils/Utils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ConsumableCursorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ConsumableCursorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/RecordSetTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultCursorBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultCursorBuilderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultCursorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultCursorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/ResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Result/SummaryBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Result/SummaryBuilderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ResultCursorExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ResultCursorExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionPoolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ClusterDiscoveryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LeastConnectedLoadBalancingStrategyTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LeastConnectedLoadBalancingStrategyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LoadBalancerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoundRobinArrayIndexTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoundRobinArrayIndexTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ServerVersionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/ServerVersionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Simple/Internal/InternalSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Simple/Internal/InternalSessionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Simple/Internal/InternalTransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Simple/Internal/InternalTransactionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Synchronous/Internal/SyncRetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Synchronous/Internal/SyncRetryLogicTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Temporal/TimeZoneMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Temporal/TimeZoneMappingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/Assertions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/Assertions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/CollectionExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/CollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/LoggingHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/LoggingHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/NetworkExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/NetworkExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/SocketClientTestHarness.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/TestDriverLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/TestDriverLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionConfigTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/DurationTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/DurationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalDateTimeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/LocalTimeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/OffsetTimeTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/OffsetTimeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/PointTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/PointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/AccessMode.cs
+++ b/Neo4j.Driver/Neo4j.Driver/AccessMode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/AuthTokens.cs
+++ b/Neo4j.Driver/Neo4j.Driver/AuthTokens.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Bookmark.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Bookmark.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/EncryptionLevel.cs
+++ b/Neo4j.Driver/Neo4j.Driver/EncryptionLevel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/ResultCursorExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/ResultCursorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Extensions/ValueExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Extensions/ValueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/GraphDatabase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IAsyncQueryRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IAsyncQueryRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IAsyncSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IAsyncTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IAsyncTransaction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IAuthToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IAuthToken.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IDriver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/ILogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ILogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IRecord.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IRecord.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IResultCursor.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IResultCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/IServerAddressResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IServerAddressResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncQueryRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncQueryRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncRetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncRetryLogic.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSessionResourceManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSessionResourceManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncTransaction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/BufferSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/BufferSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPoolSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionValidator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionValidator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IHostResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IHostResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ITcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ITcpSocketClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/CachingHostResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/CachingHostResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/DefaultHostResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/DefaultHostResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/SystemHostResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/SystemHostResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/SystemNetCoreHostResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/SystemNetCoreHostResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/EncryptionManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/EncryptionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ByteExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ByteExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/CollectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ConnectionExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ConnectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ErrorExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ErrorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/NetworkExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/NetworkExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/StreamExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/StreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/TypeExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/FetchSizeUtil.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/FetchSizeUtil.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/BookmarkHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/BookmarkHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/CertHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/CertHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/ExceptionHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/ExceptionHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/RuntimeHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/RuntimeHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/Throw.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/UniqueIdGenerator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/UniqueIdGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionReleaseManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionReleaseManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IInternalAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IInternalAsyncSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IInternalAsyncTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IInternalAsyncTransaction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IInternalDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IInternalDriver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IInternalResultCursor.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IInternalResultCursor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/Constants.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageFormat.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IPackStreamReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IPackStreamReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IPackStreamSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IPackStreamSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IPackStreamWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IPackStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageFormat.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/DiscardAllMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/DiscardAllMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/FailureMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/FailureMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/IgnoredMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/IgnoredMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/PullAllMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/PullAllMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/RecordMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/RecordMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/ResetMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/ResetMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/SuccessMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/SuccessMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/BeginMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/BeginMessageSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/CommitMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/CommitMessageSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/GoodbyeMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/GoodbyeMessageSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/HelloMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/HelloMessageSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/RollbackMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/RollbackMessageSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/RunWithMetadataMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V3/RunWithMetadataMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4/DiscardMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4/DiscardMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4/PullMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4/PullMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_1/HelloMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_1/HelloMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_2/HelloMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_2/HelloMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_3/HelloMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_3/HelloMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStream.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamBitConverter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamBitConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamReaderBytesIncompatible.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamReaderBytesIncompatible.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamWriterBytesIncompatible.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamWriterBytesIncompatible.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ReadOnlySerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ReadOnlySerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/NodeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/NodeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PathSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PathSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PointSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PointSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/RelationshipSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/RelationshipSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/DurationSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/DurationSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/LocalDateSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/LocalDateSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/LocalDateTimeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/LocalDateTimeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/LocalTimeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/LocalTimeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/OffsetTimeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/OffsetTimeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/SystemDateTimeOffsetHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/SystemDateTimeOffsetHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/SystemDateTimeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/SystemDateTimeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/SystemTimeSpanSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/SystemTimeSpanSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/ZonedDateTimeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/ZonedDateTimeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/UnboundRelationshipSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/UnboundRelationshipSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/WriteOnlySerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/WriteOnlySerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IPooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IPooledConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/InternalBookmark.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/InternalBookmark.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/DriverLoggerUtil.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/DriverLoggerUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/NullLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/NullLogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/PrefixLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/PrefixLogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/ReformattedLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/ReformattedLogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IBookmarkTracker.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IBookmarkTracker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IMetadataCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IMetadataCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IResponsePipeline.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IResponsePipeline.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IResponsePipelineError.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/IResponsePipelineError.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/BookmarkCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/BookmarkCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ConnectionIdCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ConnectionIdCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/CountersCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/CountersCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/DatabaseInfoCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/DatabaseInfoCollector.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/DurationCollectors.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/DurationCollectors.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/FieldsCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/FieldsCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/HasMoreCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/HasMoreCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/NotificationsCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/NotificationsCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/PlanCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/PlanCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ProfiledPlanCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ProfiledPlanCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/QueryIdCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/QueryIdCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ServerVersionCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ServerVersionCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/TypeCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/TypeCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/MetadataCollectingResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/MetadataCollectingResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/NoOpResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/NoOpResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/ResponsePipeline.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/ResponsePipeline.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/ResponsePipelineError.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/ResponsePipelineError.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/BeginResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/BeginResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/CommitResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/CommitResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/HelloResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/HelloResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/PullResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/PullResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/ResetResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/ResetResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/RollbackResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/RollbackResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/RunResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V3/RunResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/DiscardResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/DiscardResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/HelloResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/HelloResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/PullResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/PullResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/RunResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/RunResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_1/HelloResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_1/HelloResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_2/HelloResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_2/HelloResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_3/HelloResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_3/HelloResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_3/RouteResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4_3/RouteResponseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/DiscardAllMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/DiscardAllMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IgnoredMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/IgnoredMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/PullAllMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/PullAllMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/RecordMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/RecordMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/ResetMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/ResetMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/SuccessMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/SuccessMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/BeginMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/BeginMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/CommitMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/CommitMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/GoodbyeMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/GoodbyeMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/HelloMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/HelloMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/RollbackMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/RollbackMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/RunWithMetadataMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/RunWithMetadataMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/TransactionStartingMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V3/TransactionStartingMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4/DiscardMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4/DiscardMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4/PullMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4/PullMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4/ResultHandleMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4/ResultHandleMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4_3/HelloMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4_3/HelloMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4_3/RouteMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4_3/RouteMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/ConnectionPoolMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/ConnectionPoolMetrics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/DefaultMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/DefaultMetrics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IConnectionPoolListener.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IConnectionPoolListener.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Metrics/IMetrics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PassthroughServerAddressResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PassthroughServerAddressResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/PooledConnectionFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/PooledConnectionFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolMessageFormat.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolMessageFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3MessageFormat.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3MessageFormat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_0.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_0.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_0MessageFormat.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_0MessageFormat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/IBoltProtocol.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/IBoltProtocol.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ConsumableResultCursor.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ConsumableResultCursor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultStream.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultStream.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultStreamBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/IResultStreamBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursor.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursorBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/ResultCursorBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/SummaryBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/SummaryBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterConnectionPool.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ClusterDiscovery.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ConnectionPoolFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ConnectionPoolFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPool.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterConnectionPoolManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterErrorHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IClusterErrorHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IDiscovery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ILoadBalancingStrategy.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/ILoadBalancingStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IRoutingTable.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IRoutingTable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IRoutingTableManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IRoutingTableManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LeastConnectedLoadBalancingStrategy.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LeastConnectedLoadBalancingStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoundRobinArrayIndex.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoundRobinArrayIndex.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTable.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/RoutingSettings.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/RoutingSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Temporal/TimeZoneMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Temporal/TimeZoneMapping.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateComponents.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateComponents.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateTimeComponents.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasDateTimeComponents.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasTimeComponents.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IHasTimeComponents.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/ISegment.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/ISegment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/IValue.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/IValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/Node.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/Node.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/Path.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/Path.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/Relationship.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/Relationship.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Types/Segment.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Types/Segment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConcurrentHashSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConcurrentHashSet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConcurrentOrderedSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConcurrentOrderedSet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConfigBuilders.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConfigBuilders.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConnectionContext.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConnectionContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 //
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ServerVersion.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ServerVersion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Properties/AssemblyInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Query.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Query.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/ServerAddress.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ServerAddress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/SessionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/SessionConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/ICounters.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/ICounters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/IDatabaseInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/IDatabaseInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/IInputPosition.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/IInputPosition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/INotification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/INotification.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/IPlan.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/IPlan.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/IProfiledPlan.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/IProfiledPlan.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/IResultSummary.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/IResultSummary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/IServerInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/IServerInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Summary/QueryType.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Summary/QueryType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/Duration.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/Duration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/IEntity.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/IEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/INode.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/INode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/IPath.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/IPath.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/IRelationship.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/IRelationship.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/LocalDate.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/LocalDate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/LocalDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/LocalDateTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/LocalTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/LocalTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/OffsetTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/OffsetTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/Point.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/Point.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/TemporalValue.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/TemporalValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/Zone.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/Zone.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZoneId.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZoneId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZoneOffset.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZoneOffset.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2002-2020 "Neo4j,"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.


### PR DESCRIPTION
Changed copyright notice from:

Copyright (c) 2002-2020 "Neo4j,"
to:
Copyright (c) "Neo4j"