### PR TITLE
Bug fix. ROUTE message handling of default DB

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_3/RouteMessageSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/MessageSerializers/V4_3/RouteMessageSerializerTests.cs
@@ -43,10 +43,12 @@ namespace Neo4j.Driver.Internal.IO.MessageSerializers.V4_3
 			ex.Should().BeOfType<ProtocolException>();
 		}
 
-		[Fact]
-		public void ShouldSerialize()
-		{
-			const string db = "adb";
+		[Theory]
+		[InlineData("adb", "adb")]
+		[InlineData("", "none")]
+		[InlineData(null, "none")]
+		public void ShouldSerialize(string db, string serializedDb)
+		{	
 			var writerMachine = CreateWriterMachine();
 			var writer = writerMachine.Writer();
 			var routingContext = new Dictionary<string, string> { {"ContextKey1", "ContextValue1"},
@@ -66,6 +68,9 @@ namespace Neo4j.Driver.Internal.IO.MessageSerializers.V4_3
 			readMap.Should().HaveCount(3).And.Contain(new[] { new KeyValuePair<string, object>( "ContextKey1", "ContextValue1" ),
 															  new KeyValuePair<string, object>( "ContextKey2", "ContextValue2" ),
 															  new KeyValuePair<string, object>( "ContextKey3", "ContextValue3" ) });
+
+			reader.PeekNextType().Should().Be(PackStream.PackType.String);
+			reader.ReadString().Should().Be(serializedDb);
 		}
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
@@ -36,9 +36,9 @@ namespace Neo4j.Driver.Tests
         {
             public static IEnumerable<object[]> MessageData => new[]
             {
-				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, ""), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'none\'" },
-				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, null), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'none\'" },
-				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, "adb"), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'adb\'" },
+				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Empty" } }, ""), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Empty\' } \'none\'" },
+				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Null" } }, null), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Null\' } \'none\'" },
+				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "adb" } }, "adb"), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'adb\' } \'adb\'" },
                 new object[] {new FailureMessage("CODE", "MESSAGE"), "FAILURE code=CODE, message=MESSAGE"},
                 new object[] {new V4_3.HelloMessage("mydriver", null, new Dictionary<string, string> {{ "RoutingKey", "RoutingValue" }}), "HELLO [{user_agent, mydriver}, {routing, [{RoutingKey, RoutingValue}]}]"},
                 new object[] {new V4_3.HelloMessage("mydriver", null, new Dictionary<string, string>()), "HELLO [{user_agent, mydriver}, {routing, []}]"},

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Messaging/MessageTests.cs
@@ -36,7 +36,9 @@ namespace Neo4j.Driver.Tests
         {
             public static IEnumerable<object[]> MessageData => new[]
             {
-                new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, "adb"), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'adb\'" },
+				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, ""), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'none\'" },
+				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, null), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'none\'" },
+				new object[] {new V4_3.RouteMessage(new Dictionary<string, string> { { "RoutingKey", "RoutingValue" }, { "Bob", "Frank" } }, "adb"), "ROUTE { \'RoutingKey\':\'RoutingValue\' \'Bob\':\'Frank\' } \'adb\'" },
                 new object[] {new FailureMessage("CODE", "MESSAGE"), "FAILURE code=CODE, message=MESSAGE"},
                 new object[] {new V4_3.HelloMessage("mydriver", null, new Dictionary<string, string> {{ "RoutingKey", "RoutingValue" }}), "HELLO [{user_agent, mydriver}, {routing, [{RoutingKey, RoutingValue}]}]"},
                 new object[] {new V4_3.HelloMessage("mydriver", null, new Dictionary<string, string>()), "HELLO [{user_agent, mydriver}, {routing, []}]"},

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_3/RouteMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/V4_3/RouteMessageSerializer.cs
@@ -16,7 +16,7 @@ namespace Neo4j.Driver.Internal.IO.MessageSerializers.V4_3
             
             writer.WriteStructHeader(2, BoltProtocolV4_3MessageFormat.MsgRoute);
             writer.Write(msg.Routing);
-            writer.Write(msg.DatabaseParam);
+            writer.Write(!string.IsNullOrEmpty(msg.DatabaseParam) ? msg.DatabaseParam : "none");
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4_3/RouteMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/V4_3/RouteMessage.cs
@@ -45,7 +45,7 @@ namespace Neo4j.Driver.Internal.Messaging.V4_3
 
             message += " }";
 
-            message += (DatabaseParam != null) ? " \'" + DatabaseParam + "\'" : "";
+            message += (!string.IsNullOrEmpty(DatabaseParam)) ? " \'" + DatabaseParam + "\'" : " \'none\'";
 
             return message;
         }


### PR DESCRIPTION
When no database has been specified the serialisation of the ROUTE message should finish with the string 'none' so that it looks like:

C: ROUTE {'address': '127.0.0.1:9001', 'region': 'china', 'policy': 'my_policy'} 'none'