### PR TITLE
[4.4]Make DbHits and Rows optional in plans.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ProfiledPlanCollectorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Metadata/ProfiledPlanCollectorTests.cs
@@ -103,7 +103,7 @@ namespace Neo4j.Driver.Internal.MessageHandling.Metadata
         }
 
         [Fact]
-        public void ShouldThrowIfDbHitsIsMissing()
+        public void ShouldNotThrowIfDbHitsIsMissing()
         {
             var metadata = new Dictionary<string, object>
             {
@@ -116,15 +116,11 @@ namespace Neo4j.Driver.Internal.MessageHandling.Metadata
             };
             var collector = new ProfiledPlanCollector();
 
-            var ex = Record.Exception(() => collector.Collect(metadata));
-
-            ex.Should().BeOfType<ProtocolException>().Which
-                .Message.Should()
-                .Be("Expected key 'dbHits' to be present in the dictionary, but could not find.");
+            collector.Collect(metadata);
         }
 
         [Fact]
-        public void ShouldThrowIfRowsIsMissing()
+        public void ShouldNotThrowIfRowsIsMissing()
         {
             var metadata = new Dictionary<string, object>
             {
@@ -138,11 +134,7 @@ namespace Neo4j.Driver.Internal.MessageHandling.Metadata
             };
             var collector = new ProfiledPlanCollector();
 
-            var ex = Record.Exception(() => collector.Collect(metadata));
-
-            ex.Should().BeOfType<ProtocolException>().Which
-                .Message.Should()
-                .Be("Expected key 'rows' to be present in the dictionary, but could not find.");
+            collector.Collect(metadata);
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ProfiledPlanCollector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/ProfiledPlanCollector.cs
@@ -60,8 +60,8 @@ namespace Neo4j.Driver.Internal.MessageHandling.Metadata
                 profileDictionary.GetMandatoryValue<string>("operatorType", m => new ProtocolException(m));
             var args = profileDictionary.GetValue("args", new Dictionary<string, object>());
             var identifiers = profileDictionary.GetValue("identifiers", new List<object>()).Cast<string>();
-            var dbHits = profileDictionary.GetMandatoryValue<long>("dbHits", m => new ProtocolException(m));
-            var rows = profileDictionary.GetMandatoryValue<long>("rows", m => new ProtocolException(m));
+            var dbHits = profileDictionary.GetValue<long>("dbHits", 0);
+            var rows = profileDictionary.GetValue<long>("rows", 0);
             var pageCacheHits = profileDictionary.GetValue<long>("pageCacheHits", 0);
             var pageCacheMisses = profileDictionary.GetValue<long>("pageCacheMisses", 0);
             var pageCacheHitRatio = profileDictionary.GetValue<double>("pageCacheHitRatio", 0);


### PR DESCRIPTION
When profiling a plan, any procedure calls will not return dbhits/rows therefore it should not be mandatory.