### PR TITLE
[4.4] zoned date time fixes

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializerTests.cs
@@ -107,7 +107,7 @@ namespace Neo4j.Driver.Internal.IO.ValueSerializers.Temporal
         [WindowsFact]
         public void ShouldSerializeDateTimeWithZoneId_Windows_Istanbul()
         {
-            var inDate = new ZonedDateTime(1978, 12, 16, 12, 35, 59, 128000987, Zone.Of("Europe/Istanbul"));
+            var inDate = new ZonedDateTime(1978, 12, 16, 13, 35, 59, 128000987, Zone.Of("Europe/Istanbul"));
             var expected = (seconds: 282652559L, nanos: 128000987L, zoneId: "Europe/Istanbul");
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer();
@@ -127,7 +127,7 @@ namespace Neo4j.Driver.Internal.IO.ValueSerializers.Temporal
         [WindowsFact]
         public void ShouldDeserializeDateTimeWithZoneId_Windows_Istanbul()
         {
-            var expected = new ZonedDateTime(1978, 12, 16, 12, 35, 59, 128000987, Zone.Of("Europe/Istanbul"));
+            var expected = new ZonedDateTime(1978, 12, 16, 13, 35, 59, 128000987, Zone.Of("Europe/Istanbul"));
             var inDate = (seconds: 282652559L, nanos: 128000987L, zoneId: "Europe/Istanbul");
             var writerMachine = CreateWriterMachine();
             var writer = writerMachine.Writer();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/TemporalHelpers.cs
@@ -57,7 +57,9 @@ namespace Neo4j.Driver.Internal
         private const int NanosecondsPerTick = 100; 
         internal const long DateTimeOffsetMinSeconds = -62_135_596_800;
         internal const long DateTimeOffsetMaxSeconds = 253_402_300_799;
-
+        internal const long MinUtcForZonedDateTime = -31557014135596800;
+        internal const long MaxUtcForZonedDateTime = 31556889832780799;
+        
         public static long ToNanoOfDay(this IHasTimeComponents time)
         {
             return (time.Hour * NanosPerHour) + (time.Minute * NanosPerMinute) + (time.Second * NanosPerSecond) +


### PR DESCRIPTION
This change backports fixes for zoned date time handling from the 5.X implementation.