### PR TITLE
Reverting docker file to use the .Net 5.0 sdk

### DIFF
--- a/Testkit/Dockerfile
+++ b/Testkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 
 RUN apt update \
 	&& ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime \


### PR DESCRIPTION
Microsoft have now fixed the certificate issue, so will no longer use the recommended workaround in the dockerfile.