### PR TITLE
Remove 4.0 Testkit feature flag

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/SupportedFeatures.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/SupportedFeatures.cs
@@ -20,7 +20,6 @@ namespace Neo4j.Driver.Tests.TestBackend
                 "Feature:Auth:Custom",
                 "Feature:Auth:Kerberos",
                 "Feature:Bolt:3.0",
-                "Feature:Bolt:4.0",
                 "Feature:Bolt:4.1",
                 "Feature:Bolt:4.2",
                 "Feature:Bolt:4.3",


### PR DESCRIPTION
4.0 is not supported in the 5.0 handshake (full or minimal)