### PR TITLE
Skip for stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_nested

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -107,7 +107,9 @@ namespace Neo4j.Driver.Tests.TestBackend
 			("stub.tx_lifetime.test_tx_lifetime.TestTxLifetime.test_managed_tx_raises_tx_managed_exec",
 				"Driver (still) allows explicit managing of managed transaction"),
 
-            ("test_summary.TestSummary.test_protocol_version_information", "Server not responding with 5.0")
+            ("test_summary.TestSummary.test_protocol_version_information", "Server not responding with 5.0"),
+
+            ("stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_nested", "Requires further investigation")
 		};
 
 		public static bool FindTest(string testName, out string reason)


### PR DESCRIPTION
`stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_nested` is failing consistently, skip until we have a better understanding.