### PR TITLE
Mark client errors as client errors

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
@@ -302,7 +302,7 @@ namespace Neo4j.Driver
     /// When seen this error, contact driver developers.
     /// </summary>
     [DataContract]
-    public class ProtocolException : Neo4jException
+    public class ProtocolException : ClientException
     {
         private const string ErrorCodeInvalid = "Neo.ClientError.Request.Invalid";
         private const string ErrorCodeInvalidFormat = "Neo.ClientError.Request.InvalidFormat";


### PR DESCRIPTION
This works towards our new list of errors on which we want our drivers to fail fast during discovery. Note, that the .NET (with and without this PR) is more strict than other drivers and tends to fail faster during discover.

Here are the error codes other drivers use to determine whether they should fail fast during discovery:

 * Fail fast on
   * `Neo.ClientError.Database.DatabaseNotFound`
   * `Neo.ClientError.Transaction.InvalidBookmark`
   * `Neo.ClientError.Transaction.InvalidBookmarkMixture`
   * `Neo.ClientError.Statement.TypeError`
   * `Neo.ClientError.Statement.ArgumentError`
   * `Neo.ClientError.Request.Invalid`
   * `Neo.ClientError.Security.*`
     * Unless it's `Neo.ClientError.Security.AuthorizationExpired`