### PR TITLE
Fixes to native integration tests for BEGIN message responses

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V3/connection_error_on_commit.script
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V3/connection_error_on_commit.script
@@ -3,10 +3,10 @@
 !: AUTO RESET
 
 C: BEGIN {}
-   RUN "CREATE (n {name: 'Bob'})" {} {}
+S: SUCCESS {}
+C: RUN "CREATE (n {name: 'Bob'})" {} {}
    PULL_ALL
 S: SUCCESS {}
-   SUCCESS {}
    SUCCESS {}
 C: COMMIT
 S: <EXIT>

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/accessmode_reader_func.script
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/accessmode_reader_func.script
@@ -3,10 +3,10 @@
 !: AUTO RESET
 
 C:  BEGIN {"mode": "r"}
-	RUN "RETURN $x" {"x": 1} {}
-    PULL {"n": 1000}
 S:	SUCCESS {}
-	SUCCESS {"fields": ["x"]}
+C:	RUN "RETURN $x" {"x": 1} {}
+    PULL {"n": 1000}
+S:	SUCCESS {"fields": ["x"]}
     RECORD [1]
     SUCCESS {}
 C:  COMMIT

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/accessmode_writer_func.script
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/accessmode_writer_func.script
@@ -3,10 +3,10 @@
 !: AUTO RESET
 
 C:  BEGIN {}
-	RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1} {}
-    PULL {"n": 1000}
 S:	SUCCESS {}
-	SUCCESS {"fields": ["x"]}
+C:	RUN "CREATE (n: { id: $x }) RETURN $x" {"x": 1} {}
+    PULL {"n": 1000}
+S:	SUCCESS {"fields": ["x"]}
     RECORD [1]
     SUCCESS {}
 C:  COMMIT

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/connection_error_on_commit.script
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/connection_error_on_commit.script
@@ -3,10 +3,10 @@
 !: AUTO RESET
 
 C: BEGIN {}
-   RUN "CREATE (n {name: 'Bob'})" {} {}
+S: SUCCESS {}
+C: RUN "CREATE (n {name: 'Bob'})" {} {}
    PULL {"n": 1000}
 S: SUCCESS {}
-   SUCCESS {}
    SUCCESS {}
 C: COMMIT
 S: <EXIT>

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/discard_streaming_records_tx.script
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Resources/V4/discard_streaming_records_tx.script
@@ -4,9 +4,9 @@
 !: AUTO GOODBYE
 
 C: BEGIN { "mode": "r" }
-   RUN "UNWIND [1,2,3,4] AS n RETURN n" {} {}
 S: SUCCESS {}
-   SUCCESS {"t_first": 110, "fields": ["n"]}
+C: RUN "UNWIND [1,2,3,4] AS n RETURN n" {} {}
+S: SUCCESS {"t_first": 110, "fields": ["n"]}
 C: DISCARD {"n": -1}
 S: SUCCESS {"type": "r", "t_last": 3, "db": "neo4j"}
 C: COMMIT

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
@@ -95,6 +95,7 @@ namespace Neo4j.Driver.Internal.Protocol
 														   connection.GetEnforcedAccessMode()),
 											new V3.BeginResponseHandler()
 										  ).ConfigureAwait(false);
+			
 			await connection.SyncAsync().ConfigureAwait(false);
 		}
 


### PR DESCRIPTION
BeginTransactionAsync now waits for a response before proceeding. It used to only do this wait if there were bookmarks supplied. The stub scripts for the native integration tests needed to be updated to reflect this.