### PR TITLE
Liveness check

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/GetConnectionPoolMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/GetConnectionPoolMetrics.cs
@@ -20,11 +20,15 @@ namespace Neo4j.Driver.Tests.TestBackend;
 
 internal class GetConnectionPoolMetrics : IProtocolObject
 {
-    public Request data { get; set; }
+    public GetConnectionPoolMetricsDto data { get; set; }
 
     public override string Respond()
     {
-        var driver = ObjManager.GetObject<NewDriver>(data.driverId).Driver as Internal.Driver;
+        if (ObjManager.GetObject<NewDriver>(data.driverId).Driver is not Internal.Driver driver)
+        {
+            throw new Exception("The driver is not an internal driver");
+        }
+        
         var metrics = driver.Context.Metrics.ConnectionPoolMetrics;
         var address = metrics.Where(x => x.Value.Id.Contains(data.address, StringComparison.OrdinalIgnoreCase))
             .Select(x => x.Value)
@@ -35,7 +39,7 @@ internal class GetConnectionPoolMetrics : IProtocolObject
             new { inUse = address.InUse, idle = address.Idle }).Encode();
     }
 
-    public class Request
+    public class GetConnectionPoolMetricsDto
     {
         public string driverId { get; set; }
         public string address { get; set; }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/GetConnectionPoolMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/GetConnectionPoolMetrics.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend;
+
+internal class GetConnectionPoolMetrics : IProtocolObject
+{
+    public Request data { get; set; }
+
+    public override string Respond()
+    {
+        var driver = ObjManager.GetObject<NewDriver>(data.driverId).Driver as Internal.Driver;
+        var metrics = driver.Context.Metrics.ConnectionPoolMetrics;
+        var address = metrics.Where(x => x.Value.Id.Contains(data.address, StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Value)
+            .First();
+
+        return new ProtocolResponse(
+            "ConnectionPoolMetrics",
+            new { inUse = address.InUse, idle = address.Idle }).Encode();
+    }
+
+    public class Request
+    {
+        public string driverId { get; set; }
+        public string address { get; set; }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
@@ -65,6 +65,8 @@ internal class NewDriver : IProtocolObject
 
     private void DriverConfig(ConfigBuilder configBuilder)
     {
+        configBuilder.WithMetricsEnabled(true);
+        
         if (!string.IsNullOrEmpty(data.userAgent))
         {
             configBuilder.WithUserAgent(data.userAgent);

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
@@ -26,25 +26,26 @@ internal class NewDriver : IProtocolObject
 {
     public NewDriverType data { get; set; } = new();
 
-    [JsonIgnore] public IDriver Driver { get; set; }
+    [JsonIgnore]
+    public IDriver Driver { get; set; }
 
-    [JsonIgnore] private Controller Control { get; set; }
+    [JsonIgnore]
+    private Controller Control { get; set; }
 
     public override Task Process(Controller controller)
     {
         Control = controller;
 
-
         if (data.authorizationToken != null)
         {
-            IAuthToken authToken = data.authorizationToken.AsToken();
-           
+            var authToken = data.authorizationToken.AsToken();
+
             Driver = GraphDatabase.Driver(data.uri, authToken, DriverConfig);
         }
         else
         {
             var authDataManager = ObjManager.GetObject(data.authTokenManagerId);
-            
+
             if (authDataManager is NewNeo4jAuthTokenManager atm)
             {
                 Driver = GraphDatabase.Driver(data.uri, atm.TokenManager, DriverConfig);
@@ -66,7 +67,7 @@ internal class NewDriver : IProtocolObject
     private void DriverConfig(ConfigBuilder configBuilder)
     {
         configBuilder.WithMetricsEnabled(true);
-        
+
         if (!string.IsNullOrEmpty(data.userAgent))
         {
             configBuilder.WithUserAgent(data.userAgent);
@@ -152,19 +153,20 @@ internal class NewDriver : IProtocolObject
                 var cats = data.notificationsDisabledCategories
                     ?.Select(x => Enum.Parse<Category>(x, true))
                     .ToArray();
-                
+
                 configBuilder.WithNotifications(sev, cats);
             }
         }
 
-        if(data.telemetryDisabled.HasValue && data.telemetryDisabled.Value)
+        if (data.telemetryDisabled.HasValue && data.telemetryDisabled.Value)
         {
             configBuilder.WithTelemetryDisabled();
         }
 
         if (data.livenessCheckTimeoutMs.HasValue)
         {
-            configBuilder.WithLivenessCheckTimeout(TimeSpan.FromMilliseconds(data.livenessCheckTimeoutMs.Value));
+            configBuilder.WithConnectionLivenessCheckTimeout(
+                TimeSpan.FromMilliseconds(data.livenessCheckTimeoutMs.Value));
         }
 
         var logger = new SimpleLogger();

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
@@ -160,6 +160,11 @@ internal class NewDriver : IProtocolObject
             configBuilder.WithTelemetryDisabled();
         }
 
+        if (data.livenessCheckTimeoutMs.HasValue)
+        {
+            configBuilder.WithLivenessCheckTimeout(TimeSpan.FromMilliseconds(data.livenessCheckTimeoutMs.Value));
+        }
+
         var logger = new SimpleLogger();
         configBuilder.WithLogger(logger);
     }
@@ -200,5 +205,6 @@ internal class NewDriver : IProtocolObject
 
         public string notificationsMinSeverity { get; set; }
         public string[] notificationsDisabledCategories { get; set; }
+        public int? livenessCheckTimeoutMs { get; set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriverConverter.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriverConverter.cs
@@ -49,6 +49,7 @@ internal class NewDriverConverter : JsonConverter<NewDriver.NewDriverType>
         newDriverRequest.maxTxRetryTimeMs = jsonObj["maxTxRetryTimeMs"]?.Value<long?>();
         newDriverRequest.notificationsMinSeverity = jsonObj["notificationsMinSeverity"]?.Value<string>();
         newDriverRequest.telemetryDisabled = jsonObj["telemetryDisabled"]?.Value<bool?>();
+        newDriverRequest.livenessCheckTimeoutMs = jsonObj["livenessCheckTimeoutMs"]?.Value<int?>();
 
         if (jsonObj.TryGetValue("trustedCertificates", out var token))
         {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Time/FakeTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Time/FakeTime.cs
@@ -93,9 +93,9 @@ internal class FakeTime : IDateTimeProvider
 
     public ITimer NewTimer()
     {
-        var t= new FakeTimer();
-        Timers.Add(t);
-        return t;
+        var fakeTimer = new FakeTimer();
+        Timers.Add(fakeTimer);
+        return fakeTimer;
     }
 
     public void Freeze()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/SupportedFeatures.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/SupportedFeatures.cs
@@ -37,7 +37,7 @@ internal static class SupportedFeatures
             "Feature:API:Driver.VerifyAuthentication",
             "Feature:API:Driver.VerifyConnectivity",
             "Feature:API:Driver.SupportsSessionAuth",
-            //"Feature:API:Liveness.Check",
+            "Feature:API:Liveness.Check",
             "Feature:API:Result.List",
             "Feature:API:Result.Peek",
             "Feature:API:Result.Single",

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionValidatorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionValidatorTests.cs
@@ -29,10 +29,8 @@ namespace Neo4j.Driver.Tests
             TimeSpan? maxConnLifetime = null,
             TimeSpan? livelinessCheckTimeout = null)
         {
-            connIdleTimeout ??= Config.InfiniteInterval;
-            maxConnLifetime ??= Config.InfiniteInterval;
-            livelinessCheckTimeout ??= Config.InfiniteInterval;
-            return new ConnectionValidator(connIdleTimeout.Value, maxConnLifetime.Value, livelinessCheckTimeout.Value);
+            return new ConnectionValidator(connIdleTimeout ?? Config.InfiniteInterval,
+                maxConnLifetime ?? Config.InfiniteInterval, livelinessCheckTimeout);
         }
 
         public class IsConnectionReusableTests

--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -118,7 +118,19 @@ public class Config
     public TimeSpan ConnectionAcquisitionTimeout { get; internal set; } = TimeSpan.FromMinutes(1);
     
     /// <summary>
-    /// 
+    /// Pooled connections that have been idle in the pool for longer than this timeout will be tested before they are
+    /// used again, to ensure they are still live. If this option is set too low, an additional network call will
+    /// be incurred when acquiring a connection, which causes a performance hit.
+    /// <para/>
+    /// If this is set high, you may receive sessions that are backed by no longer live connections, which will lead
+    /// to exceptions in your application. Assuming the database is running, these exceptions will go away if you
+    /// retry acquiring sessions.
+    /// <para/>
+    /// Hence, this parameter tunes a balance between the likelihood of your application seeing connection problems, and
+    /// performance.
+    /// <para/>
+    /// You normally should not need to tune this parameter. No connection liveness check is done by default.
+    /// Value 0 means connections will always be tested for validity. Values less than 0 are not allowed.
     /// </summary>
     public TimeSpan? ConnectionLivenessThreshold { get; internal set; }
 

--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -116,6 +116,11 @@ public class Config
     /// create a new connection when pool is not full.
     /// </summary>
     public TimeSpan ConnectionAcquisitionTimeout { get; internal set; } = TimeSpan.FromMinutes(1);
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    public TimeSpan? ConnectionLivenessThreshold { get; internal set; }
 
     /// <summary>The connection timeout when establishing a connection with a server.</summary>
     public TimeSpan ConnectionTimeout { get; internal set; } = TimeSpan.FromSeconds(30);

--- a/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
@@ -394,6 +394,7 @@ public sealed class ConfigBuilder
     /// <seealso cref="WithNotificationsDisabled"/>
     /// <seealso cref="SessionConfigBuilder.WithNotifications"/>
     /// <seealso cref="SessionConfigBuilder.WithNotificationsDisabled"/>
+    /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     public ConfigBuilder WithNotifications(
         Severity? minimumSeverity,
         Category[] disabledCategories)
@@ -435,6 +436,7 @@ public sealed class ConfigBuilder
     /// telemetry data for diagnostics purposes.<br/>
     /// By default the driver allows the collection of this telemetry.
     /// </summary>
+    /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     public ConfigBuilder WithTelemetryDisabled()
     {
         _config.TelemetryDisabled = true;
@@ -444,9 +446,21 @@ public sealed class ConfigBuilder
     /// <summary>
     /// Sets the <see cref="MessageReaderConfig"/> config to use in the driver.
     /// </summary>
+    /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     public ConfigBuilder WithMessageReaderConfig(MessageReaderConfig config)
     {
         _config.MessageReaderConfig = config ?? throw new ArgumentNullException(nameof(config));
+        return this;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="fromMilliseconds"></param>
+    /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
+    public ConfigBuilder WithLivenessCheckTimeout(TimeSpan fromMilliseconds)
+    {
+        _config.ConnectionLivenessThreshold = fromMilliseconds;
         return this;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
@@ -454,13 +454,35 @@ public sealed class ConfigBuilder
     }
 
     /// <summary>
-    /// 
+    /// Sets the connection liveness timeout. Pooled connections that have been idle in the pool for longer than this
+    /// timeout will be tested before they are used again, to ensure they are still live. If this option is set too low,
+    /// an additional network call will be incurred when acquiring a connection, which causes a performance hit.
+    /// <para/>
+    /// If this is set high, you may receive sessions that are backed by no longer live connections, which will lead
+    /// to exceptions in your application. Assuming the database is running, these exceptions will go away if you
+    /// retry acquiring sessions.
+    /// <para/>
+    /// Hence, this parameter tunes a balance between the likelihood of your application seeing connection problems, and
+    /// performance.
+    /// <para/>
+    /// You normally should not need to tune this parameter. No connection liveness check is done by default.
+    /// Value 0 means connections will always be tested for validity. Values less than 0 are not allowed.
     /// </summary>
-    /// <param name="fromMilliseconds"></param>
+    /// <param name="timeout">The liveness timeout.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// When <paramref name="timeout"/> is less than <see cref="TimeSpan.Zero"/>.
+    /// </exception>
     /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
-    public ConfigBuilder WithLivenessCheckTimeout(TimeSpan fromMilliseconds)
+    public ConfigBuilder WithConnectionLivenessCheckTimeout(TimeSpan timeout)
     {
-        _config.ConnectionLivenessThreshold = fromMilliseconds;
+        if (timeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                timeout,
+                "must be >= 0");
+        }
+        _config.ConnectionLivenessThreshold = timeout;
         return this;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AcquireStatus.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AcquireStatus.cs
@@ -1,0 +1,24 @@
+﻿
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neo4j.Driver.Internal;
+
+internal enum AcquireStatus
+{
+    Healthy,
+    Unhealthy,
+    RequiresLivenessProbe
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/PooledConnection.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Neo4j.Driver.Internal.Services;
 
 namespace Neo4j.Driver.Internal.Connector;
 
@@ -30,10 +31,11 @@ internal class PooledConnection : DelegatedConnection, IPooledConnection
         : base(conn)
     {
         _releaseManager = releaseManager;
+        
         // IdleTimer starts to count when the connection is put back to the pool.
-        IdleTimer = new StopwatchBasedTimer();
+        IdleTimer = DateTimeProvider.StaticInstance.NewTimer();
         // LifetimeTimer starts to count once the connection is created.
-        LifetimeTimer = new StopwatchBasedTimer();
+        LifetimeTimer = DateTimeProvider.StaticInstance.NewTimer();
         LifetimeTimer.Start();
     }
 
@@ -123,12 +125,7 @@ internal class PooledConnection : DelegatedConnection, IPooledConnection
 
 internal class StopwatchBasedTimer : ITimer
 {
-    private readonly Stopwatch _stopwatch;
-
-    public StopwatchBasedTimer()
-    {
-        _stopwatch = new Stopwatch();
-    }
+    private readonly Stopwatch _stopwatch = new();
 
     public long ElapsedMilliseconds => _stopwatch.ElapsedMilliseconds;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DriverContext.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DriverContext.cs
@@ -67,5 +67,4 @@ internal sealed class DriverContext
     public IHostResolver HostResolver { get; }
     public IInternalMetrics Metrics { get; }
     public IDictionary<string, string> RoutingContext { get; }
-
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IPooledConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IPooledConnection.cs
@@ -21,7 +21,6 @@ namespace Neo4j.Driver.Internal;
 internal interface IPooledConnection : IConnection
 {
     ITimer IdleTimer { get; }
-
     ITimer LifetimeTimer { get; }
     bool StaleCredentials { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Services/DateTimeProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Services/DateTimeProvider.cs
@@ -14,12 +14,14 @@
 // limitations under the License.
 
 using System;
+using Neo4j.Driver.Internal.Connector;
 
 namespace Neo4j.Driver.Internal.Services;
 
 internal interface IDateTimeProvider
 {
     DateTime Now();
+    ITimer NewTimer();
 }
 
 internal class DateTimeProvider : IDateTimeProvider
@@ -35,5 +37,10 @@ internal class DateTimeProvider : IDateTimeProvider
     public DateTime Now()
     {
         return DateTime.UtcNow;
+    }
+
+    public ITimer NewTimer()
+    {
+        return new StopwatchBasedTimer();
     }
 }


### PR DESCRIPTION
This change introduces a liveness check timeout.
- Liveness checks will be completed when borrowing a pooled connection, given that the connection has been idle longer than the timeout.
- The driver, by default, will not add liveness checks, but this can be configured with `WithConnectionLivenessCheckTimeout` on the `ConfigBuilder`.

```csharp
using var driver = GraphDatabase.Driver(uri, creds, 
    cb => cb.WithConnectionLivenessCheckTimeout(TimeSpan.FromSeconds(30));
```

Using a timeout of `0`, all connections will complete a liveness check when taken from the pool; this ensures connections are healthy but comes at the cost of performance when running queries or starting transactions.