### PR TITLE
Fix parameter decoding in backend's tx run

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRun.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRun.cs
@@ -16,16 +16,31 @@ namespace Neo4j.Driver.Tests.TestBackend
         public class TransactionRunType
         {
             public string txId { get; set; }
-            public string cypher { get; set; }
+            public string cypher { get; set; }            
             [JsonProperty("params")]
-            public Dictionary<string, object> parameters { get; set; } = new Dictionary<string, object>();
+            public Dictionary<string, CypherToNativeObject> parameters { get; set; } = new Dictionary<string, CypherToNativeObject>();
         }
+
+        private Dictionary<string, object> ConvertParameters(Dictionary<string, CypherToNativeObject> source)
+		{
+            if (data.parameters == null)
+                return null;
+
+            Dictionary<string, object> newParams = new Dictionary<string, object>();
+
+            foreach(KeyValuePair<string, CypherToNativeObject> element in source)
+			{
+                newParams.Add(element.Key, CypherToNative.Convert(element.Value));
+			}
+
+            return newParams;
+		}
 
         public override async Task Process(Controller controller)
         {
             var transactionWrapper = controller.TransactionManagager.FindTransaction(data.txId);
 
-            IResultCursor cursor = await transactionWrapper.Transaction.RunAsync(data.cypher, data.parameters).ConfigureAwait(false);
+            IResultCursor cursor = await transactionWrapper.Transaction.RunAsync(data.cypher, ConvertParameters(data.parameters)).ConfigureAwait(false);
 
 			ResultId = await transactionWrapper.ProcessResults(cursor);
 		}


### PR DESCRIPTION
This backend bug currently blocks https://github.com/neo4j-drivers/testkit/pull/240