### PR TITLE
Updated comment to match the default value for MaxConnectionPoolSize

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -35,7 +35,7 @@ namespace Neo4j.Driver
     /// <item><see cref="SocketKeepAlive"/>: <c>true</c></item>
     /// <item><see cref="Ipv6Enabled"/>: <c>true</c></item>
     /// <br></br>
-    /// <item><see cref="MaxConnectionPoolSize"/> : <c>500</c> </item>
+    /// <item><see cref="MaxConnectionPoolSize"/> : <c>100</c> </item>
     /// <item><see cref="ConnectionAcquisitionTimeout"/> : <c>1mins</c> </item>
     /// <item><see cref="ConnectionIdleTimeout"/>: <see cref="InfiniteInterval"/></item>
     /// <item><see cref="MaxConnectionLifetime"/>: <c>1h</c></item>


### PR DESCRIPTION
After changing the MaxConnectionPoolSize value to a default of 100 from 500 the associated comment was missed.