### PR TITLE
Fix for TemporalTypesIT.ShouldSendAndReceiveRandomDuration

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
@@ -31,7 +31,7 @@ namespace Neo4j.Driver.IntegrationTests.Types
 {
     public class TemporalTypesIT : DirectDriverTestBase
     {
-        private const int NumberOfRandomSequences = 2000;
+        private const int NumberOfRandomSequences = 100;
         private const int MinArrayLength = 5;
         private const int MaxArrayLength = 1000;
 


### PR DESCRIPTION
Massively reduced the number of test writes and reads, each in a new task and using a new session, from 2000 to 100. This should prevent it from blowing the threadpool occasionally.