### PR TITLE
Throw on returning cursor

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
@@ -315,7 +315,7 @@ public class AsyncSessionTests
     public class ThrowWhenReturningCursor
     {
         [Fact]
-        public async void ShouldThrowWhenReturningResultCursor()
+        public async Task ShouldThrowWhenReturningResultCursor()
         {
             var mockProtocol = new Mock<IBoltProtocol>();
             var mockConn = new Mock<IConnection>();
@@ -344,7 +344,7 @@ public class AsyncSessionTests
         }
 
         [Fact]
-        public async void ShouldThrowWhenReturningResultCursorEnumerator()
+        public async Task ShouldThrowWhenReturningResultCursorEnumerator()
         {
             var mockProtocol = new Mock<IBoltProtocol>();
             var mockConn = new Mock<IConnection>();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Protocol;
+using Neo4j.Driver.Internal.Result;
 using Neo4j.Driver.Internal.Telemetry;
 using static Neo4j.Driver.Internal.Logging.DriverLoggerUtil;
 
@@ -323,6 +324,12 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
                         if (tx.IsOpen)
                         {
                             await tx.CommitAsync().ConfigureAwait(false);
+                        }
+
+                        if(result is ResultCursor or IAsyncEnumerator<IRecord>)
+                        {
+                           throw new InvalidOperationException(
+                               "The result of the transaction function cannot be a cursor.");
                         }
 
                         return result;


### PR DESCRIPTION
With this PR, an exception is thrown if the user tries to return a cursor (or the cursor's enumerator) from a transaction. Doing so and then attempting to use the cursor will result in attempting to reference a disposed resource.