### PR TITLE
Skip timeout: connection acquisition timeout includes router handshake

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -114,7 +114,7 @@ namespace Neo4j.Driver.Tests.TestBackend
 	            "Requires further investigation"),
 
 			("stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake",
-				"TODO: ConnectionAcquisitionTimeout cancles handshake with the router")
+				"TODO: ConnectionAcquisitionTimeout cancels handshake with the router")
 		};
 
 		public static bool FindTest(string testName, out string reason)

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -111,7 +111,10 @@ namespace Neo4j.Driver.Tests.TestBackend
 
             ("stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_nested", "Requires further investigation"),
             ("stub.iteration.test_iteration_session_run.TestIterationSessionRun.test_nested",
-	            "Requires further investigation")
+	            "Requires further investigation"),
+
+			("stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake",
+				"TODO: ConnectionAcquisitionTimeout cancles handshake with the router")
 		};
 
 		public static bool FindTest(string testName, out string reason)


### PR DESCRIPTION
Required for https://github.com/neo4j-drivers/testkit/pull/474.

See [internal ADR](https://github.com/neo-technology/drivers-adr/pull/18) for details on the agreed upon approach.