### PR TITLE
Skip bookmark tests

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -8,61 +8,61 @@ namespace Neo4j.Driver.Tests.TestBackend
 {
 	static class TestBlackList
 	{
-		private static readonly (string Name, string Reason)[] BlackListNames = new []														
-		{ 
-			("sessionrun.TestSessionRun.test_iteration_nested",																				
+		private static readonly (string Name, string Reason)[] BlackListNames = new []
+		{
+			("sessionrun.TestSessionRun.test_iteration_nested",
 			 "Nested results not working in 4.2 and earlier. FIX AND ENABLE in 4.3"),
-			
-			("txfuncrun.TestTxFuncRun.test_iteration_nested",																				
-			 "Fails for some reason"),															
-			
-			("retry.TestRetry.test_disconnect_on_commit", 																					
+
+			("txfuncrun.TestTxFuncRun.test_iteration_nested",
+			 "Fails for some reason"),
+
+			("retry.TestRetry.test_disconnect_on_commit",
 			 "Keeps retrying on commit despite connection being dropped"),
-			
-			("retry.TestRetry.test_retry_ForbiddenOnReadOnlyDatabase", 																		
+
+			("retry.TestRetry.test_retry_ForbiddenOnReadOnlyDatabase",
 			 "Behaves strange"),
 
-			("retry.TestRetry.test_retry_NotALeader",																								
+			("retry.TestRetry.test_retry_NotALeader",
 			 "Behaves strange"),
 
-			("retry.TestRetry.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter", 														
+			("retry.TestRetry.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter",
 			 "Behaves strange"),
 
-			
-			("routing.Routing.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function", 						
+
+			("routing.Routing.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function",
 				"requires investigation"),
 
-			("routing.Routing.test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code",										
+			("routing.Routing.test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code",
 				"consume not implemented in backend"),
 
-			("routing.Routing.test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code_using_tx_run", 						
+			("routing.Routing.test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code_using_tx_run",
 				"consume not implemented in backend"),
 
-			("routing.Routing.test_should_retry_read_tx_until_success", 																	
+			("routing.Routing.test_should_retry_read_tx_until_success",
 				"requires investigation"),
 
-			("routing.Routing.test_should_retry_write_tx_until_success", 																	
+			("routing.Routing.test_should_retry_write_tx_until_success",
 				"requires investigation"),
 
-			("routing.Routing.test_should_retry_read_tx_and_rediscovery_until_success", 													
+			("routing.Routing.test_should_retry_read_tx_and_rediscovery_until_success",
 				"requires investigation"),
 
-			("routing.Routing.test_should_retry_write_tx_and_rediscovery_until_success", 													
+			("routing.Routing.test_should_retry_write_tx_and_rediscovery_until_success",
 				"requires investigation"),
 
-			("routing.Routing.test_should_serve_reads_and_fail_writes_when_no_writers_available",											
+			("routing.Routing.test_should_serve_reads_and_fail_writes_when_no_writers_available",
 				"consume not implemented in backend or requires investigation"),
 
-			("routing.Routing.test_should_use_resolver_during_rediscovery_when_existing_routers_fail", 										
+			("routing.Routing.test_should_use_resolver_during_rediscovery_when_existing_routers_fail",
 				"resolver not implemented in backend"),
 
-			("routing.Routing.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors", 								
-				"resolver not implemented in backend"),	
-
-			("routing.Routing.test_should_read_successfully_on_empty_discovery_result_using_session_run",									
+			("routing.Routing.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors",
 				"resolver not implemented in backend"),
 
-			("routing.Routing.test_should_fail_with_routing_failure_on_db_not_found_discovery_failure",										
+			("routing.Routing.test_should_read_successfully_on_empty_discovery_result_using_session_run",
+				"resolver not implemented in backend"),
+
+			("routing.Routing.test_should_fail_with_routing_failure_on_db_not_found_discovery_failure",
 				"add code support"),
 
 			("tlsversions.TestTlsVersions.test_1_1",
@@ -89,8 +89,8 @@ namespace Neo4j.Driver.Tests.TestBackend
 			("test_routing_v3.RoutingV3.test_should_successfully_send_multiple_bookmarks",
 				"Test failing requires investigation"),
 
-			
-			
+
+
 			("test_should_revert_to_initial_router_if_known_router_throws_protocol_errors",
 				"Test failing requires investigation"),
 			("test_should_request_rt_from_all_initial_routers_until_successful",
@@ -101,11 +101,14 @@ namespace Neo4j.Driver.Tests.TestBackend
 				"Test failing requires investigation"),
 
 
-			("test_should_echo_relationship", 
+			("test_should_echo_relationship",
 				"Backend does not yet support serializing relationships"),
-			("test_should_echo_path", 
-				"Backend does not yet support serializing paths")
-		}; 
+			("test_should_echo_path",
+				"Backend does not yet support serializing paths"),
+
+			("stub.bookmarks.",
+				"New session returns initial bookmarks"),
+		};
 
 		public static bool FindTest(string testName, out string reason)
 		{
@@ -118,7 +121,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 			}
 
 			reason = string.Empty;
-			return false;			
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
until returning no bookmarks on new sessions has been implemented.

Towards (but does not depend on) neo4j-drivers/testkit#364