### PR TITLE
testkit-backend: Writing error over the wire when ArgumentException occurs

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs
@@ -99,6 +99,11 @@ namespace Neo4j.Driver.Tests.TestBackend
                         await ResponseWriter.WriteResponseAsync(ExceptionManager.GenerateExceptionResponse(ex));
                         restartConnection = false;
                     }
+                    catch (ArgumentException ex) 
+                    {
+                        await ResponseWriter.WriteResponseAsync(ExceptionManager.GenerateExceptionResponse(ex));
+                        restartConnection = false;
+                    }
                     catch (NotSupportedException ex)
                     {
                         await ResponseWriter.WriteResponseAsync(ExceptionManager.GenerateExceptionResponse(ex));


### PR DESCRIPTION
This issue was not allowing to run the tests to check if the driver will fail to be created when there are url query-string params for a bolt (direct) connection.