### PR TITLE
[4.4] Skip timeout: connection acquisition timeout includes router handshake

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
@@ -58,6 +58,8 @@ namespace Neo4j.Driver.Tests.TestBackend
 			public int connectionTimeoutMs { get; set; } = -1;
 			public int? maxConnectionPoolSize { get; set; }
 			public int? connectionAcquisitionTimeoutMs { get; set; }
+			public int? sessionConnectionTimeoutMs { get; set; }
+			public int? updateRoutingTableTimeoutMs { get; set; }
 			public int? fetchSize { get; set; }
 			public int? maxTxRetryTimeMs { get; set; }
 			public int? livenessCheckTimeoutMs { get; set; }
@@ -110,6 +112,10 @@ namespace Neo4j.Driver.Tests.TestBackend
 			if (data.maxConnectionPoolSize.HasValue) configBuilder.WithMaxConnectionPoolSize(data.maxConnectionPoolSize.Value);
 
 			if (data.connectionAcquisitionTimeoutMs.HasValue) configBuilder.WithConnectionAcquisitionTimeout(TimeSpan.FromMilliseconds(data.connectionAcquisitionTimeoutMs.Value));
+
+			if (data.sessionConnectionTimeoutMs.HasValue) throw new TestKitProtocolException("Backend does not know how to handle sessionConnectionTimeoutMs.");
+
+			if (data.updateRoutingTableTimeoutMs.HasValue) throw new TestKitProtocolException("Backend does not know how to handle updateRoutingTableTimeoutMs.");
 
 			SimpleLogger logger = new SimpleLogger();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -107,7 +107,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 				"Backend does not yet support serializing paths"),
 
 			("stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake",
-				"TODO: ConnectionAcquisitionTimeout cancles handshake with the router"),
+				"TODO: ConnectionAcquisitionTimeout cancels handshake with the router"),
 
 			// Replacing temporary feature flags
 			("test_should_accept_custom_fetch_size_using_driver_configuration",

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -106,6 +106,9 @@ namespace Neo4j.Driver.Tests.TestBackend
 			("test_should_echo_path",
 				"Backend does not yet support serializing paths"),
 
+			("stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake",
+				"TODO: ConnectionAcquisitionTimeout cancles handshake with the router"),
+
 			// Replacing temporary feature flags
 			("test_should_accept_custom_fetch_size_using_driver_configuration",
 				"TMP_DRIVER_FETCH_SIZE"),


### PR DESCRIPTION
Required for https://github.com/neo4j-drivers/testkit/pull/477.

See [internal ADR](https://github.com/neo-technology/drivers-adr/pull/18) for details on the agreed upon approach.