### PR TITLE
Reduce memory allocations when creating a record object

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/Throw.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Helpers/Throw.cs
@@ -13,38 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Neo4j.Driver.Internal.Helpers;
 
 internal static class Throw
 {
     public static class ProtocolException
     {
-        public static void IfNotEqual(int first, int second, string firstParam, string secondParam)
-        {
-            If(() => first != second, first, second, firstParam, secondParam);
-        }
-
-        internal static void IfNotEqual(object first, object second, string firstParam, string secondParam)
-        {
-            if (first == null && second == null)
-            {
-                return;
-            }
-
-            If(() => first == null || second == null || !first.Equals(second), first, second, firstParam, secondParam);
-        }
-
-        public static void If(Func<bool> func, object first, object second, string firstParam, string secondParam)
-        {
-            if (func())
-            {
-                throw new Neo4j.Driver.ProtocolException(
-                    $"{firstParam} ({first}) does not equal to {secondParam} ({second})");
-            }
-        }
-
         public static void IfFalse(bool value, string nameofValue)
         {
             if (!value)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/Record.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Neo4j.Driver.Internal.Helpers;
 
 namespace Neo4j.Driver.Internal.Result;
 
@@ -22,9 +21,13 @@ internal class Record : IRecord
 {
     public Record(string[] keys, object[] values)
     {
-        Throw.ProtocolException.IfNotEqual(keys.Length, values.Length, nameof(keys), nameof(values));
-
-        var valueKeys = new Dictionary<string, object>();
+        if (keys.Length != values.Length)
+        {
+            throw new ProtocolException(
+                $"{nameof(keys)} length ({keys.Length}) does not equal to {nameof(values)} length ({values.Length})");
+        }
+        
+        var valueKeys = new Dictionary<string, object>(keys.Length);
 
         for (var i = 0; i < keys.Length; i++)
         {


### PR DESCRIPTION
- Use a simple if instead of delegate
- Don't grow dictionary.