### PR TITLE
Fix IsRetriable not being available on the public API

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ErrorExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/ErrorExtensions.cs
@@ -95,7 +95,7 @@ namespace Neo4j.Driver.Internal
 
         public static bool CanBeRetried(this Exception error)
         {
-            return error is Neo4jException neo4JException && neo4JException.CanBeRetried;
+            return error is Neo4jException neo4JException && neo4JException.IsRetriable;
         }
 
         public static bool IsRecoverableError(this Exception error)

--- a/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4jException.cs
@@ -27,7 +27,11 @@ namespace Neo4j.Driver
     [DataContract]
     public class Neo4jException : Exception
     {
-        internal virtual bool CanBeRetried => false;
+        /// <summary>
+        /// Gets whether the exception retriable or not.
+        /// </summary>
+        public virtual bool IsRetriable => false;
+        
         /// <summary>
         /// Create a new <see cref="Neo4jException"/>
         /// </summary>
@@ -143,7 +147,7 @@ namespace Neo4j.Driver
     [DataContract]
     public class TransientException : Neo4jException
     {
-        internal override bool CanBeRetried => true;
+        public override bool IsRetriable => true;
 
         /// <summary>
         /// Create a new <see cref="TransientException"/>.
@@ -222,7 +226,7 @@ namespace Neo4j.Driver
     [DataContract]
     public class ServiceUnavailableException : Neo4jException
     {
-        internal override bool CanBeRetried => true;
+        public override bool IsRetriable => true;
 
         /// <summary>
         /// Create a new <see cref="ServiceUnavailableException"/> with an error message.
@@ -251,7 +255,7 @@ namespace Neo4j.Driver
     [DataContract]
     public class SessionExpiredException : Neo4jException
     {
-        internal override bool CanBeRetried => true;
+        public override bool IsRetriable => true;
 
         /// <summary>
         /// Create a new <see cref="SessionExpiredException"/> with an error message.
@@ -277,7 +281,7 @@ namespace Neo4j.Driver
     [DataContract]
     public class ConnectionReadTimeoutException : Neo4jException
     {
-        internal override bool CanBeRetried => true;
+        public override bool IsRetriable => true;
 
         /// <summary>
         /// Create a new <see cref="ConnectionReadTimeoutException"/> with an error message.
@@ -402,7 +406,7 @@ namespace Neo4j.Driver
     /// </summary>
     public class AuthorizationException : SecurityException
     {
-        internal override bool CanBeRetried => true;
+        public override bool IsRetriable => true;
 
         private const string ErrorCode = "Neo.ClientError.Security.AuthorizationExpired";
 


### PR DESCRIPTION
IsRetriable was supposed to be available as a public call, this resolves it be marked as internal and incorrectly named.