### PR TITLE
Rename IProtocolObject  to ProtocolObject

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Controller.cs
@@ -55,7 +55,7 @@ internal class Controller
         BreakProcessLoop = false; //Ensure that any process loops that this one is running within still continue.
     }
 
-    public async Task<IProtocolObject> TryConsumeStreamObjectOfType(Type type)
+    public async Task<ProtocolObject> TryConsumeStreamObjectOfType(Type type)
     {
         //Read the next incoming request message
         await RequestReader.ParseNextRequest().ConfigureAwait(false);
@@ -70,7 +70,7 @@ internal class Controller
         return ProtocolObjectFactory.CreateObject(RequestReader.CurrentObjectData);
     }
 
-    public async Task<T> TryConsumeStreamObjectOfType<T>() where T : IProtocolObject
+    public async Task<T> TryConsumeStreamObjectOfType<T>() where T : ProtocolObject
     {
         var result = await TryConsumeStreamObjectOfType(typeof(T)).ConfigureAwait(false);
         return (T)result;
@@ -187,7 +187,7 @@ internal class Controller
         BreakProcessLoop = true;
     }
 
-    public async Task SendResponse(IProtocolObject protocolObject)
+    public async Task SendResponse(ProtocolObject protocolObject)
     {
         await ResponseWriter.WriteResponseAsync(protocolObject).ConfigureAwait(false);
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/IO/RequestReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/IO/RequestReader.cs
@@ -110,7 +110,7 @@ internal class RequestReader
         return false;
     }
 
-    public IProtocolObject CreateObjectFromData()
+    public ProtocolObject CreateObjectFromData()
     {
         return ProtocolObjectFactory.CreateObject(CurrentObjectData);
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/IO/ResponseWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/IO/ResponseWriter.cs
@@ -31,7 +31,7 @@ internal class ResponseWriter
 
     private StreamWriter WriterTarget { get; }
 
-    public async Task<string> WriteResponseAsync(IProtocolObject protocolObject)
+    public async Task<string> WriteResponseAsync(ProtocolObject protocolObject)
     {
         return await WriteResponseAsync(protocolObject.Respond());
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/AuthTokenManagerClose.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/AuthTokenManagerClose.cs
@@ -15,7 +15,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class AuthTokenManagerClose : IProtocolObject
+internal class AuthTokenManagerClose : ProtocolObject
 {
     public AuthTokenManagerCloseType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/AuthTokenManagerGetAuthCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/AuthTokenManagerGetAuthCompleted.cs
@@ -17,7 +17,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class AuthTokenManagerGetAuthCompleted : IProtocolObject
+internal class AuthTokenManagerGetAuthCompleted : ProtocolObject
 {
     public AuthTokenManagerGetAuthCompletedDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/AuthTokenManagerHandleSecurityExceptionCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/AuthTokenManagerHandleSecurityExceptionCompleted.cs
@@ -17,7 +17,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class AuthTokenManagerHandleSecurityExceptionCompleted : IProtocolObject
+internal class AuthTokenManagerHandleSecurityExceptionCompleted : ProtocolObject
 {
     public AuthTokenManagerHandleSecurityExceptionCompletedDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/BasicAuthTokenProviderCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/BasicAuthTokenProviderCompleted.cs
@@ -17,7 +17,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BasicAuthTokenProviderCompleted : IProtocolObject
+internal class BasicAuthTokenProviderCompleted : ProtocolObject
 {
     public BasicAuthTokenProviderCompletedDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/BearerAuthTokenProviderCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/BearerAuthTokenProviderCompleted.cs
@@ -17,7 +17,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BearerAuthTokenProviderCompleted : IProtocolObject
+internal class BearerAuthTokenProviderCompleted : ProtocolObject
 {
     public BearerAuthTokenProviderCompletedDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/CheckSessionAuthSupport.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/CheckSessionAuthSupport.cs
@@ -17,7 +17,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class CheckSessionAuthSupport : IProtocolObject
+internal class CheckSessionAuthSupport : ProtocolObject
 {
     public CheckSessionAuthSupportDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/NewBasicAuthTokenManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/NewBasicAuthTokenManager.cs
@@ -24,7 +24,7 @@ using Neo4j.Driver.Internal.Auth;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal abstract class TestAuthTokenManager : IProtocolObject, IAuthTokenManager
+internal abstract class TestAuthTokenManager : ProtocolObject, IAuthTokenManager
 {
     public abstract ValueTask<IAuthToken> GetTokenAsync(CancellationToken cancellationToken = default);
 
@@ -34,7 +34,7 @@ internal abstract class TestAuthTokenManager : IProtocolObject, IAuthTokenManage
         CancellationToken cancellationToken = default);
 }
 
-internal class NewNeo4jAuthTokenManager : IProtocolObject
+internal class NewNeo4jAuthTokenManager : ProtocolObject
 {
     protected Controller _controller;
     public IAuthTokenManager TokenManager;

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/TemporalAuthTokenProviderCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/TemporalAuthTokenProviderCompleted.cs
@@ -17,7 +17,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class TemporalAuthTokenProviderCompleted : IProtocolObject
+internal class TemporalAuthTokenProviderCompleted : ProtocolObject
 {
     public TemporalAuthTokenProviderCompletedDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/VerifyAuthentication.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Auth/VerifyAuthentication.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class VerifyAuthentication : IProtocolObject
+internal class VerifyAuthentication : ProtocolObject
 {
     public VerifyAuthenticationDTO data { get; set; } = null!;
     [JsonIgnore]

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/AuthorizationToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/AuthorizationToken.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class AuthorizationToken : IProtocolObject
+internal class AuthorizationToken : ProtocolObject
 {
     public AuthorizationTokenType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerClose.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerClose.cs
@@ -15,7 +15,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BookmarkManagerClose : IProtocolObject
+internal class BookmarkManagerClose : ProtocolObject
 {
     public BookmarkManagerCloseDto data;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerConsumerRequest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerConsumerRequest.cs
@@ -15,7 +15,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BookmarkManagerConsumerRequest : IProtocolObject
+internal class BookmarkManagerConsumerRequest : ProtocolObject
 {
     public BookmarkManagerConsumerRequest(ProtocolObjectManager pom)
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerSupplierRequest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerSupplierRequest.cs
@@ -15,7 +15,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BookmarkManagerSupplierRequest : IProtocolObject
+internal class BookmarkManagerSupplierRequest : ProtocolObject
 {
     public BookmarkManagerSupplierRequest(ProtocolObjectManager pom)
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksConsumerCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksConsumerCompleted.cs
@@ -15,7 +15,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BookmarksConsumerCompleted : IProtocolObject
+internal class BookmarksConsumerCompleted : ProtocolObject
 {
     public BookmarksConsumerCompletedDto data;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksSupplierCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksSupplierCompleted.cs
@@ -15,7 +15,7 @@
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class BookmarksSupplierCompleted : IProtocolObject
+internal class BookmarksSupplierCompleted : ProtocolObject
 {
     public BookmarksSupplierCompletedDto data;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/NewBookmarkManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/NewBookmarkManager.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class NewBookmarkManager : IProtocolObject
+internal class NewBookmarkManager : ProtocolObject
 {
     public NewBookmarkManagerDto data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/DriverClose.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/DriverClose.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class DriverClose : IProtocolObject
+internal class DriverClose : ProtocolObject
 {
     public DriverCloseType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/GetConnectionPoolMetrics.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/GetConnectionPoolMetrics.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class GetConnectionPoolMetrics : IProtocolObject
+internal class GetConnectionPoolMetrics : ProtocolObject
 {
     public GetConnectionPoolMetricsDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class NewDriver : IProtocolObject
+internal class NewDriver : ProtocolObject
 {
     public NewDriverType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ExecuteQuery : IProtocolObject
+internal class ExecuteQuery : ProtocolObject
 {
     public ExecuteQueryDto data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/GetFeatures.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/GetFeatures.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class GetFeatures : IProtocolObject
+internal class GetFeatures : ProtocolObject
 {
     public GetFeaturesType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/StartTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/StartTest.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class StartTest : IProtocolObject
+internal class StartTest : ProtocolObject
 {
     public StartTestType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Protocol.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Protocol.cs
@@ -42,7 +42,7 @@ public static class Protocol
         Assembly
             .GetExecutingAssembly()
             .DefinedTypes
-            .Where(t => t.IsAssignableTo(typeof(IProtocolObject))));
+            .Where(t => t.IsAssignableTo(typeof(ProtocolObject))));
 
     public static void ValidateType(string typeName)
     {
@@ -66,7 +66,7 @@ public static class Protocol
     }
 }
 
-internal abstract class IProtocolObject
+internal abstract class ProtocolObject
 {
     public string name { get; set; }
 
@@ -97,9 +97,8 @@ internal abstract class IProtocolObject
         await Task.CompletedTask;
     }
 
-    public virtual async Task
-        Process(
-            Controller controller) //Default is to not use the controller object. But option to override this method and use it if necessary.
+    //Default is to not use the controller object. But option to override this method and use it if necessary.
+    public virtual async Task Process(Controller controller)
     {
         await Process();
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/ProtocolException.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/ProtocolException.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ProtocolException : IProtocolObject
+internal class ProtocolException : ProtocolObject
 {
     public ProtocolExceptionType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/ProtocolObjectFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/ProtocolObjectFactory.cs
@@ -23,24 +23,24 @@ internal static class ProtocolObjectFactory
 {
     public static ProtocolObjectManager ObjManager { get; set; }
 
-    public static IProtocolObject CreateObject(string jsonString)
+    public static ProtocolObject CreateObject(string jsonString)
     {
         var type = GetObjectType(jsonString);
         Protocol.ValidateType(type);
         return CreateObject(type, jsonString);
     }
 
-    public static T CreateObject<T>() where T : IProtocolObject
+    public static T CreateObject<T>() where T : ProtocolObject
     {
         Protocol.ValidateType(typeof(T));
         return (T)CreateObject(typeof(T));
     }
 
-    private static IProtocolObject CreateObject(Type type, string jsonString = null)
+    private static ProtocolObject CreateObject(Type type, string jsonString = null)
     {
         try
         {
-            var newObject = (IProtocolObject)CreateNewObjectOfType(
+            var newObject = (ProtocolObject)CreateNewObjectOfType(
                 type,
                 jsonString,
                 new JsonSerializerSettings
@@ -72,7 +72,7 @@ internal static class ProtocolObjectFactory
         return (string)jsonObject["name"];
     }
 
-    public static T CreateObject<T>(string jsonString = null) where T : IProtocolObject, new()
+    public static T CreateObject<T>(string jsonString = null) where T : ProtocolObject, new()
     {
         return (T)CreateObject(jsonString);
     }
@@ -95,7 +95,7 @@ internal static class ProtocolObjectFactory
         return string.IsNullOrEmpty(jsonString) ? new T() : JsonConvert.DeserializeObject<T>(jsonString, settings);
     }
 
-    private static void ProcessNewObject(IProtocolObject newObject)
+    private static void ProcessNewObject(ProtocolObject newObject)
     {
         newObject.SetObjectManager(ObjManager);
         ObjManager.AddProtocolObject(newObject);

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/ProtocolObjectManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/ProtocolObjectManager.cs
@@ -20,7 +20,7 @@ namespace Neo4j.Driver.Tests.TestBackend;
 internal class ProtocolObjectManager
 {
     private static int ObjectCounter { get; set; }
-    private Dictionary<string, IProtocolObject> ProtocolObjects { get; } = new();
+    private Dictionary<string, ProtocolObject> ProtocolObjects { get; } = new();
     public int ObjectCount => ProtocolObjects.Count;
 
     public static string GenerateUniqueIdString()
@@ -33,13 +33,13 @@ internal class ProtocolObjectManager
         return ObjectCounter++;
     }
 
-    public void AddProtocolObject(IProtocolObject obj)
+    public void AddProtocolObject(ProtocolObject obj)
     {
         obj.SetUniqueId(GenerateUniqueIdString());
         ProtocolObjects[obj.uniqueId] = obj;
     }
 
-    public IProtocolObject GetObject(string id)
+    public ProtocolObject GetObject(string id)
     {
         if (string.IsNullOrEmpty(id))
         {
@@ -49,7 +49,7 @@ internal class ProtocolObjectManager
         return ProtocolObjects[id];
     }
 
-    public T GetObject<T>(string id) where T : IProtocolObject
+    public T GetObject<T>(string id) where T : ProtocolObject
     {
         if (string.IsNullOrEmpty(id))
         {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/CypherTypeField.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/CypherTypeField.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class CypherTypeField : IProtocolObject
+internal class CypherTypeField : ProtocolObject
 {
     [JsonProperty("data")] public CypherTypeFieldRequest RequestData { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/Result.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/Result.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class Result : IProtocolObject
+internal class Result : ProtocolObject
 {
     [JsonIgnore] public IResultCursor ResultCursor { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultConsume.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultConsume.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ResultConsume : IProtocolObject
+internal class ResultConsume : ProtocolObject
 {
     public ResultConsumeType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultList.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ResultList : IProtocolObject
+internal class ResultList : ProtocolObject
 {
     public ResultListType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultNext.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultNext.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ResultNext : IProtocolObject
+internal class ResultNext : ProtocolObject
 {
     public ResultNextType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultPeek.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultPeek.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ResultPeek : IProtocolObject
+internal class ResultPeek : ProtocolObject
 {
     public ResultPeekType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultSingle.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/ResultSingle.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ResultSingle : IProtocolObject
+internal class ResultSingle : ProtocolObject
 {
     public ResultSingleType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/NewSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/NewSession.cs
@@ -23,7 +23,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class NewSession : IProtocolObject
+internal class NewSession : ProtocolObject
 {
     public enum SessionState
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/RetryableNegative.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/RetryableNegative.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class RetryableNegative : IProtocolObject
+internal class RetryableNegative : ProtocolObject
 {
     public RetryableNegativeType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/RetryablePositive.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/RetryablePositive.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class RetryablePositive : IProtocolObject
+internal class RetryablePositive : ProtocolObject
 {
     public RetryablePositiveType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionBeginTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionBeginTransaction.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class SessionBeginTransaction : IProtocolObject
+internal class SessionBeginTransaction : ProtocolObject
 {
     public SessionBeginTransactionType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionClose.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionClose.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class SessionClose : IProtocolObject
+internal class SessionClose : ProtocolObject
 {
     public SessionCloseType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionLastBookmarks.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionLastBookmarks.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class SessionLastBookmarks : IProtocolObject
+internal class SessionLastBookmarks : ProtocolObject
 {
     private string[] Bookmarks { get; set; }
     public SessionLastBookmarksType data { get; set; } = new();

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionReadTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionReadTransaction.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class SessionReadTransaction : IProtocolObject
+internal class SessionReadTransaction : ProtocolObject
 {
     public SessionReadTransactionType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionRun.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionRun.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class SessionRun : IProtocolObject
+internal class SessionRun : ProtocolObject
 {
     public SessionRunType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionWriteTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Session/SessionWriteTransaction.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class SessionWriteTransaction : IProtocolObject
+internal class SessionWriteTransaction : ProtocolObject
 {
     public SessionWriteTransactionType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/CheckDriverIsEncrypted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/CheckDriverIsEncrypted.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class CheckDriverIsEncrypted : IProtocolObject
+internal class CheckDriverIsEncrypted : ProtocolObject
 {
     public DriverIsEncryptedType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/CheckMultiDBSupport.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/CheckMultiDBSupport.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class CheckMultiDBSupport : IProtocolObject
+internal class CheckMultiDBSupport : ProtocolObject
 {
     public CheckMultiDBSupportType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/GetRoutingTable.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/GetRoutingTable.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class GetRoutingTable : IProtocolObject
+internal class GetRoutingTable : ProtocolObject
 {
     public GetRoutingTableDataType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/GetServerInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/GetServerInfo.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class GetServerInfo : IProtocolObject
+internal class GetServerInfo : ProtocolObject
 {
     public GetServerInfoType Data { get; set; } = new();
     public IServerInfo ServerInfo { get; set; }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/ResolverResolutionCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/ResolverResolutionCompleted.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class ResolverResolutionCompleted : IProtocolObject
+internal class ResolverResolutionCompleted : ProtocolObject
 {
     public ResolverResolutionCompletedType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/VerifyConnectivity.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/SupportFunctions/VerifyConnectivity.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class VerifyConnectivity : IProtocolObject
+internal class VerifyConnectivity : ProtocolObject
 {
     public VerifyConnectivityType Data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Time/FakeTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Time/FakeTime.cs
@@ -26,7 +26,7 @@ internal class FakeTimeHolder
     internal static IDateTimeProvider OriginalTimeProvider;
 }
 
-internal class FakeTimeInstall : IProtocolObject
+internal class FakeTimeInstall : ProtocolObject
 {
     public object data { get; set; }
 
@@ -44,7 +44,7 @@ internal class FakeTimeInstall : IProtocolObject
     }
 }
 
-internal class FakeTimeTick : IProtocolObject
+internal class FakeTimeTick : ProtocolObject
 {
     public FakeTimeTickDto data { get; set; }
 
@@ -62,7 +62,7 @@ internal class FakeTimeTick : IProtocolObject
     public record FakeTimeTickDto(int incrementMs);
 }
 
-internal class FakeTimeUninstall : IProtocolObject
+internal class FakeTimeUninstall : ProtocolObject
 {
     public object data { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionClose.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionClose.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class TransactionClose : IProtocolObject
+internal class TransactionClose : ProtocolObject
 {
     public TransactionCloseDataType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionCommit.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionCommit.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class TransactionCommit : IProtocolObject
+internal class TransactionCommit : ProtocolObject
 {
     public TransactionCommitType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRollback.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRollback.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class TransactionRollback : IProtocolObject
+internal class TransactionRollback : ProtocolObject
 {
     public TransactionRollbackType data { get; set; } = new();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRun.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Transaction/TransactionRun.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
-internal class TransactionRun : IProtocolObject
+internal class TransactionRun : ProtocolObject
 {
     public TransactionRunType data { get; set; } = new();
 


### PR DESCRIPTION
Simply rename this class since it is currently named like an interface