### PR TITLE
Updated common.props to remove use of deprecated tag

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Neo4j
-Copyright (c) 2002-2020 Neo4j Sweden AB (referred to
+Copyright (c) 2002-2021 Neo4j Sweden AB (referred to
 in this notice as "Neo4j, Inc.")
    [http://neo4j.com]
 

--- a/Neo4j.Driver.Docs.shfbproj
+++ b/Neo4j.Driver.Docs.shfbproj
@@ -47,7 +47,7 @@
     <Preliminary>False</Preliminary>
     <NamingMethod>Guid</NamingMethod>
     <HelpTitle>Neo4j Bolt Driver $(DriverVersion) for .NET</HelpTitle>
-    <CopyrightText>Copyright %28c%29 2002-2020 Neo4j</CopyrightText>
+    <CopyrightText>Copyright %28c%29 2002-2021 Neo4j</CopyrightText>
     <CopyrightHref>http://neo4j.com</CopyrightHref>
     <ContentPlacement>AboveNamespaces</ContentPlacement>
     <NamespaceSummaries>

--- a/Neo4j.Driver/common.props
+++ b/Neo4j.Driver/common.props
@@ -33,6 +33,6 @@
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
       <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
       <PackageProjectUrl>https://github.com/neo4j/neo4j-dotnet-driver</PackageProjectUrl>
-      <PackageIconUrl>https://avatars3.githubusercontent.com/u/201120?v=3&amp;s=64</PackageIconUrl>
+      <PackageIcon>https://avatars3.githubusercontent.com/u/201120?v=3&amp;s=64</PackageIcon>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
PackageIconUrl is now deprecated in favour of PackageIcon, common.props updated to reflect this.

Updated copyright to 2021 in a couple of places.