### PR TITLE
[5.11] Zoned date time fixes

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializerTests.cs
@@ -120,7 +120,7 @@ namespace Neo4j.Driver.Internal.IO.ValueSerializers.Temporal
         public void ShouldSerializeDateTimeWithZoneId_Windows_Istanbul()
         {
             var inDate = new ZonedDateTime(1978, 12, 16, 12, 35, 59, 128000987, Zone.Of("Europe/Istanbul"));
-            var expected = (seconds: 282652559L, nanos: 128000987L, zoneId: "Europe/Istanbul");
+            var expected = (seconds: 282648959, nanos: 128000987L, zoneId: "Europe/Istanbul");
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer;
             writer.Write(inDate);
@@ -140,7 +140,7 @@ namespace Neo4j.Driver.Internal.IO.ValueSerializers.Temporal
         public void ShouldDeserializeDateTimeWithZoneId_Windows_Istanbul()
         {
             var expected = new ZonedDateTime(1978, 12, 16, 12, 35, 59, 128000987, Zone.Of("Europe/Istanbul"));
-            var inDate = (seconds: 282652559L, nanos: 128000987L, zoneId: "Europe/Istanbul");
+            var inDate = (seconds: 282648959, nanos: 128000987L, zoneId: "Europe/Istanbul");
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections;
 using FluentAssertions;
+using Neo4j.Driver.Internal;
 using Xunit;
 
 namespace Neo4j.Driver.Tests.Types
@@ -425,6 +426,46 @@ namespace Neo4j.Driver.Tests.Types
             {
                 testAction.Should().Throw<InvalidCastException>();
             }
+        }
+
+        [Fact]
+        public void ShouldCreateMinZonedDateTime()
+        {
+            var zone = new ZonedDateTime(TemporalHelpers.MinUtcForZonedDateTime, 0, Zone.Of(0));
+            zone.Year.Should().Be(-999_999_999);
+            zone.Month.Should().Be(1);
+            zone.Day.Should().Be(1);
+            zone.Hour.Should().Be(0);
+            zone.Minute.Should().Be(0);
+            zone.Second.Should().Be(0);
+            zone.Nanosecond.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldCreateMinZonedDateTimeFromComponents()
+        {
+            var zone = new ZonedDateTime(-999_999_999, 1, 1, 0, 0, 0, Zone.Of(0));
+            zone.UtcSeconds.Should().Be(TemporalHelpers.MinUtcForZonedDateTime);
+        }
+
+        [Fact]
+        public void ShouldCreateMaxZonedDateTime()
+        {
+            var zone = new ZonedDateTime(TemporalHelpers.MaxUtcForZonedDateTime, 0, Zone.Of(0));
+            zone.Year.Should().Be(999_999_999);
+            zone.Month.Should().Be(12);
+            zone.Day.Should().Be(31);
+            zone.Hour.Should().Be(23);
+            zone.Minute.Should().Be(59);
+            zone.Second.Should().Be(59);
+            zone.Nanosecond.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldCreateMaxZonedDateTimeFromComponents()
+        {
+            var zone = new ZonedDateTime(999_999_999, 12, 31, 23, 59, 59, Zone.Of(0));
+            zone.UtcSeconds.Should().Be(TemporalHelpers.MaxUtcForZonedDateTime);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -423,11 +423,12 @@ namespace Neo4j.Driver.Tests.Types
         public static TheoryData<Func<ZonedDateTime>> NullZoneConstructors = new()
         {
             () => new ZonedDateTime(0, 0, null),
+            () => new ZonedDateTime(0, null),
             () => new ZonedDateTime(DateTime.Now, null),
             () => new ZonedDateTime(new LocalDateTime(DateTime.Now), null),
             () => new ZonedDateTime(2020, 12, 31, 12, 0, 0, null)
         };
-        
+
         [Theory]
         [MemberData(nameof(NullZoneConstructors))]
         public void ShouldThrowWithNullZoneId(Func<ZonedDateTime> ctor)
@@ -435,5 +436,18 @@ namespace Neo4j.Driver.Tests.Types
             Record.Exception(ctor).Should().BeOfType<ArgumentNullException>();
         }
 
+        public static TheoryData<Func<ZonedDateTime>> LocalConstructorsWithUnkownZoneIds = new()
+        {
+            () => new ZonedDateTime(DateTime.Now, "Europe/Neo4j"),
+            () => new ZonedDateTime(2020, 12, 31, 12, 0, 0, new ZoneId("Europe/Neo4j")),
+            () => new ZonedDateTime(new LocalDateTime(DateTime.Now), new ZoneId("Europe/Neo4j"))
+        };
+
+        [Theory]
+        [MemberData(nameof(LocalConstructorsWithUnkownZoneIds))]
+        public void ShouldThrowExceptionWhenNonMonotonicTimeProvidedAndUnknownZoneId(Func<ZonedDateTime> ctor)
+        {
+            Record.Exception(ctor).Should().BeOfType<TimeZoneNotFoundException>();
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -422,8 +422,8 @@ namespace Neo4j.Driver.Tests.Types
 
         public static TheoryData<Func<ZonedDateTime>> NullZoneConstructors = new()
         {
-            () => new ZonedDateTime(0, 0, null),
-            () => new ZonedDateTime(0, null),
+            () => new ZonedDateTime(0L, 0, null),
+            () => new ZonedDateTime(0L, null),
             () => new ZonedDateTime(DateTime.Now, null),
             () => new ZonedDateTime(new LocalDateTime(DateTime.Now), null),
             () => new ZonedDateTime(2020, 12, 31, 12, 0, 0, null)

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -450,45 +450,6 @@ namespace Neo4j.Driver.Tests.Types
         {
             Record.Exception(ctor).Should().BeOfType<TimeZoneNotFoundException>();
         }
-    
-        [Fact]
-        public void ShouldCreateMinZonedDateTime()
-        {
-            var zone = new ZonedDateTime(TemporalHelpers.MinUtcForZonedDateTime, 0, Zone.Of(0));
-            zone.Year.Should().Be(-999_999_999);
-            zone.Month.Should().Be(1);
-            zone.Day.Should().Be(1);
-            zone.Hour.Should().Be(0);
-            zone.Minute.Should().Be(0);
-            zone.Second.Should().Be(0);
-            zone.Nanosecond.Should().Be(0);
-        }
 
-        [Fact]
-        public void ShouldCreateMinZonedDateTimeFromComponents()
-        {
-            var zone = new ZonedDateTime(-999_999_999, 1, 1, 0 ,0, 0, Zone.Of(0));
-            zone.UtcSeconds.Should().Be(TemporalHelpers.MinUtcForZonedDateTime);
-        }
-
-        [Fact]
-        public void ShouldCreateMaxZonedDateTime()
-        {
-            var zone = new ZonedDateTime(TemporalHelpers.MaxUtcForZonedDateTime, 0, Zone.Of(0));
-            zone.Year.Should().Be(999_999_999);
-            zone.Month.Should().Be(12);
-            zone.Day.Should().Be(31);
-            zone.Hour.Should().Be(23);
-            zone.Minute.Should().Be(59);
-            zone.Second.Should().Be(59);
-            zone.Nanosecond.Should().Be(0);
-        }
-
-        [Fact]
-        public void ShouldCreateMaxZonedDateTimeFromComponents()
-        {
-            var zone = new ZonedDateTime(999_999_999, 12, 31, 23, 59, 59, Zone.Of(0));
-            zone.UtcSeconds.Should().Be(TemporalHelpers.MaxUtcForZonedDateTime);
-        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
+using Neo4j.Driver.Internal;
 using Xunit;
 
 namespace Neo4j.Driver.Tests.Types
@@ -448,6 +449,46 @@ namespace Neo4j.Driver.Tests.Types
         public void ShouldThrowExceptionWhenNonMonotonicTimeProvidedAndUnknownZoneId(Func<ZonedDateTime> ctor)
         {
             Record.Exception(ctor).Should().BeOfType<TimeZoneNotFoundException>();
+        }
+    
+        [Fact]
+        public void ShouldCreateMinZonedDateTime()
+        {
+            var zone = new ZonedDateTime(TemporalHelpers.MinUtcForZonedDateTime, 0, Zone.Of(0));
+            zone.Year.Should().Be(-999_999_999);
+            zone.Month.Should().Be(1);
+            zone.Day.Should().Be(1);
+            zone.Hour.Should().Be(0);
+            zone.Minute.Should().Be(0);
+            zone.Second.Should().Be(0);
+            zone.Nanosecond.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldCreateMinZonedDateTimeFromComponents()
+        {
+            var zone = new ZonedDateTime(-999_999_999, 1, 1, 0 ,0, 0, Zone.Of(0));
+            zone.UtcSeconds.Should().Be(TemporalHelpers.MinUtcForZonedDateTime);
+        }
+
+        [Fact]
+        public void ShouldCreateMaxZonedDateTime()
+        {
+            var zone = new ZonedDateTime(TemporalHelpers.MaxUtcForZonedDateTime, 0, Zone.Of(0));
+            zone.Year.Should().Be(999_999_999);
+            zone.Month.Should().Be(12);
+            zone.Day.Should().Be(31);
+            zone.Hour.Should().Be(23);
+            zone.Minute.Should().Be(59);
+            zone.Second.Should().Be(59);
+            zone.Nanosecond.Should().Be(0);
+        }
+
+        [Fact]
+        public void ShouldCreateMaxZonedDateTimeFromComponents()
+        {
+            var zone = new ZonedDateTime(999_999_999, 12, 31, 23, 59, 59, Zone.Of(0));
+            zone.UtcSeconds.Should().Be(TemporalHelpers.MaxUtcForZonedDateTime);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -57,8 +57,8 @@ internal static class TemporalHelpers
     private const int NanosecondsPerTick = 100;
     internal const long DateTimeOffsetMinSeconds = -62_135_596_800;
     internal const long DateTimeOffsetMaxSeconds = 253_402_300_799;
-    internal const long MinUtcForZonedDateTime = -31557014167219199L;
-    internal const long MaxUtcForZonedDateTime = 31556889864403198L; 
+    internal const long MinUtcForZonedDateTime = -31557014135596800;
+    internal const long MaxUtcForZonedDateTime = 31556889832780799; 
 
     public static long ToNanoOfDay(this IHasTimeComponents time)
     {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -55,6 +55,8 @@ internal static class TemporalHelpers
     private const long Days0000To1970 = DaysPerCycle * 5L - (30L * 365L + 7L);
     private const int DaysPerCycle = 146_097;
     private const int NanosecondsPerTick = 100;
+    internal const long DateTimeOffsetMinSeconds = -62_135_596_800;
+    internal const long DateTimeOffsetMaxSeconds = 253_402_300_799;
 
     public static long ToNanoOfDay(this IHasTimeComponents time)
     {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -57,6 +57,8 @@ internal static class TemporalHelpers
     private const int NanosecondsPerTick = 100;
     internal const long DateTimeOffsetMinSeconds = -62_135_596_800;
     internal const long DateTimeOffsetMaxSeconds = 253_402_300_799;
+    internal const long MinUtcForZonedDateTime = -31557014167219199L;
+    internal const long MaxUtcForZonedDateTime = 31556889864403198L; 
 
     public static long ToNanoOfDay(this IHasTimeComponents time)
     {
@@ -112,7 +114,7 @@ internal static class TemporalHelpers
     {
         var epochDay = FloorDiv(epochSeconds, SecondsPerDay);
         var secondsOfDay = FloorMod(epochSeconds, SecondsPerDay);
-        var nanoOfDay = secondsOfDay * NanosPerSecond + nano;
+        var nanoOfDay = secondsOfDay * NanosPerSecond + nano;   
 
         ComponentsOfEpochDays(epochDay, out var year, out var month, out var day);
         ComponentsOfNanoOfDay(nanoOfDay, out var hour, out var minute, out var second, out var nanosecond);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializer.cs
@@ -58,14 +58,14 @@ internal class UtcZonedDateTimeSerializer : IPackStreamSerializer
         {
             case ZoneId zone:
                 writer.WriteStructHeader(StructSize, StructTypeWithId);
-                writer.WriteLong(TemporalHelpers.UtcEpochSeconds(dateTime));
+                writer.WriteLong(dateTime.UtcSeconds);
                 writer.WriteInt(dateTime.Nanosecond);
                 writer.WriteString(zone.Id);
                 break;
 
             case ZoneOffset zone:
                 writer.WriteStructHeader(StructSize, StructTypeWithOffset);
-                writer.WriteLong(TemporalHelpers.UtcEpochSeconds(dateTime));
+                writer.WriteLong(dateTime.UtcSeconds);
                 writer.WriteInt(dateTime.Nanosecond);
                 writer.WriteInt(zone.OffsetSeconds);
                 break;

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -46,8 +46,8 @@ public sealed class ZonedDateTime : TemporalValue,
         UnspecifiedDateTimeKind,
 
         /// <summary>
-        /// The lookup of the offset will be completed with a value truncated to the range of BCL types meaning that any
-        /// rules that may apply outside of the BCL ranges are not applied.
+        /// The lookup of the offset will be completed with a value truncated to the range of BCL date/time types meaning that any
+        /// rules that may apply outside of the BCL date/time type range are not applied.
         /// </summary>
         RuleLookupTruncatedToClrRange
     }
@@ -60,10 +60,10 @@ public sealed class ZonedDateTime : TemporalValue,
 
     /// <summary>
     /// Create a new instance of <see cref="ZonedDateTime"/> using delta from unix epoch (1970-1-1 00:00:00.00 UTC). <br/>
-    /// Allows handling values in range for neo4j and outside of the range of BCL date types (<see cref="DateTime"/>,
+    /// Allows handling values in range for neo4j and outside of the range of BCL date/time types (<see cref="DateTime"/>,
     /// <see cref="DateTimeOffset"/>).
     /// <remarks>
-    /// When <paramref name="utcSeconds"/> is outside of BCL date ranges (-62_135_596_800, 253_402_300_799) and
+    /// When <paramref name="utcSeconds"/> is outside of BCL date/time types range (-62_135_596_800, 253_402_300_799) and
     /// <paramref name="zone"/> is a <see cref="ZoneId"/> the <see cref="ZonedDateTime"/> instance will be marked as
     /// <see cref="Ambiguous"/>.
     /// </remarks>
@@ -74,6 +74,11 @@ public sealed class ZonedDateTime : TemporalValue,
     /// <param name="zone">Zone for offsetting utc to local.</param>
     public ZonedDateTime(long utcSeconds, int nanos, Zone zone)
     {
+        if (utcSeconds is > TemporalHelpers.MaxUtcForZonedDateTime or < TemporalHelpers.MinUtcForZonedDateTime)
+        {
+            throw new ArgumentOutOfRangeException(nameof(utcSeconds));
+        }
+        
         UtcSeconds = utcSeconds;
         Nanosecond = nanos;
         Zone = zone ?? throw new ArgumentNullException(nameof(zone));

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -410,7 +410,7 @@ public sealed class ZonedDateTime : TemporalValue,
             if (zone is ZoneOffset zo)
             {
                 _offsetSeconds = zo.OffsetSeconds;
-                var epoch = new LocalDateTime(year, month, day, hour, month, second, nanosecond).ToEpochSeconds();
+                var epoch = new LocalDateTime(year, month, day, hour, minute, second, nanosecond).ToEpochSeconds();
                 UtcSeconds = epoch - _offsetSeconds.Value;
             }
             else
@@ -420,7 +420,7 @@ public sealed class ZonedDateTime : TemporalValue,
                     AmbiguityReason.ZoneIdLookUpWithLocalTime |
                     AmbiguityReason.RuleLookupTruncatedToClrRange);
 
-                var local = new LocalDateTime(year, month, day, hour, month, second, nanosecond);
+                var local = new LocalDateTime(year, month, day, hour, minute, second, nanosecond);
                 var offset = LookupOffsetAt(ClrFriendly(local));
                 _offsetSeconds = offset.Seconds;
                 UtcSeconds = local.ToEpochSeconds() - _offsetSeconds.Value;
@@ -434,7 +434,7 @@ public sealed class ZonedDateTime : TemporalValue,
                 var mod = Math.Abs(zo.OffsetSeconds);
                 if (mod % 60 > 0 || mod > 50400)
                 {
-                    var epoch = new LocalDateTime(year, month, day, hour, month, second, nanosecond).ToEpochSeconds();
+                    var epoch = new LocalDateTime(year, month, day, hour, minute, second, nanosecond).ToEpochSeconds();
                     UtcSeconds = epoch - _offsetSeconds.Value;
                 }
                 else

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -408,7 +408,7 @@ public sealed class ZonedDateTime : TemporalValue,
 
             var local = new LocalDateTime(year, month, day, hour, minute, second, nanosecond);
             var offset = LookupOffsetAt(ClrFriendly(local));
-            _offsetSeconds = offset.Seconds;
+            _offsetSeconds = (int)offset.TotalSeconds;
             UtcSeconds = local.ToEpochSeconds() - _offsetSeconds.Value;
         }
     }
@@ -685,12 +685,7 @@ public sealed class ZonedDateTime : TemporalValue,
     {
         unchecked
         {
-            var hashCode = Year;
-            hashCode = (hashCode * 397) ^ Month;
-            hashCode = (hashCode * 397) ^ Day;
-            hashCode = (hashCode * 397) ^ Hour;
-            hashCode = (hashCode * 397) ^ Second;
-            hashCode = (hashCode * 397) ^ Nanosecond;
+            var hashCode = Nanosecond;
             hashCode = (hashCode * 397) ^ Zone.GetHashCode();
             hashCode = (hashCode * 397) ^ UtcSeconds.GetHashCode();
             return hashCode;

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -406,22 +406,29 @@ public sealed class ZonedDateTime : TemporalValue,
         }
         else
         {
-            if (Year is > 9999 or < 1)
+            try
             {
-                SetAmbiguous(
-                    AmbiguityReason.UnspecifiedDateTimeKind |
-                    AmbiguityReason.ZoneIdLookUpWithLocalTime |
-                    AmbiguityReason.RuleLookupTruncatedToClrRange);
-            }
-            else
-            {
-                SetAmbiguous(AmbiguityReason.UnspecifiedDateTimeKind | AmbiguityReason.ZoneIdLookUpWithLocalTime);
-            }
+                if (Year is > 9999 or < 1)
+                {
+                    SetAmbiguous(
+                        AmbiguityReason.UnspecifiedDateTimeKind |
+                        AmbiguityReason.ZoneIdLookUpWithLocalTime |
+                        AmbiguityReason.RuleLookupTruncatedToClrRange);
+                }
+                else
+                {
+                    SetAmbiguous(AmbiguityReason.UnspecifiedDateTimeKind | AmbiguityReason.ZoneIdLookUpWithLocalTime);
+                }
 
-            var local = new LocalDateTime(Year, Month, Day, Hour, Minute, Second, Nanosecond);
-            var offset = LookupOffsetAt(ClrFriendly(local));
-            _offsetSeconds = (int)offset.TotalSeconds;
-            UtcSeconds = local.ToEpochSeconds() - _offsetSeconds.Value;
+                var local = new LocalDateTime(Year, Month, Day, Hour, Minute, Second, Nanosecond);
+                var offset = LookupOffsetAt(ClrFriendly(local));
+                _offsetSeconds = (int)offset.TotalSeconds;
+                UtcSeconds = local.ToEpochSeconds() - _offsetSeconds.Value;
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                UnknownZoneInfo = true;
+            }
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -331,8 +331,8 @@ public sealed class ZonedDateTime : TemporalValue,
     }
 
     /// <summary>Initializes a new instance of <see cref="ZonedDateTime"/> from individual date time component values</summary>
-    /// <param name="year"></param>
-    /// <param name="month"></param>
+    /// <param name="year">Year in Locale.</param>
+    /// <param name="month">Month in Locale.</param>
     /// <param name="day"></param>
     /// <param name="hour"></param>
     /// <param name="minute"></param>
@@ -448,6 +448,7 @@ public sealed class ZonedDateTime : TemporalValue,
             else
             {
                 SetAmbiguous(AmbiguityReason.UnspecifiedDateTimeKind | AmbiguityReason.ZoneIdLookUpWithLocalTime);
+                
                 var local = new DateTime(Year, Month, Day, Hour, Minute, Second, DateTimeKind.Unspecified)
                     .AddTicks(TemporalHelpers.ExtractTicksFromNanosecond(TruncatedNanos()));
 
@@ -488,15 +489,16 @@ public sealed class ZonedDateTime : TemporalValue,
     public long UtcSeconds { get; }
 
     /// <summary>
-    /// Gets the number of Ticks from the Unix Epoch (00:00:00 UTC, Thursday, 1 January 1970). Truncates Nanoseconds
+    /// Gets the number of Ticks from the Unix Epoch (00:00:00 UTC, Thursday, 1 January 1970). Truncates <see cref="Nanosecond"/>
     /// to closest tick.
     /// </summary>
-    public long Ticks => UtcSeconds * TimeSpan.TicksPerSecond + TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond);
+    public long EpochTicks => UtcSeconds * TimeSpan.TicksPerSecond + TemporalHelpers.ExtractTicksFromNanosecond(Nanosecond);
 
     /// <summary>The time zone that this instance represents.</summary>
     public Zone Zone { get; }
 
     /// <summary>Gets a <see cref="DateTime"/> value that represents the local date and time of this instance.</summary>
+    /// <exception cref="TimeZoneNotFoundException">If <see cref="Zone"/> is not known locally.</exception>
     /// <exception cref="ValueOverflowException">If the value cannot be represented with DateTime</exception>
     /// <exception cref="ValueTruncationException">If a truncation occurs during conversion</exception>
     public DateTime LocalDateTime
@@ -543,6 +545,7 @@ public sealed class ZonedDateTime : TemporalValue,
     }
 
     /// <summary></summary>
+    /// <exception cref="TimeZoneNotFoundException">If <see cref="Zone"/> is not known locally.</exception>
     public int OffsetSeconds => _offsetSeconds ?? LookupOffsetFromZone();
 
     /// <summary>Gets a <see cref="TimeSpan"/> value that represents the offset of this instance.</summary>


### PR DESCRIPTION
Fixes for ZonedDateTime.
- Introduce `Ambiguous` `bool` property, Creating `ZonedDateTime` with out a datetime kind, or using a datetime kind local with a named Zone:`Zone.of(string)`, meant we could create an ambiguous date time.
- Introduce `ZonedDateTime.AmbiguityReason` enum flags type.
- Introduce `Reason` `AmbiguityReason` property for `ZonedDateTimes`, to allow users to see why a value is considered ambiguous.
- Introduce `UtcSeconds` `long` property which is the understood monotonic timestamp from unix epoch in UTC.
- Fix ZonedDateTime lazily parsing when returned from a query, now it is parsed immediately.
- Fix ZonedDateTime not supporting values outside of range of BCL Date Types
- Add `Ticks` Property, and constructor which can be used for easy interop with nodatime's [Instant](https://nodatime.org/1.0.x/api/NodaTime.Instant.html)