### PR TITLE
Added the ability to refresh credentials in the auth token

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
@@ -103,6 +103,36 @@ namespace Neo4j.Driver.Tests
                 nums["Two"].Should().Be(2);
                 nums["Three"].Should().Be(3);
             }
+
+            [Fact]
+            public void ShouldCreateCustomAuthTokenWithRefresher()
+            {
+                var runNumber = 0;
+
+                var authToken = AuthTokens.Custom("zhenli", null, "foo", "custom", null, Refresher);
+                var dict = authToken.AsDictionary();
+
+                dict.Count.Should().Be(4);
+                dict["scheme"].Should().Be("custom");
+                dict["principal"].Should().Be("zhenli");
+                dict["credentials"].Should().Be("1");
+                dict["realm"].Should().Be("foo");
+
+                // refresh token
+                dict = authToken.AsDictionary();
+
+                dict.Count.Should().Be(4);
+                dict["scheme"].Should().Be("custom");
+                dict["principal"].Should().Be("zhenli");
+                // credentials should be updated
+                dict["credentials"].Should().Be("2");
+                dict["realm"].Should().Be("foo");
+
+                void Refresher(IDictionary<string, object> dict)
+                {
+                    dict["credentials"] = (++runNumber).ToString();
+                }
+            }
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/AuthTokens.cs
+++ b/Neo4j.Driver/Neo4j.Driver/AuthTokens.cs
@@ -116,7 +116,6 @@ namespace Neo4j.Driver
             return Custom(principal, credentials, realm, scheme, null);
         }
 
-
         /// <summary>
         ///     Gets an authentication token that can be used to connect to Neo4j instances with auth disabled.
         ///     This will only work if authentication is disabled on the Neo4j Instance we are connecting to.
@@ -133,6 +132,27 @@ namespace Neo4j.Driver
         public static IAuthToken Custom(string principal, string credentials, string realm, string scheme,
             Dictionary<string, object> parameters)
         {
+            return Custom(principal, credentials, realm, scheme, parameters, null);
+        }
+
+
+        /// <summary>
+        ///     Gets an authentication token that can be used to connect to Neo4j instances with auth disabled.
+        ///     This will only work if authentication is disabled on the Neo4j Instance we are connecting to.
+        /// </summary>
+        /// <remarks>
+        ///     <see cref="GraphDatabase.Driver(string, IAuthToken, Action{ConfigBuilder})" />
+        /// </remarks>
+        /// <param name="principal">This is used to identify who this token represents.</param>
+        /// <param name="credentials">This is credentials authenticating the principal.</param>
+        /// <param name="realm">This is the "realm", specifies the authentication provider.</param>
+        /// <param name="scheme">This is the authentication scheme, specifying what kind of authentication that should be used.</param>
+        /// <param name="parameters">Extra parameters to be sent along the authentication provider. If none is given, then no extra parameters will be added.</param>
+        /// <param name="tokenRefresher">Optional function which can be used to refresh tokens with a limited validity period.</param>
+        /// <returns>An authentication token that can be used to connect to Neo4j.</returns>
+        public static IAuthToken Custom(string principal, string credentials, string realm, string scheme,
+            Dictionary<string, object> parameters, Action<IDictionary<string, object>> tokenRefresher)
+        {
             var token = new Dictionary<string, object>();
             if (!string.IsNullOrEmpty(principal)) token.Add(PrincipalKey, principal);
             if (!string.IsNullOrEmpty(scheme)) token.Add(SchemeKey, scheme);
@@ -144,7 +164,7 @@ namespace Neo4j.Driver
                 token.Add(ParametersKey, parameters);
             }
 
-            return new AuthToken(token);
+            return new AuthToken(token, tokenRefresher);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AuthToken.cs
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+using System;
 using System.Collections.Generic;
 using Neo4j.Driver.Internal.IO;
 
@@ -29,14 +30,25 @@ namespace Neo4j.Driver.Internal
         public const string CredentialsKey = "credentials";
         public const string RealmKey = "realm";
         public const string ParametersKey = "parameters";
-        
-        public AuthToken(IDictionary<string, object> content)
+
+        private readonly IDictionary<string, object> _content;
+        private readonly Action<IDictionary<string, object>> _tokenRefresher;
+
+        public AuthToken(IDictionary<string, object> content, Action<IDictionary<string, object>> tokenRefresher = null)
         {
             Throw.ArgumentNullException.IfNull(content, nameof(content));
-            Content = content;
+            _content = content;
+            _tokenRefresher = tokenRefresher;
         }
 
-        public IDictionary<string, object> Content { get; }
+        public IDictionary<string, object> Content
+        {
+            get
+            {
+                _tokenRefresher?.Invoke(_content);
+                return _content;
+            }
+        }
     }
 
     internal static class AuthTokenExtensions


### PR DESCRIPTION
Add the ability to Refresh Auth Token Credentials

Currently when credentials expire, GraphDatabase.Driver will continue trying to connect with the outdated login/password. There is no ability to update or refresh login credentials (See https://github.com/neo4j/neo4j-dotnet-driver/issues/664).

This PR introduces the ability to pass an optional tokenRefresher function to an AuthToken object which will change credentials as they become obsolete.

There are no breaking changes introduced in this PR.

There is a test which validates these modifications by using a simple tokenRefresher which increments the credentials and verifies that the auth token is being updated as expected.

Also tested with connection idle timeout 20 seconds and interval between requests 30 seconds, new credentials were correctly used to create a new connection.

Intended use
`var authToken = new SecretsProvider().GetNeo4jToken();
var driver = GraphDatabase.Driver(Url, authToken, o => o.WithEncryptionLevel(EncryptionLevel.Encrypted));`

`GetNeo4jToken` will receive credits from the secret manager and update them if necessary. This is useful because when changing the password, there is no need to restart the microservices that are connected to the database.