### PR TITLE
Comply to the latest revision of the ExecuteQuery ADR

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Experimental/FluentQueries/IExecutableQuery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Experimental/FluentQueries/IExecutableQuery.cs
@@ -60,8 +60,8 @@ public interface IExecutableQuery<T>
     /// </summary>
     /// <param name="streamProcessor">The stream processor function.</param>
     /// <returns>The executable query object allowing method chaining.</returns>
-    IExecutableQuery<TResult> WithStreamProcessor<TResult>(
-        Func<IAsyncEnumerable<IRecord>, ValueTask<TResult>> streamProcessor);
+    IExecutableQuery<TResult> WithResultTransformer<TResult>(
+        Func<IAsyncEnumerable<IRecord>, ValueTask<TResult>> resultTransformer);
 
     /// <summary>Executes the query as configured and returns the results, fully materialised.</summary>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>

--- a/Neo4j.Driver/Neo4j.Driver/Experimental/QueryConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Experimental/QueryConfig.cs
@@ -30,7 +30,7 @@ public class QueryConfig
     /// <param name="impersonatedUser">Username of a user to impersonate while executing a query.</param>
     /// <param name="bookmarkManager">
     /// Instance of <see cref="IBookmarkManager"/> to provide bookmarks for query execution, and
-    /// receive resulting bookmarks.<br/> When null the driver will use it's own <see cref="IBookmarkManager"/> for causal
+    /// receive resulting bookmarks.<br/> When null the driver will use its own <see cref="IBookmarkManager"/> for causal
     /// chaining.
     /// </param>
     /// <param name="enableBookmarkManager">

--- a/Neo4j.Driver/Neo4j.Driver/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IDriver.cs
@@ -17,6 +17,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Neo4j.Driver.Experimental;
+using Neo4j.Driver.Experimental.FluentQueries;
 
 namespace Neo4j.Driver;
 
@@ -84,4 +86,12 @@ public interface IDriver : IDisposable, IAsyncDisposable
     /// cluster support multi-databases, otherwise false.
     /// </returns>
     Task<bool> SupportsMultiDbAsync();
+
+    /// <summary>
+    /// Returns the bookmark manager exercised by <see cref="ExecutableQuery{T}.ExecuteAsync"/> by default.
+    /// The returned bookmark manager can then be explicitly configured for use by specific <see cref="IAsyncSession"/>
+    /// calls.
+    /// </summary>
+    /// <returns>The default bookmark manager instance.</returns>
+    IBookmarkManager GetDefaultExecuteQueryBookmarkManager();
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IInternalDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IInternalDriver.cs
@@ -29,7 +29,7 @@ internal interface IInternalDriver : IDriver
 
     Task<EagerResult<TResult>> ExecuteQueryAsync<TResult>(
         Query query,
-        Func<IAsyncEnumerable<IRecord>, ValueTask<TResult>> streamProcessor,
+        Func<IAsyncEnumerable<IRecord>, ValueTask<TResult>> resultTransformer,
         QueryConfig config = null,
         CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Rename stream processor to result transformer

Expose ExecuteQuery's default bookmark manager