### PR TITLE
TestKit Backend: Remove Unnecessary Skip

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -112,9 +112,6 @@ namespace Neo4j.Driver.Tests.TestBackend
             ("stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_nested", "Requires further investigation"),
             ("stub.iteration.test_iteration_session_run.TestIterationSessionRun.test_nested",
 	            "Requires further investigation"),
-
-			("stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_handshake",
-				"TODO: ConnectionAcquisitionTimeout cancels handshake with the router")
 		};
 
 		public static bool FindTest(string testName, out string reason)


### PR DESCRIPTION
The driver was behaving correctly. The TestKit tests were adjusted:
https://github.com/neo4j-drivers/testkit/pull/504
Hence, the skip can be removed.