### PR TITLE
Add session auth to executeQuery

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
@@ -80,10 +80,10 @@ internal class ExecuteQuery : ProtocolObject
             Metadata = data.config.txMeta != null ? CypherToNativeObject.ConvertDictionaryToNative(data.config.txMeta) : new Dictionary<string, object>()
         };
 
-        var authToken = data.config.auth switch
+        var authToken = data.config.authorizationToken switch
         {
             null => null,
-            not null => data.config.auth.AsToken()
+            not null => data.config.authorizationToken.AsToken()
         };
 
         return new QueryConfig(
@@ -139,6 +139,6 @@ internal class ExecuteQuery : ProtocolObject
         public int? timeout { get; set; }
         [JsonConverter(typeof(QueryParameterConverter))]
         public Dictionary<string, CypherToNativeObject> txMeta { get; set; }
-        public AuthorizationToken auth { get; set; }
+        public AuthorizationToken authorizationToken { get; set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/DriverQuery/ExecuteQuery.cs
@@ -80,13 +80,20 @@ internal class ExecuteQuery : ProtocolObject
             Metadata = data.config.txMeta != null ? CypherToNativeObject.ConvertDictionaryToNative(data.config.txMeta) : new Dictionary<string, object>()
         };
 
+        var authToken = data.config.auth switch
+        {
+            null => null,
+            not null => data.config.auth.AsToken()
+        };
+
         return new QueryConfig(
             routingControl,
             data.config.database,
             data.config.impersonatedUser,
             bookmarkManager,
             enableBookmarkManager,
-            transactionConfig);
+            transactionConfig,
+            authToken);
     }
 
     public override string Respond()
@@ -132,5 +139,6 @@ internal class ExecuteQuery : ProtocolObject
         public int? timeout { get; set; }
         [JsonConverter(typeof(QueryParameterConverter))]
         public Dictionary<string, CypherToNativeObject> txMeta { get; set; }
+        public AuthorizationToken auth { get; set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/SupportedFeatures.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/SupportedFeatures.cs
@@ -31,6 +31,7 @@ internal static class SupportedFeatures
             "Feature:API:BookmarkManager",
             "Feature:API:ConnectionAcquisitionTimeout",
             "Feature:API:Driver.ExecuteQuery",
+            "Feature:API:Driver.ExecuteQuery:WithAuth",
             "Feature:API:Driver:GetServerInfo",
             "Feature:API:Driver.IsEncrypted",
             "Feature:API:Driver:NotificationsConfig",

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -277,6 +277,11 @@ internal sealed class Driver : IInternalDriver
             sessionConfigBuilder.WithBookmarkManager(config.BookmarkManager ?? _bookmarkManager);
         }
 
+        if(config.AuthToken != null)
+        {
+            sessionConfigBuilder.WithAuthToken(config.AuthToken);
+        }
+
         sessionConfigBuilder.WithDefaultAccessMode(
             config.Routing switch
             {

--- a/Neo4j.Driver/Neo4j.Driver/Public/ExecuteQuery/QueryConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/ExecuteQuery/QueryConfig.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Neo4j.Driver.Internal.Auth;
 
 namespace Neo4j.Driver;
 
@@ -36,13 +37,15 @@ public class QueryConfig
     /// remove any usage or modification of <see cref="IBookmarkManager"/>.
     /// </param>
     /// <param name="transactionConfig">Transaction configuration.</param>
+    /// <param name="authToken">Auth token to use for the session executing the query.</param>
     public QueryConfig(
         RoutingControl routing = RoutingControl.Writers,
         string database = null,
         string impersonatedUser = null,
         IBookmarkManager bookmarkManager = null,
         bool enableBookmarkManager = true,
-        TransactionConfig transactionConfig = null)
+        TransactionConfig transactionConfig = null,
+        IAuthToken authToken = null)
     {
         Routing = routing;
         Database = database;
@@ -50,7 +53,9 @@ public class QueryConfig
         BookmarkManager = bookmarkManager;
         EnableBookmarkManager = enableBookmarkManager;
         TransactionConfig = transactionConfig ?? TransactionConfig.Default;
+        AuthToken = authToken;
     }
+
     /// <summary>Config for the transaction that will be used to execute the query.</summary>
     public TransactionConfig TransactionConfig { get; }
 
@@ -71,6 +76,11 @@ public class QueryConfig
 
     /// <summary>Enables or disables the use of an <see cref="IBookmarkManager"/> for causal chaining.</summary>
     public bool EnableBookmarkManager { get; }
+
+    /// <summary>
+    /// Auth token to use for the session executing the query.
+    /// </summary>
+    public IAuthToken AuthToken { get; }
 }
 
 /// <summary>Configuration for running queries using the simplified API.</summary>
@@ -93,6 +103,7 @@ public class QueryConfig<T> : QueryConfig
     /// remove any usage or modification of <see cref="IBookmarkManager"/>.
     /// </param>
     /// <param name="transactionConfig">Transaction configuration.</param>
+    /// <param name="authToken">Auth token to use for the session executing the query.</param>
     /// <exception cref="ArgumentNullException"></exception>
     public QueryConfig(
         Func<IResultCursor, CancellationToken, Task<T>> cursorProcessor,
@@ -101,8 +112,16 @@ public class QueryConfig<T> : QueryConfig
         string impersonatedUser = null,
         IBookmarkManager bookmarkManager = null,
         bool enableBookmarkManager = true,
-        TransactionConfig transactionConfig = null)
-        : base(routing, database, impersonatedUser, bookmarkManager, enableBookmarkManager, transactionConfig)
+        TransactionConfig transactionConfig = null,
+        IAuthToken authToken = null)
+        : base(
+            routing,
+            database,
+            impersonatedUser,
+            bookmarkManager,
+            enableBookmarkManager,
+            transactionConfig,
+            authToken)
     {
         CursorProcessor = cursorProcessor ?? throw new ArgumentNullException(nameof(cursorProcessor));
     }


### PR DESCRIPTION
This PR adds the ability to specifiy an AuthToken when creating a QueryConfig object to use with the driver-level ExecutableQuery API.