### PR TITLE
Improve transaction timeout docs

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -51,7 +51,7 @@ public sealed class TransactionConfig
 
     /// <summary>
     /// Transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows the driver to limit query/transaction execution time. The Specified timeout
+    /// by the database. This functionality allows the driver to limit query/transaction execution time. The specified timeout
     /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
     /// ignored and will fall back to the default for server versions 4.2 to including 5.2. Leave this field unmodified or set it
@@ -116,7 +116,7 @@ public sealed class TransactionConfigBuilder
 
     /// <summary>
     /// Sets the transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows user code to limit query/transaction execution time. The Specified timeout
+    /// by the database. This functionality allows user code to limit query/transaction execution time. The specified timeout
     /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
     /// ignored and will fall back to default for server versions between 4.2 and 5.2 (inclusive). Leave this field unmodified or

--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -50,14 +50,16 @@ public sealed class TransactionConfig
     }
 
     /// <summary>
-    /// Transaction timeout. Transactions that execute longer than the configured timeout will be terminated by the
-    /// database. This functionality allows to limit query/transaction execution time. Specified timeout overrides the default
-    /// timeout configured in the database using <code>dbms.transaction.timeout</code> setting. Leave this field unmodified to
-    /// use default timeout configured on database. Setting a zero timeout will result in no timeout.
+    /// Transaction timeout. Transactions that execute longer than the configured timeout will be terminated
+    /// by the database. This functionality allows to limit query/transaction execution time. The Specified timeout overrides the
+    /// default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
+    /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
+    /// ignored and will fall back to the default for server versions 4.2 to including 5.2. Leave this field unmodified or set it
+    /// to <code>null</code> to use the default timeout configured on the server. A timeout of zero will make the transaction
+    /// execute indefinitely.
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// If the value given to transaction timeout in milliseconds is less than
-    /// zero
+    /// If the value given to transaction timeout in milliseconds is less than zero.
     /// </exception>
     public TimeSpan? Timeout
     {
@@ -114,9 +116,12 @@ public sealed class TransactionConfigBuilder
 
     /// <summary>
     /// Sets the transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows to limit query/transaction execution time. Specified timeout overrides the
-    /// default timeout configured in the database using <code>dbms.transaction.timeout</code> setting. Leave this field
-    /// unmodified to use default timeout configured on database. Setting a zero timeout will result in no timeout.
+    /// by the database. This functionality allows to limit query/transaction execution time. The Specified timeout overrides the
+    /// default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
+    /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
+    /// ignored and will fall back to default for server versions 4.2 to including 5.2. Leave this field unmodified or set it to
+    /// <code>null</code> to use the default timeout configured on the server. A timeout of zero will make the transaction execute
+    /// indefinitely.
     /// <para/>
     /// If the timeout is not an exact number of milliseconds, it will be rounded up to the next millisecond.
     /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -51,8 +51,8 @@ public sealed class TransactionConfig
 
     /// <summary>
     /// Transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows to limit query/transaction execution time. The Specified timeout overrides the
-    /// default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
+    /// by the database. This functionality allows the driver to limit query/transaction execution time. The Specified timeout
+    /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
     /// ignored and will fall back to the default for server versions 4.2 to including 5.2. Leave this field unmodified or set it
     /// to <code>null</code> to use the default timeout configured on the server. A timeout of zero will make the transaction
@@ -116,12 +116,12 @@ public sealed class TransactionConfigBuilder
 
     /// <summary>
     /// Sets the transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows to limit query/transaction execution time. The Specified timeout overrides the
-    /// default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
+    /// by the database. This functionality allows the driver to limit query/transaction execution time. The Specified timeout
+    /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
-    /// ignored and will fall back to default for server versions 4.2 to including 5.2. Leave this field unmodified or set it to
-    /// <code>null</code> to use the default timeout configured on the server. A timeout of zero will make the transaction execute
-    /// indefinitely.
+    /// ignored and will fall back to default for server versions between 4.2 and 5.2 (inclusive). Leave this field unmodified or
+    /// set it to <code>null</code> to use the default timeout configured on the server. A timeout of zero will make the transaction
+    /// execute indefinitely.
     /// <para/>
     /// If the timeout is not an exact number of milliseconds, it will be rounded up to the next millisecond.
     /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -116,7 +116,7 @@ public sealed class TransactionConfigBuilder
 
     /// <summary>
     /// Sets the transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows the driver to limit query/transaction execution time. The Specified timeout
+    /// by the database. This functionality allows user code to limit query/transaction execution time. The Specified timeout
     /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
     /// ignored and will fall back to default for server versions between 4.2 and 5.2 (inclusive). Leave this field unmodified or

--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -54,7 +54,7 @@ public sealed class TransactionConfig
     /// by the database. This functionality allows user code to limit query/transaction execution time. The specified timeout
     /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
-    /// ignored and will fall back to the default for server versions 4.2 to including 5.2. Leave this field unmodified or set it
+    /// ignored and will fall back to the default for server versions between 4.2 and 5.2 (inclusive). Leave this field unmodified or set it
     /// to <code>null</code> to use the default timeout configured on the server. A timeout of zero will make the transaction
     /// execute indefinitely.
     /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TransactionConfig.cs
@@ -51,7 +51,7 @@ public sealed class TransactionConfig
 
     /// <summary>
     /// Transaction timeout. Transactions that execute longer than the configured timeout will be terminated
-    /// by the database. This functionality allows the driver to limit query/transaction execution time. The specified timeout
+    /// by the database. This functionality allows user code to limit query/transaction execution time. The specified timeout
     /// overrides the default timeout configured in the database using the <code>db.transaction.timeout</code> setting 
     /// (<code>dbms.transaction.timeout</code> before Neo4j 5.0). Values higher than <code>db.transaction.timeout</code> will be
     /// ignored and will fall back to the default for server versions 4.2 to including 5.2. Leave this field unmodified or set it


### PR DESCRIPTION
The timeout behaves differently on different server versions in respects to the user being or not being able to overwrite the server timeout with a bigger value.

Also make sure the docs mention special values like `0`.