### PR TITLE
TestKit backend output goes to stdout/stderr

### DIFF
--- a/testkit/backend.py
+++ b/testkit/backend.py
@@ -3,11 +3,16 @@ Executed in dotnet driver container.
 Assumes driver and backend has been built.
 Responsible for starting the test backend.
 """
-import os, subprocess
+import os
+import subprocess
+import sys
 
 if __name__ == "__main__":
-    backend_path = os.path.join("bin", "Publish", "Neo4j.Driver.Tests.TestBackend.dll")
+    backend_path = os.path.join(
+        "bin", "Publish", "Neo4j.Driver.Tests.TestBackend.dll"
+    )
     logfile_path = os.path.join("..", "artifacts", "backend.log")
-    err = open("/artifacts/backenderr.log", "w")
-    out = open("/artifacts/backendout.log", "w")
-    subprocess.check_call(["dotnet", backend_path, "0.0.0.0", "9876", logfile_path], stdout=out, stderr=err)
+    subprocess.check_call(
+        ["dotnet", backend_path, "0.0.0.0", "9876", logfile_path],
+        stdout=sys.stdout, stderr=sys.stderr
+    )


### PR DESCRIPTION
From there, TestKit can pick it up and write it into logfiles if desired.
https://github.com/neo4j-drivers/testkit/pull/309