### PR TITLE
Skip testkit test that crashes the backend

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -219,6 +219,14 @@ namespace Neo4j.Driver.Tests.TestBackend
 
 			("stub.authorization.NoRoutingAuthorizationTests.test_should_be_able_to_use_current_sessions_after_AuthorizationExpired",
 				"Temporarily disabled whilst being developed"),
+
+
+
+
+
+			("stub.retry.test_retry.TestRetry.test_no_retry_on_syntax_error",
+				"Crashes the backend"),
+
 		}; 
 
 		public static bool FindTest(string testName, out string reason)


### PR DESCRIPTION
This test got migrated from the Python driver.

The backend crash blocks https://github.com/neo4j-drivers/testkit/pull/112

If you want to investigate, here is the backend's log

```
Logging to file: ../artifacts/backend.log
Starting TestBackend on 0.0.0.0:9876
Creating Server
Starting TCP server
Controller initialising
Starting Controller.Process
Starting to listen for Connections
Connected
Connection open
Starting to listen for requests
Listening for request

Request recieved: 
Closing Connection
Starting to listen for Connections
Connected
Connection open
Starting to listen for requests
Listening for request

Request recieved: {"name": "GetFeatures", "data": {}}
Sending response: {"name":"FeatureList","data":{"features":["AuthorizationExpiredTreatment"]}}

Listening for request

Request recieved: {"name": "StartTest", "data": {"testName": "stub.retry.test_retry.TestRetry.test_no_retry_on_syntax_error"}}
Sending response: {"name":"RunTest","data":null}

Listening for request

Request recieved: {"name": "StartTest", "data": {"testName": "stub.retry.TestRetry.test_no_retry_on_syntax_error"}}
Sending response: {"name":"RunTest","data":null}

Listening for request

Request recieved: {"name": "NewDriver", "data": {"uri": "bolt://runner:9001", "authorizationToken": {"name": "AuthorizationToken", "data": {"scheme": "basic", "principal": "", "credentials": "", "realm": "", "ticket": ""}}, "userAgent": null, "resolverRegistered": false, "domainNameResolverRegistered": false, "connectionTimeoutMs": null}}
Sending response: {"name":"Driver","data":{"id":"3"}}

Listening for request

Request recieved: {"name": "NewSession", "data": {"driverId": "3", "accessMode": "r", "bookmarks": null, "database": null, "fetchSize": null}}
Sending response: {"name":"Session","data":{"id":"4"}}

Listening for request

Request recieved: {"name": "SessionReadTransaction", "data": {"sessionId": "4", "txMeta": null, "timeout": null}}
Sending response: {"name":"RetryableTry","data":{"id":"6"}}

Listening for request

Request recieved: {"name": "TransactionRun", "data": {"txId": "6", "cypher": "RETURN 1", "params": null}}
Sending response: {"name":"DriverError","data":{"id":"9","errorType":"ClientError","msg":"Error from client in retryable tx","code":null}}

Listening for request

Request recieved: {"name": "RetryableNegative", "data": {"sessionId": "4", "errorId": "9"}}
Closing Connection
It looks like the ExceptionExtensions system has failed in an unexpected way. 
System.Collections.Generic.KeyNotFoundException: The given key '6' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Neo4j.Driver.Tests.TestBackend.TransactionManager.FindTransaction(String key) in /driver/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Transaction/TransactionManager.cs:line 46
   at Neo4j.Driver.Tests.TestBackend.RetryableNegative.TransactionRollBackDelegate(String transactionId, Controller controller) in /driver/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/RetryableNegative.cs:line 33
   at Neo4j.Driver.Tests.TestBackend.RetryableNegative.Process(Controller controller) in /driver/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/RetryableNegative.cs:line 26
   at Neo4j.Driver.Tests.TestBackend.Controller.ProcessStreamObjects() in /driver/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs:line 36
   at Neo4j.Driver.Tests.TestBackend.Controller.Process() in /driver/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs:line 93
Stopping TCP server
Stopping TCP server
```