### PR TITLE
Protect default memory pool for bolt

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -270,12 +270,13 @@ public sealed class MessageReaderConfig
         {
             return;
         }
-        MemoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+
         if (minBufferSize is < -1 or 0)
         {
             throw new ArgumentOutOfRangeException(nameof(minBufferSize));
         }
         MinBufferSize = minBufferSize == -1 ? 65_535 + 4 : minBufferSize;
+        MemoryPool = memoryPool ?? new PipeReaderMemoryPool(MinBufferSize);
         StreamPipeReaderOptions = new(MemoryPool, MinBufferSize, leaveOpen: true);
     }
     
@@ -289,8 +290,8 @@ public sealed class MessageReaderConfig
     /// <summary>
     /// The memory pool for creating buffers when reading messages. The PipeReader will borrow memory from the pool of
     /// at least <see cref="MinBufferSize"/> size. The message reader can request larger memory blocks to host
-    /// an entire message. User code can provide an implementation for monitoring; by default, the driver will use
-    /// .NET's <see cref="MemoryPool{Byte}.Shared"/> pool.
+    /// an entire message. User code can provide an implementation for monitoring; by default, the driver will allocate
+    /// a new array pool for only it's use.
     /// </summary>
     public MemoryPool<byte> MemoryPool { get; }
     

--- a/Neo4j.Driver/Neo4j.Driver/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Config.cs
@@ -255,13 +255,18 @@ public sealed class MessageReaderConfig
     /// setting this to true will revert the driver to the legacy message reader.</param>
     /// <param name="memoryPool">The memory pool for creating buffers when reading messages. The PipeReader will borrow
     /// memory from the pool of at least ReadBufferSize size. The message reader can request larger memory blocks to
-    /// host an entire message. User code can provide an implementation for monitoring; by default, the driver will use
-    /// .NET's <see cref="System.Buffers.MemoryPool{Byte}.Shared"/> pool.</param>
+    /// host an entire message. User code can provide an implementation for monitoring; by default, the driver will
+    /// allocate a new array pool that does not take advantage of shared memory pools.</param>
     /// <param name="minBufferSize">The minimum buffer size to use when renting memory from the pool. The default value
     /// is 65,539.</param>
     /// <seealso cref="PipeReader"/>
     /// <seealso cref="MemoryPool{T}"/>
     /// <seealso cref="StreamPipeReaderOptions"/>
+    /// <remarks>
+    /// To optimize the memory usage of the driver pass .NET's shared memory pool(<see cref="MemoryPool{T}.Shared"/>) as
+    /// the <paramref name="memoryPool"/>, this should only be used when there is complete trust over the usage of
+    /// shared memory buffers in the application as other components may be using the same memory pool.
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">If <paramref name="minBufferSize"/>is less than 1.</exception>
     public MessageReaderConfig(bool disablePipelinedMessageReader = false, MemoryPool<byte> memoryPool = null, int minBufferSize = -1)
     {
@@ -291,7 +296,7 @@ public sealed class MessageReaderConfig
     /// The memory pool for creating buffers when reading messages. The PipeReader will borrow memory from the pool of
     /// at least <see cref="MinBufferSize"/> size. The message reader can request larger memory blocks to host
     /// an entire message. User code can provide an implementation for monitoring; by default, the driver will allocate
-    /// a new array pool for only it's use.
+    /// a new array pool that does not take advantage of shared memory pools.
     /// </summary>
     public MemoryPool<byte> MemoryPool { get; }
     

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/PipeReaderMemoryPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/PipeReaderMemoryPool.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Buffers;
+
+namespace Neo4j.Driver.Internal;
+
+/// <summary>
+/// Simple memory pool based on the .NET's Pool.
+/// </summary>
+internal sealed class PipeReaderMemoryPool : MemoryPool<byte>
+{
+    private readonly int _defaultSize;
+    private ArrayPool<byte> Pool { get; } = ArrayPool<byte>.Create();
+
+    public PipeReaderMemoryPool(int defaultSize)
+    {
+        _defaultSize = defaultSize;
+    }
+
+    public override int MaxBufferSize => int.MaxValue;
+
+    public override IMemoryOwner<byte> Rent(int minimumBufferSize = -1)
+    {
+        if (minimumBufferSize == -1)
+        {
+            minimumBufferSize = _defaultSize;
+        }
+        
+        if (minimumBufferSize < 0 || minimumBufferSize > MaxBufferSize)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumBufferSize), minimumBufferSize, "requested size is invalid");
+        }
+        
+        return new PooledMemory(minimumBufferSize, Pool);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+    }
+
+    private sealed class PooledMemory : IMemoryOwner<byte>
+    {
+        private byte[] _array;
+        private readonly ArrayPool<byte> _pool;
+
+        public PooledMemory(int size, ArrayPool<byte> pool)
+        {
+            _array = pool.Rent(size);
+            _pool = pool;
+        }
+
+        public Memory<byte> Memory
+        {
+            get
+            {
+                var array = _array;
+                if (array == null)
+                {
+                    throw new ObjectDisposedException(nameof(PooledMemory));
+                }
+
+                return new Memory<byte>(array);
+            }
+        }
+
+        public void Dispose()
+        {
+            var array = _array;
+            
+            if (array == null)
+            {
+                return;
+            }
+
+            _array = null;
+            _pool.Return(array);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/PipeReaderMemoryPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/PipeReaderMemoryPool.cs
@@ -24,11 +24,12 @@ namespace Neo4j.Driver.Internal;
 internal sealed class PipeReaderMemoryPool : MemoryPool<byte>
 {
     private readonly int _defaultSize;
-    private ArrayPool<byte> Pool { get; } = ArrayPool<byte>.Create();
+    private readonly ArrayPool<byte> _pool;
 
     public PipeReaderMemoryPool(int defaultSize)
     {
         _defaultSize = defaultSize;
+        _pool = ArrayPool<byte>.Create();
     }
 
     public override int MaxBufferSize => int.MaxValue;
@@ -45,7 +46,7 @@ internal sealed class PipeReaderMemoryPool : MemoryPool<byte>
             throw new ArgumentOutOfRangeException(nameof(minimumBufferSize), minimumBufferSize, "requested size is invalid");
         }
         
-        return new PooledMemory(minimumBufferSize, Pool);
+        return new PooledMemory(minimumBufferSize, _pool);
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
This change introduces and defaults the pool used for bolt to a hermetic pool, and removes the ability to disable new pipeline reader
- The best pool to use is the shared pool as it means any buffers allocated are shared to the application, but this exposes users to a level of risk, while we should suggest users use the shared pool, the default should remain isolated.