### PR TITLE
Flaky test improvements from 4.2

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/NestedQueriesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Reactive/NestedQueriesIT.cs
@@ -76,7 +76,13 @@ namespace Neo4j.Driver.IntegrationTests.Reactive
                 .AssertEqual(OnCompleted<int>(0));
         }
 
-        [RequireServerFact("4.0.0", GreaterThanOrEqualTo)]
+		public bool OutputMessage(string message, string expectedMessage)
+		{
+			Output.WriteLine(message);
+			return message.Contains(expectedMessage);
+		}
+
+		[RequireServerFact("4.0.0", GreaterThanOrEqualTo)]
         public void ShouldErrorToRunNestedQueriesWithTransactionFunctions()
         {
             const int size = 1024;
@@ -95,7 +101,7 @@ namespace Neo4j.Driver.IntegrationTests.Reactive
                 .AssertEqual(
                     OnError<int>(0,
                         MatchesException<ClientException>(e =>
-                            e.Message.Contains("close the currently open transaction object before"))));
+                            OutputMessage(e.Message, "close the currently open transaction object before"))));
         }
 
         [RequireServerFact("4.0.0", GreaterThanOrEqualTo)]


### PR DESCRIPTION
Improved output on error for reactive nested integration tests.
Increased timeouts on checking blocking on max pool size reached.