### PR TITLE
Implement consume on transaction results

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Protocol.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Protocol.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend
 {
-	public class TestKitProtocolException : Exception 
+	public class TestKitProtocolException : Exception
 	{
 		public TestKitProtocolException(string message) : base(message)
 		{
@@ -14,7 +14,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 		}
 	}
 
-	public class TestKitClientException : Exception 
+	public class TestKitClientException : Exception
 	{
 		public TestKitClientException(string message) : base(message)
 		{
@@ -38,8 +38,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 									typeof(SessionReadTransaction),
 									typeof(SessionWriteTransaction),
 									typeof(SessionBeginTransaction),
-									typeof(TransactionResult),
-									typeof(SessionResult),
+									typeof(Result),
 									typeof(ResultNext),
 									typeof(ResultConsume),
 									typeof(RetryablePositive),
@@ -52,13 +51,13 @@ namespace Neo4j.Driver.Tests.TestBackend
 									typeof(StartTest),
 									typeof(GetFeatures)};
 
-        
+
 		static Protocol()
         {
-            
+
         }
 
-        public static void ValidateType(string typeName) 
+        public static void ValidateType(string typeName)
         {
 			var objectType = Type.GetType(typeName, true);
 			ValidateType(objectType);
@@ -77,7 +76,7 @@ namespace Neo4j.Driver.Tests.TestBackend
         [JsonProperty("id")]
         public string uniqueId { get; internal set; }    //Only exposes the get option so that the serializer will output it.  Don't want to read in on deserialization.
         [JsonIgnore]
-        protected ProtocolObjectManager ObjManager { get; set; }        
+        protected ProtocolObjectManager ObjManager { get; set; }
         public event EventHandler ProtocolEvent;
 
         public void SetObjectManager(ProtocolObjectManager objManager)
@@ -98,7 +97,7 @@ namespace Neo4j.Driver.Tests.TestBackend
             await Process();
         }
 
-        public string Encode()      
+        public string Encode()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/Result.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/Result.cs
@@ -11,7 +11,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 	internal class Result : IProtocolObject
 	{
 		public ResultType data { get; set; } = new ResultType();
-		
+
         public class ResultType
         {
             public string id { get; set; }
@@ -29,16 +29,21 @@ namespace Neo4j.Driver.Tests.TestBackend
         }
 
 		public async virtual Task<IRecord> GetNextRecord()
-		{	
+		{
 			return await Task.FromResult<IRecord>(null);
 		}
-    }
+
+		public async virtual Task<IResultSummary> ConsumeResults()
+		{
+			return await Task.FromResult<IResultSummary>(null);
+		}
+	}
 
 	internal class TransactionResult : Result
 	{
 		[JsonIgnore]
 		private IResultCursor ResultCursor { get; set; }
-		
+
 
 		public async override Task<IRecord> GetNextRecord()
 		{
@@ -54,6 +59,11 @@ namespace Neo4j.Driver.Tests.TestBackend
 		{
 			ResultCursor = cursor;
 			await Task.CompletedTask;
+		}
+
+		public async override Task<IResultSummary> ConsumeResults()
+		{
+			return await ResultCursor.ConsumeAsync().ConfigureAwait(false);
 		}
 	}
 
@@ -73,7 +83,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 			return await Task.FromResult<IRecord>(null);
 		}
 
-		public async Task<IResultSummary> ConsumeResults()
+		public async override Task<IResultSummary> ConsumeResults()
 		{
 			return await Results.ConsumeAsync().ConfigureAwait(false);
 		}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultConsume.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultConsume.cs
@@ -14,12 +14,12 @@ namespace Neo4j.Driver.Tests.TestBackend
 
 		public class ResultConsumeType
 		{
-			public string resultId { get; set; }			
+			public string resultId { get; set; }
 		}
 
 		public override async Task Process()
 		{
-			Summary = await ((SessionResult)ObjManager.GetObject(data.resultId)).ConsumeResults().ConfigureAwait(false);
+			Summary = await ((Result)ObjManager.GetObject(data.resultId)).ConsumeResults().ConfigureAwait(false);
 		}
 
 		public override string Respond()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionBeginTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionBeginTransaction.cs
@@ -37,12 +37,12 @@ namespace Neo4j.Driver.Tests.TestBackend
 		{
 			var sessionContainer = (NewSession)ObjManager.GetObject(data.sessionId);
 			var transaction = await sessionContainer.Session.BeginTransactionAsync(TransactionConfig);
-			TransactionId = controller.TransactionManagager.AddTransaction(new TransactionWrapper(transaction, async cursor => 
-			{	
-				var result = ProtocolObjectFactory.CreateObject<SessionResult>();
-				result.Results = cursor;
+			TransactionId = controller.TransactionManagager.AddTransaction(new TransactionWrapper(transaction, async cursor =>
+			{
+				var result = ProtocolObjectFactory.CreateObject<Result>();
+				result.ResultCursor = cursor;
 
-				return await Task.FromResult<string>(result.uniqueId);				
+				return await Task.FromResult<string>(result.uniqueId);
 			}));
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionReadTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionReadTransaction.cs
@@ -6,15 +6,15 @@ using System.Collections.Generic;
 namespace Neo4j.Driver.Tests.TestBackend
 {
     internal class SessionReadTransaction : IProtocolObject
-    {   
+    {
         public SessionReadTransactionType data { get; set; } = new SessionReadTransactionType();
         [JsonIgnore]
         private string TransactionId { get; set; }
-		
+
 
         public class SessionReadTransactionType
         {
-            public string sessionId { get; set; }  
+            public string sessionId { get; set; }
 
             public string cypher { get; set; }
 
@@ -34,7 +34,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 
 				TransactionId = controller.TransactionManagager.AddTransaction(new TransactionWrapper(tx, async cursor =>
 				{
-					var result = ProtocolObjectFactory.CreateObject<TransactionResult>();
+					var result = ProtocolObjectFactory.CreateObject<Result>();
 					await result.PopulateRecords(cursor).ConfigureAwait(false);
 					return result.uniqueId;
 				}));
@@ -74,8 +74,8 @@ namespace Neo4j.Driver.Tests.TestBackend
 
 					//Otherwise keep processing unrelated commands.
 				}
-				
-				//controller.TransactionManagager.RemoveTransaction(TransactionId);                
+
+				//controller.TransactionManagager.RemoveTransaction(TransactionId);
 			}, TransactionConfig);
         }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionRun.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionRun.cs
@@ -16,9 +16,9 @@ namespace Neo4j.Driver.Tests.TestBackend
         public class SessionRunType
         {
             public string sessionId { get; set; }
-            
+
             public string cypher { get; set; }
-            
+
             [JsonProperty("params")]
             public Dictionary<string, CypherToNativeObject> parameters { get; set; } = new Dictionary<string, CypherToNativeObject>();
 
@@ -27,7 +27,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 
             [JsonProperty(Required = Required.AllowNull)]
             public int timeout { get; set; } = -1;
-            
+
         }
 
         private Dictionary<string, object> ConvertParameters(Dictionary<string, CypherToNativeObject> source)
@@ -61,14 +61,14 @@ namespace Neo4j.Driver.Tests.TestBackend
             var newSession = (NewSession)ObjManager.GetObject(data.sessionId);
             IResultCursor cursor = await newSession.Session.RunAsync(data.cypher, ConvertParameters(data.parameters), TransactionConfig).ConfigureAwait(false);
 
-            var result = ProtocolObjectFactory.CreateObject<SessionResult>();
-			result.Results = cursor;
+            var result = ProtocolObjectFactory.CreateObject<Result>();
+			result.ResultCursor = cursor;
 
 			ResultId = result.uniqueId;
         }
 
         public override string Respond()
-        {   
+        {
             return ((Result)ObjManager.GetObject(ResultId)).Respond();
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRun.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRun.cs
@@ -16,25 +16,25 @@ namespace Neo4j.Driver.Tests.TestBackend
         public class TransactionRunType
         {
             public string txId { get; set; }
-            public string cypher { get; set; }            
+            public string cypher { get; set; }
             [JsonProperty("params")]
             public Dictionary<string, CypherToNativeObject> parameters { get; set; } = new Dictionary<string, CypherToNativeObject>();
         }
 
         private Dictionary<string, object> ConvertParameters(Dictionary<string, CypherToNativeObject> source)
-		{
+        {
             if (data.parameters == null)
                 return null;
 
             Dictionary<string, object> newParams = new Dictionary<string, object>();
 
             foreach(KeyValuePair<string, CypherToNativeObject> element in source)
-			{
+            {
                 newParams.Add(element.Key, CypherToNative.Convert(element.Value));
-			}
+            }
 
             return newParams;
-		}
+        }
 
         public override async Task Process(Controller controller)
         {
@@ -42,8 +42,8 @@ namespace Neo4j.Driver.Tests.TestBackend
 
             IResultCursor cursor = await transactionWrapper.Transaction.RunAsync(data.cypher, ConvertParameters(data.parameters)).ConfigureAwait(false);
 
-			ResultId = await transactionWrapper.ProcessResults(cursor);
-		}
+            ResultId = await transactionWrapper.ProcessResults(cursor);
+        }
 
         public override string Respond()
         {   


### PR DESCRIPTION
TransactionResults in TestKit backend had no consume method.

Found as it failed in (and currently blocks) https://github.com/neo4j-drivers/testkit/pull/240