### PR TITLE
[4.4] Close connections on exception updating routing table.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_3Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_3Tests.cs
@@ -102,7 +102,6 @@ namespace Neo4j.Driver.Internal.Protocol
 			{
 				{"name", "molly"},
 				{"age", "1"},
-				{"color", "white"}
 			};
 
 			var mockConn = Tests.Routing.ClusterDiscoveryTests.Setup43SocketConnection(routingContext, 
@@ -126,7 +125,6 @@ namespace Neo4j.Driver.Internal.Protocol
 				{
 					{"name", "molly"},
 					{"age", "1"},
-					{"color", "white"}
 				};
 
 			var mockConn = Tests.Routing.ClusterDiscoveryTests.Setup43SocketConnection(routingContext, 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_3Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_3Tests.cs
@@ -25,6 +25,7 @@ using Neo4j.Driver.Internal.Messaging.V4_3;
 using Neo4j.Driver.Internal.Result;
 using Xunit;
 using Neo4j.Driver.Internal.MessageHandling.V4_3;
+using Record = Xunit.Record;
 
 namespace Neo4j.Driver.Internal.Protocol
 {
@@ -91,6 +92,33 @@ namespace Neo4j.Driver.Internal.Protocol
 			routingTable.ToDictionary().Should().ContainKey("db").WhichValue.Should().Be(databaseName);
 		}
 
+		[Fact]
+		public async Task ShouldCloseConnectionWhenThrows()
+		{
+
+			var databaseName = "myDatabaseName";
+			var protocol = new BoltProtocolV4_3(new Dictionary<string, string> { { "ContextKey", "ContextValue" } });
+			var routingContext = new Dictionary<string, string>
+			{
+				{"name", "molly"},
+				{"age", "1"},
+				{"color", "white"}
+			};
+
+			var mockConn = Tests.Routing.ClusterDiscoveryTests.Setup43SocketConnection(routingContext, 
+				databaseName, 
+				null, 
+				Tests.Routing.ClusterDiscoveryTests.CreateGetServersDictionary(1, 1, 1));
+
+			mockConn.Setup(x => x.SyncAsync()).Throws(new FatalDiscoveryException("database doesn't exist"));
+			
+			mockConn.Setup(m => m.RoutingContext).Returns(routingContext);
+			var exception = await Record.ExceptionAsync(() => protocol.GetRoutingTable(mockConn.Object, databaseName, null, null));
+
+			exception.Should().BeOfType<FatalDiscoveryException>();
+			mockConn.Verify(x => x.CloseAsync(), Times.Once);
+		}
+		
 		private IConnection SetupMockedConnection(string databaseName)
 		{
 			//Given

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_4Tests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Protocol/BoltProtocolV4_4Tests.cs
@@ -90,7 +90,6 @@ namespace Neo4j.Driver.Internal.Protocol
 			{
 				{"name", "molly"},
 				{"age", "1"},
-				{"color", "white"}
 			};
 
 			var mockConn = new Mock<IConnection>();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_3.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_3.cs
@@ -54,8 +54,15 @@ namespace Neo4j.Driver.Internal.Protocol
 
 			await connection.EnqueueAsync(new RouteMessage(connection.RoutingContext, bookmark, database), responseHandler).ConfigureAwait(false);
 
-			await connection.SyncAsync().ConfigureAwait(false);
-			await connection.CloseAsync().ConfigureAwait(false);
+			try
+			{
+				await connection.SyncAsync().ConfigureAwait(false);
+			}
+			finally
+			{
+				await connection.CloseAsync().ConfigureAwait(false);
+			}
+
 
 			//Since 4.4 the Routing information will contain a db. 4.3 needs to populate this here as it's not received in the older route response...
 			responseHandler.RoutingInformation.Add(RoutingTableDBKey, database);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_4.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV4_4.cs
@@ -71,8 +71,14 @@ namespace Neo4j.Driver.Internal.Protocol
 
 			await connection.EnqueueAsync(new RouteMessage(connection.RoutingContext, bookmark, database, impersonatedUser), responseHandler).ConfigureAwait(false);
 
-			await connection.SyncAsync().ConfigureAwait(false);
-			await connection.CloseAsync().ConfigureAwait(false);
+			try
+			{
+				await connection.SyncAsync().ConfigureAwait(false);
+			}
+			finally
+			{
+				await connection.CloseAsync().ConfigureAwait(false);
+			}
 
 			return (IReadOnlyDictionary<string, object>)responseHandler.RoutingInformation;
 		}


### PR DESCRIPTION
- Ensure the connection is closed(returned to the pool) when updating routing tables in case of exceptions.