### PR TITLE
Causal cluster stress tests

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncFailingCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncFailingCommandTxFunc.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class AsyncFailingCommandTxFunc<TContext> : AsyncCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public AsyncFailingCommandTxFunc(IDriver driver)
+			: base(driver, false)
+		{
+		}
+
+		public override async Task ExecuteAsync(TContext context)
+		{
+			var session = NewSession(AccessMode.Read, context);
+
+			try
+			{
+				await session.ReadTransactionAsync(async tx =>
+				{
+					try
+					{
+						var ex = await Record.ExceptionAsync(async () =>
+						{
+							var cursor = await tx.RunAsync("UNWIND [10, 5, 0] AS x RETURN 10 / x").ConfigureAwait(false);
+							var exc = await Record.ExceptionAsync(async () => await cursor.ConsumeAsync().ConfigureAwait(false)).ConfigureAwait(false);
+
+							exc.Should().BeOfType<ClientException>().Which.Message.Should().Contain("/ by zero");
+
+						}).ConfigureAwait(false);						
+					}
+					finally
+					{
+						await tx.RollbackAsync().ConfigureAwait(false);
+					}
+
+				}).ConfigureAwait(false);
+			}
+			finally
+			{
+				await session.CloseAsync().ConfigureAwait(false);
+			}
+		}
+	}
+}
+

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncReadCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncReadCommandTxFunc.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class AsyncReadCommandTxFunc<TContext> : AsyncCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public AsyncReadCommandTxFunc(IDriver driver, bool useBookmark)
+			: base(driver, useBookmark)
+		{
+		}
+
+		public override async Task ExecuteAsync(TContext context)
+		{
+			var session = NewSession(AccessMode.Read, context);
+
+			try
+			{
+				await session.ReadTransactionAsync(async tx =>
+				{
+					var cursor = await tx.RunAsync("MATCH (n) RETURN n LIMIT 1").ConfigureAwait(false);
+					var records = await cursor.ToListAsync().ConfigureAwait(false);
+					
+					if (records.Count > 0)
+					{
+						records[0][0].Should().BeAssignableTo<INode>();
+						context.NodeRead(await cursor.ConsumeAsync());
+					}
+				}).ConfigureAwait(false);
+			}
+			finally
+			{
+				await session.CloseAsync();
+			}
+		}
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandTxFunc.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class AsyncWriteCommandTxFunc<TContext> : AsyncCommand<TContext>
+		where TContext : StressTestContext
+	{
+		private readonly StressTest<TContext> _test;
+
+		public AsyncWriteCommandTxFunc(StressTest<TContext> test, IDriver driver, bool useBookmark)
+			: base(driver, useBookmark)
+		{
+			_test = test ?? throw new ArgumentNullException(nameof(test));
+		}
+
+		public override async Task ExecuteAsync(TContext context)
+		{
+			var summary = default(IResultSummary);
+			var error = default(Exception);
+			var session = NewSession(AccessMode.Write, context);
+
+			try
+			{
+				await session.WriteTransactionAsync(async tx =>
+				{
+					try
+					{
+						var cursor = await tx.RunAsync("CREATE ()").ConfigureAwait(false);
+						summary = await cursor.ConsumeAsync().ConfigureAwait(false);
+						await tx.CommitAsync();
+					}
+					catch
+					{
+						await tx.RollbackAsync().ConfigureAwait(false);
+						throw;
+					}
+
+					context.Bookmark = session.LastBookmark;
+				}).ConfigureAwait(false);
+			}
+			catch(Exception ex)
+			{
+				error = ex;
+
+				if (!_test.HandleWriteFailure(error, context))
+				{
+					throw;
+				}
+			}
+			finally
+			{
+				await session.CloseAsync().ConfigureAwait(false);
+			}
+
+			if (error == null && summary != null)
+			{
+				summary.Counters.NodesCreated.Should().Be(1);
+				context.NodeCreated();
+			}
+		}
+	}
+}
+

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandUsingReadSessionTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWriteCommandUsingReadSessionTxFunc.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class AsyncWriteCommandUsingReadSessionTxFunc<TContext> : AsyncCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public AsyncWriteCommandUsingReadSessionTxFunc(IDriver driver, bool useBookmark)
+			: base(driver, useBookmark)
+		{
+		}
+
+		public override async Task ExecuteAsync(TContext context)
+		{
+			var cursor = default(IResultCursor);
+			
+			var session = NewSession(AccessMode.Read, context);
+			try
+			{
+				await session.ReadTransactionAsync(async tx =>
+				{
+					try
+					{
+						var exc = await Record.ExceptionAsync(async () =>
+						{
+							cursor = await tx.RunAsync("CREATE ()");
+							await cursor.ConsumeAsync();
+						});
+
+						exc.Should().BeOfType<ClientException>();
+					}
+					finally
+					{
+						await tx.RollbackAsync().ConfigureAwait(false);
+					}
+
+				}).ConfigureAwait(false);
+			}
+			finally
+			{
+				await session.CloseAsync().ConfigureAwait(false);
+			}
+
+			cursor.Should().NotBeNull();
+			var summary = await cursor.ConsumeAsync();
+			summary.Counters.NodesCreated.Should().Be(0);
+		}
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWrongCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Async/AsyncWrongCommandTxFunc.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class AsyncWrongCommandTxFunc<TContext> : AsyncCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public AsyncWrongCommandTxFunc(IDriver driver)
+			: base(driver, false)
+		{
+		}
+
+		public override async Task ExecuteAsync(TContext context)
+		{
+			var session = NewSession(AccessMode.Read, context);
+
+			try
+			{
+				await session.ReadTransactionAsync(async tx =>
+				{
+					try
+					{
+						var exc = await Record.ExceptionAsync(async () =>
+						{
+							var cursor = await tx.RunAsync("RETURN").ConfigureAwait(false);
+							await cursor.ConsumeAsync();
+						}).ConfigureAwait(false);
+
+						exc.Should().BeOfType<ClientException>().Which.Message.Should().Contain("Unexpected end of input");
+					}
+					finally
+					{
+						await tx.RollbackAsync().ConfigureAwait(false);
+					}
+
+				}).ConfigureAwait(false);
+			}
+			finally
+			{
+				await session.CloseAsync().ConfigureAwait(false);
+			}
+		}
+	}
+}
+

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingFailingCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingFailingCommandTxFunc.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class BlockingFailingCommandTxFunc<TContext> : BlockingCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public BlockingFailingCommandTxFunc(IDriver driver)
+			: base(driver, false)
+		{
+		}
+
+		public override void Execute(TContext context)
+		{
+			using (var session = NewSession(AccessMode.Read, context))
+			{
+				session.ReadTransaction(tx =>
+				{
+					var result = tx.Run("UNWIND [10, 5, 0] AS x RETURN 10 / x");
+					var exc = Record.Exception(() => result.Consume());
+
+					exc.Should().BeOfType<ClientException>().Which.Message.Should().Contain("/ by zero");
+
+					return result;
+				});
+			}
+		}
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingReadCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingReadCommandTxFunc.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using FluentAssertions;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class BlockingReadCommandTxFunc<TContext> : BlockingCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public BlockingReadCommandTxFunc(IDriver driver, bool useBookmark)
+			: base(driver, useBookmark)
+		{
+		}
+
+		public override void Execute(TContext context)
+		{
+			using (var session = NewSession(AccessMode.Read, context))
+			{
+				session.ReadTransaction(txc =>
+				{
+					var result = txc.Run("MATCH (n) RETURN n LIMIT 1");
+					var record = result.SingleOrDefault();
+					record?[0].Should().BeAssignableTo<INode>();
+
+					context.NodeRead(result.Consume());
+
+					txc.Commit();
+					return record;
+				});
+			}
+		}
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandTxFunc.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using FluentAssertions;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class BlockingWriteCommandTxFunc<TContext> : BlockingCommand<TContext>
+		where TContext : StressTestContext
+	{
+		private readonly StressTest<TContext> _test;
+
+		public BlockingWriteCommandTxFunc(StressTest<TContext> test, IDriver driver, bool useBookmark)
+			: base(driver, useBookmark)
+		{
+			_test = test ?? throw new ArgumentNullException(nameof(test));
+		}
+
+		public override void Execute(TContext context)
+		{
+			var summary = default(IResultSummary);
+			var error = default(Exception);
+
+			try
+			{
+				using (var session = NewSession(AccessMode.Write, context))
+				{
+					session.WriteTransaction(txc =>
+					{
+						summary = txc.Run("CREATE ()").Consume();
+						txc.Commit();
+
+						return summary;
+					});
+
+					context.Bookmark = session.LastBookmark;
+				}
+			}
+			catch (Exception exc)
+			{
+				error = exc;
+				if (!_test.HandleWriteFailure(error, context))
+				{
+					throw;
+				}
+			}
+
+			if (error == null && summary != null)
+			{
+				summary.Counters.NodesCreated.Should().Be(1);
+				context.NodeCreated();
+			}
+		}
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandUsingReadSessionTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWriteCommandUsingReadSessionTxFunc.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class BlockingWriteCommandUsingReadSessionTxFunc<TContext> : BlockingCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public BlockingWriteCommandUsingReadSessionTxFunc(IDriver driver, bool useBookmark)
+			: base(driver, useBookmark)
+		{
+		}
+
+		public override void Execute(TContext context)
+		{
+			var result = default(IResult);
+
+			using (var session = NewSession(AccessMode.Read, context))
+			{
+				session.ReadTransaction(tx =>
+				{
+					var exc = Record.Exception(() =>
+					{
+						result = tx.Run("CREATE ()");
+						result.Consume();
+						return result;
+					});
+
+					exc.Should().BeOfType<ClientException>();
+					return result;
+				});
+			}
+
+			result.Should().NotBeNull();
+			result.Consume().Counters.NodesCreated.Should().Be(0);
+		}
+
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWrongCommandTxFunc.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Blocking/BlockingWrongCommandTxFunc.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+// 
+// This file is part of Neo4j.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Neo4j.Driver.IntegrationTests.Stress
+{
+	public class BlockingWrongCommandTxFunc<TContext> : BlockingCommand<TContext>
+		where TContext : StressTestContext
+	{
+		public BlockingWrongCommandTxFunc(IDriver driver)
+			: base(driver, false)
+		{
+		}
+
+		public override void Execute(TContext context)
+		{
+			using (var session = NewSession(AccessMode.Read, context))
+			{
+				session.ReadTransaction(txc =>
+				{
+					var result = txc.Run("RETURN");
+					var exc = Record.Exception(() => result.Consume());
+
+					exc.Should().BeOfType<ClientException>().Which.Message.Should().Contain("Unexpected end of input");
+
+					return result;
+				});
+			}
+		}
+	}
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/CausalClusterStressTests.cs
@@ -48,34 +48,24 @@ namespace Neo4j.Driver.IntegrationTests.Stress
         {
             return new List<IBlockingCommand<Context>>
             {
-                new BlockingWriteCommandUsingReadSession<Context>(_driver, false),
-                new BlockingWriteCommandUsingReadSession<Context>(_driver, true),
-                new BlockingWriteCommandUsingReadSessionInTx<Context>(_driver, false),
-                new BlockingWriteCommandUsingReadSessionInTx<Context>(_driver, true)
-            };
+				new BlockingWriteCommandUsingReadSessionTxFunc<Context>(_driver, false),
+				new BlockingWriteCommandUsingReadSessionTxFunc<Context>(_driver, true)
+			};
         }
 
         protected override IEnumerable<IAsyncCommand<Context>> CreateTestSpecificAsyncCommands()
         {
             return new List<IAsyncCommand<Context>>
             {
-                new AsyncWriteCommandUsingReadSession<Context>(_driver, false),
-                new AsyncWriteCommandUsingReadSession<Context>(_driver, true),
-                new AsyncWriteCommandUsingReadSessionInTx<Context>(_driver, false),
-                new AsyncWriteCommandUsingReadSessionInTx<Context>(_driver, true)
+                new AsyncWriteCommandUsingReadSessionTxFunc<Context>(_driver, false),
+                new AsyncWriteCommandUsingReadSessionTxFunc<Context>(_driver, true)
             };
         }
 
         protected override IEnumerable<IRxCommand<Context>> CreateTestSpecificRxCommands()
         {
-            return new List<IRxCommand<Context>>
-            {
-                new RxWriteCommandUsingReadSession<Context>(_driver, false),
-                new RxWriteCommandUsingReadSession<Context>(_driver, true),
-                new RxWriteCommandUsingReadSessionInTx<Context>(_driver, false),
-                new RxWriteCommandUsingReadSessionInTx<Context>(_driver, true)
-            };
-        }
+            return Enumerable.Empty<IRxCommand<Context>>();
+		}
 
         protected override void PrintStats(Context context)
         {
@@ -89,8 +79,8 @@ namespace Neo4j.Driver.IntegrationTests.Stress
             VerifyServedReadQueries(context, clusterAddresses);
             VerifyServedSimilarAmountOfReadQueries(context, clusterAddresses);
         }
-
-        public override bool HandleWriteFailure(Exception error, Context context)
+		
+		public override bool HandleWriteFailure(Exception error, Context context)
         {
             switch (error)
             {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxFailingCommandInTx.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/Reactive/RxFailingCommandInTx.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2020 "Neo4j,"
+// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [http://neo4j.com]
 // 
 // This file is part of Neo4j.

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/SingleInstanceStressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/SingleInstanceStressTests.cs
@@ -54,7 +54,15 @@ namespace Neo4j.Driver.IntegrationTests.Stress
 
         protected override IEnumerable<IRxCommand<Context>> CreateTestSpecificRxCommands()
         {
-            return Enumerable.Empty<IRxCommand<Context>>();
+			return new List<IRxCommand<Context>>
+			{
+				new RxReadCommandInTx<Context>(_driver, false),
+				new RxReadCommandInTx<Context>(_driver, true),
+				new RxWriteCommandInTx<Context>(this, _driver, false),
+				new RxWriteCommandInTx<Context>(this, _driver, true),
+				new RxWrongCommandInTx<Context>(_driver),
+				new RxFailingCommandInTx<Context>(_driver)
+			};
         }
 
         protected override void PrintStats(Context context)
@@ -72,7 +80,13 @@ namespace Neo4j.Driver.IntegrationTests.Stress
             return false;
         }
 
-        public class Context : StressTestContext
+		protected override void RunReactiveBigData()
+		{
+			var bookmark = CreateNodesRx(BigDataTestBatchCount, BigDataTestBatchSize, BigDataTestBatchBuffer, _driver);
+			ReadNodesRx(_driver, bookmark, BigDataTestBatchCount * BigDataTestBatchSize);
+		}
+
+		public class Context : StressTestContext
         {
             private readonly string _expectedAddress;
             private long _readQueries;


### PR DESCRIPTION
Causal cluster stress tests now use transaction functions only.