### PR TITLE
General tidy up, and remove warnings

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/TemporalTypesIT.cs
@@ -24,6 +24,8 @@ using Neo4j.Driver.Internal;
 using Xunit.Abstractions;
 using static Neo4j.Driver.IntegrationTests.Internals.VersionComparison;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but we still test obsolete members
+
 namespace Neo4j.Driver.IntegrationTests.Types;
 
 public sealed class TemporalTypesIT : DirectDriverTestBase

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerClose.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarkManagerClose.cs
@@ -17,7 +17,9 @@ namespace Neo4j.Driver.Tests.TestBackend;
 
 internal class BookmarkManagerClose : ProtocolObject
 {
+#pragma warning disable CS0649 // field will only be assigned to during deserialization from JSON message
     public BookmarkManagerCloseDto data;
+#pragma warning restore CS0649
 
     public override string Respond()
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksConsumerCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksConsumerCompleted.cs
@@ -17,7 +17,9 @@ namespace Neo4j.Driver.Tests.TestBackend;
 
 internal class BookmarksConsumerCompleted : ProtocolObject
 {
+#pragma warning disable CS0649 // field will only be assigned to during deserialization from JSON message
     public BookmarksConsumerCompletedDto data;
+#pragma warning restore CS0649
 
     public class BookmarksConsumerCompletedDto
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksSupplierCompleted.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/BookmarkManager/BookmarksSupplierCompleted.cs
@@ -17,7 +17,9 @@ namespace Neo4j.Driver.Tests.TestBackend;
 
 internal class BookmarksSupplierCompleted : ProtocolObject
 {
+#pragma warning disable CS0649 // field will only be assigned to during deserialization from JSON message
     public BookmarksSupplierCompletedDto data;
+#pragma warning restore CS0649
 
     public class BookmarksSupplierCompletedDto
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Neo4j.Driver.Internal.Auth;
 using Newtonsoft.Json;
 
 namespace Neo4j.Driver.Tests.TestBackend;

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/SummaryJsonSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Result/SummaryJsonSerializer.cs
@@ -18,6 +18,8 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but still needs to be handled
+
 namespace Neo4j.Driver.Tests.TestBackend;
 
 internal static class SummaryJsonSerializer

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/CypherToNative.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/CypherToNative.cs
@@ -19,6 +19,8 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but still needs to be handled
+
 namespace Neo4j.Driver.Tests.TestBackend;
 
 internal class CypherToNativeObject

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/NativeToCypher.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/NativeToCypher.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but still needs to be handled
+
 namespace Neo4j.Driver.Tests.TestBackend;
 
 internal class NativeToCypherObject

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/ElementNodeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/ElementNodeSerializerTests.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/ElementRelationshipSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/ElementRelationshipSerializerTests.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/NodeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/NodeSerializerTests.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/UtcZonedDateTimeSerializerTests.cs
@@ -18,6 +18,8 @@ using FluentAssertions;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but we still test obsolete members
+
 namespace Neo4j.Driver.Internal.IO.ValueSerializers.Temporal
 {
     public class UtcZonedDateTimeSerializerTests : PackStreamSerializerTests

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/ZonedDateTimeSerializerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ValueSerializers/Temporal/ZonedDateTimeSerializerTests.cs
@@ -18,6 +18,8 @@ using FluentAssertions;
 using Neo4j.Driver.Internal.IO.Utils;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but we still test obsolete members
+
 namespace Neo4j.Driver.Internal.IO.ValueSerializers.Temporal
 {
     public class ZonedDateTimeSerializerTests : PackStreamSerializerTests

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/InMemoryPipelinedMessageReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/InMemoryPipelinedMessageReaderTests.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Moq;
-using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Tests;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/MessageFomatTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/MessageFomatTests.cs
@@ -16,7 +16,6 @@
 using System.Linq;
 using FluentAssertions;
 using Neo4j.Driver.Internal.IO;
-using Neo4j.Driver.Internal.IO.MessageSerializers;
 using Neo4j.Driver.Internal.IO.ValueSerializers;
 using Neo4j.Driver.Internal.IO.ValueSerializers.Temporal;
 using Neo4j.Driver.Tests;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/NetworkedPipelinedMessageReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/NetworkedPipelinedMessageReaderTests.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Moq;
@@ -21,8 +20,6 @@ using Moq.AutoMock;
 using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.Preview.Mapping;
 using Xunit;
-
-using Record = Neo4j.Driver.Internal.Result.Record;
 
 namespace Neo4j.Driver.Tests.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
@@ -83,7 +83,7 @@ public class RecordMappingTests
     {
         public string Title { get; set; } = "";
         public int Released { get; set; }
-        public string? Tagline { get; set; }
+        public string Tagline { get; set; }
     }
 
     private class Person

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithOffsetTests.cs
@@ -19,6 +19,8 @@ using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but we still test obsolete members
+
 namespace Neo4j.Driver.Tests.Types
 {
     public class ZonedDateTimeWithOffsetTests

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Types/ZonedDateTimeWithZoneIdTests.cs
@@ -18,6 +18,8 @@ using System.Collections;
 using FluentAssertions;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete - but we still test obsolete members
+
 namespace Neo4j.Driver.Tests.Types
 {
     public class ZonedDateTimeWithZoneIdTests

--- a/Neo4j.Driver/Neo4j.Driver/Exceptions/AuthorizationException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Exceptions/AuthorizationException.cs
@@ -25,6 +25,7 @@ namespace Neo4j.Driver;
 [ErrorCode("Neo.ClientError.Security.AuthorizationExpired")]
 public class AuthorizationException : SecurityException
 {
+    /// <inheritdoc />
     public override bool IsRetriable => true;
 
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Exceptions/ConnectionReadTimeoutException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Exceptions/ConnectionReadTimeoutException.cs
@@ -26,6 +26,7 @@ namespace Neo4j.Driver;
 [DataContract]
 public class ConnectionReadTimeoutException : Neo4jException
 {
+    /// <inheritdoc />
     public override bool IsRetriable => true;
 
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Exceptions/ServiceUnavailableException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Exceptions/ServiceUnavailableException.cs
@@ -26,6 +26,7 @@ namespace Neo4j.Driver;
 [DataContract]
 public class ServiceUnavailableException : Neo4jException
 {
+    /// <inheritdoc />
     public override bool IsRetriable => true;
 
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Exceptions/SessionExpiredException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Exceptions/SessionExpiredException.cs
@@ -29,6 +29,7 @@ namespace Neo4j.Driver;
 [DataContract]
 public class SessionExpiredException : Neo4jException
 {
+    /// <inheritdoc />
     public override bool IsRetriable => true;
 
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Exceptions/StatementArgumentException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Exceptions/StatementArgumentException.cs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Runtime.Serialization;
 using Neo4j.Driver.Internal.ExceptionHandling;
 

--- a/Neo4j.Driver/Neo4j.Driver/Exceptions/TransactionTerminatedException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Exceptions/TransactionTerminatedException.cs
@@ -11,6 +11,7 @@ namespace Neo4j.Driver;
 [DataContract]
 public sealed class TransactionTerminatedException : ClientException
 {
+    /// <inheritdoc />
     public override bool IsRetriable => (InnerException as Neo4jException)?.IsRetriable ?? false;
 
     internal TransactionTerminatedException(Exception inner) :

--- a/Neo4j.Driver/Neo4j.Driver/ExecuteQuery/QueryConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ExecuteQuery/QueryConfig.cs
@@ -35,6 +35,7 @@ public class QueryConfig
     /// Whether or not to use a <see cref="IBookmarkManager"/>, setting to false will
     /// remove any usage or modification of <see cref="IBookmarkManager"/>.
     /// </param>
+    /// <param name="transactionConfig">Transaction configuration.</param>
     public QueryConfig(
         RoutingControl routing = RoutingControl.Writers,
         string database = null,
@@ -91,6 +92,7 @@ public class QueryConfig<T> : QueryConfig
     /// Whether or not to use an <see cref="IBookmarkManager"/>, setting to false will
     /// remove any usage or modification of <see cref="IBookmarkManager"/>.
     /// </param>
+    /// <param name="transactionConfig">Transaction configuration.</param>
     /// <exception cref="ArgumentNullException"></exception>
     public QueryConfig(
         Func<IResultCursor, CancellationToken, Task<T>> cursorProcessor,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/SimpleWildcardHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/SimpleWildcardHelper.cs
@@ -20,8 +20,8 @@ namespace Neo4j.Driver.Internal;
 internal class SimpleWildcardHelper
 {
     /// <summary>
-    /// Returns true if the two strings are the same, or, if <see cref="y"/> ends with an asterisk (*),
-    /// returns true if <see cref="x"/> starts with <see cref="y"/> (minus the asterisk).
+    /// Returns true if the two strings are the same, or, if <paramref name="y"/> ends with an asterisk (*),
+    /// returns true if <paramref name="x"/> starts with <paramref name="y"/> (minus the asterisk).
     /// </summary>
     /// <param name="x">The string to check.</param>
     /// <param name="y">The (potential) wildcard to compare with</param>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/SimpleWildcardHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/SimpleWildcardHelper.cs
@@ -15,8 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
-
 namespace Neo4j.Driver.Internal;
 
 internal class SimpleWildcardHelper

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/FailureMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/FailureMessageSerializer.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.IO.MessageSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/IgnoredMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/IgnoredMessageSerializer.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.IO.MessageSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/RecordMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/RecordMessageSerializer.cs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.IO.MessageSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/SuccessMessageSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageSerializers/SuccessMessageSerializer.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
 using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.IO.MessageSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamFactory.cs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.IO;
-using Neo4j.Driver.Internal.Connector;
-
 namespace Neo4j.Driver.Internal.IO;
 
 internal interface IPackStreamFactory

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/SpanPackStreamReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/SpanPackStreamReader.cs
@@ -20,7 +20,6 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using Neo4j.Driver.Internal.Messaging;
 
 namespace Neo4j.Driver.Internal.IO;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/ElementRelationshipSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/ElementRelationshipSerializer.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.Internal.IO.ValueSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/ElementUnboundRelationshipSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/ElementUnboundRelationshipSerializer.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.Internal.IO.ValueSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PathSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PathSerializer.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Linq;
 using Neo4j.Driver.Internal.Types;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PointSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/PointSerializer.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 
 namespace Neo4j.Driver.Internal.IO.ValueSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/UnboundRelationshipSerializer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ValueSerializers/UnboundRelationshipSerializer.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver.Internal.IO.ValueSerializers;

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/BuiltMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/BuiltMapper.cs
@@ -45,18 +45,18 @@ internal class BuiltMapper<T> : IRecordMapper<T>
         return obj;
     }
 
-    private static T CreateObject<T>()
+    private static TObject CreateObject<TObject>()
     {
         // check for parameterless constructor
-        var constructor = typeof(T).GetConstructor(Type.EmptyTypes);
+        var constructor = typeof(TObject).GetConstructor(Type.EmptyTypes);
         if (constructor is null)
         {
             throw new InvalidOperationException(
-                $"Cannot create an instance of type {typeof(T).Name} " +
+                $"Cannot create an instance of type {typeof(TObject).Name} " +
                 $"because it does not have a parameterless constructor.");
         }
 
-        return (T)constructor.Invoke(Array.Empty<object>());
+        return (TObject)constructor.Invoke(Array.Empty<object>());
     }
 
     public void AddWholeObjectMapping(Func<IRecord, T> mappingFunction)

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/IMappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/IMappingBuilder.cs
@@ -25,7 +25,7 @@ namespace Neo4j.Driver.Preview.Mapping;
 public interface IMappingBuilder<TObject>
 {
     /// <summary>
-    /// Applies the default mapping for the object. Later calls to <see cref="Map{TProperty}"/> will override
+    /// Applies the default mapping for the object. Later calls to mapping configuration methods will override
     /// the default mapping.
     /// </summary>
     /// <returns>This instance for method chaining.</returns>

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingConstructorAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingConstructorAttribute.cs
@@ -17,6 +17,9 @@ using System;
 
 namespace Neo4j.Driver.Preview.Mapping;
 
+/// <summary>
+/// Indicates that the constructor should be used when mapping a record to an object.
+/// </summary>
 [AttributeUsage(AttributeTargets.Constructor)]
 public class MappingConstructorAttribute : Attribute
 {


### PR DESCRIPTION
Unused `using` statements have been removed.

Warnings have also been reduced to zero. In the cases where the code could be changed to remove the warning this was done; in other cases (for instance a unit test calling a deprecated member) the warning was suppressed at a limited scope.