### PR TITLE
Find fields and properties via dictionary first if possible

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
@@ -25,64 +25,176 @@ namespace Neo4j.Driver.Tests.Mapping;
 public class RecordPathFinderTests
 {
     [Fact]
-    public void ShouldFindSimplePath()
+    public void TryGetValueByPath_PathMatchesFieldName_ReturnsTrue()
     {
-        var record = new Record(new[] { "a" }, new object[] { "b" });
-        var finder = new RecordPathFinder();
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(new[] { "testField" }, new object[] { "testValue" });
 
-        var found = finder.TryGetValueByPath(record, "a", out var value);
+        var result = recordPathFinder.TryGetValueByPath(record, "testField", out var value);
 
-        found.Should().BeTrue();
-        value.Should().Be("b");
+        result.Should().BeTrue();
+        value.Should().Be("testValue");
     }
 
     [Fact]
-    public void ShouldReturnFalseWhenPathNotFound()
+    public void TryGetValueByPath_PathDoesNotMatchFieldName_ReturnsFalse()
     {
-        var record = new Record(new[] { "a" }, new object[] { "b" });
-        var finder = new RecordPathFinder();
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(new[] { "testField" }, new object[] { "testValue" });
 
-        var found = finder.TryGetValueByPath(record, "c", out var value);
+        var result = recordPathFinder.TryGetValueByPath(record, "nonExistentField", out var value);
 
-        found.Should().BeFalse();
+        result.Should().BeFalse();
+        value.Should().BeNull();
     }
 
     [Fact]
-    public void ShouldFindSimplePathNestedInANode()
+    public void TryGetValueByPath_PathContainsDotAndMatchesFieldNameAndPropertyName_ReturnsTrue()
     {
-        var node = new Node(1, new[] { "Test" }, new Dictionary<string, object>() { { "name", "Bob" } });
-        var record = new Record(new[] { "person" }, new object[] { node });
-        var finder = new RecordPathFinder();
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
 
-        var found = finder.TryGetValueByPath(record, "name", out var value);
+        var result = recordPathFinder.TryGetValueByPath(record, "testField.testProperty", out var value);
 
-        found.Should().BeTrue();
-        value.Should().Be("Bob");
+        result.Should().BeTrue();
+        value.Should().Be("testValue");
     }
 
     [Fact]
-    public void ShouldFindComplexPathNestedInANode()
+    public void TryGetValueByPath_PathContainsDotButDoesNotMatchFieldName_ReturnsFalse()
     {
-        var node = new Node(1, new[] { "Test" }, new Dictionary<string, object>() { { "name", "Bob" } });
-        var record = new Record(new[] { "person" }, new object[] { node });
-        var finder = new RecordPathFinder();
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
 
-        var found = finder.TryGetValueByPath(record, "person.name", out var value);
+        var result = recordPathFinder.TryGetValueByPath(record, "nonExistentField.testProperty", out var value);
 
-        found.Should().BeTrue();
-        value.Should().Be("Bob");
+        result.Should().BeFalse();
+        value.Should().BeNull();
     }
 
     [Fact]
-    public void ShouldFindComplexPathNestedInADictionary()
+    public void TryGetValueByPath_PathContainsDotMatchesFieldNameButNotPropertyName_ReturnsFalse()
     {
-        var dictionary = new Dictionary<string, object>() { { "name", "Bob" } };
-        var record = new Record(new[] { "person" }, new object[] { dictionary });
-        var finder = new RecordPathFinder();
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
 
-        var found = finder.TryGetValueByPath(record, "person.name", out var value);
+        var result = recordPathFinder.TryGetValueByPath(record, "testField.nonExistentProperty", out var value);
 
-        found.Should().BeTrue();
-        value.Should().Be("Bob");
+        result.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetValueByPath_PathContainsDotAndMatchesFieldNameAndPropertyName_ReturnsTrue_CaseInsensitive()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
+
+        var result = recordPathFinder.TryGetValueByPath(record, "testField.testProperty", out var value);
+
+        result.Should().BeTrue();
+        value.Should().Be("testValue");
+    }
+
+    [Fact]
+    public void TryGetValueByPath_PathContainsDotButDoesNotMatchFieldName_ReturnsFalse_CaseInsensitive()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
+
+        var result = recordPathFinder.TryGetValueByPath(record, "nonExistentField.testProperty", out var value);
+
+        result.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetValueByPath_PathContainsDotMatchesFieldNameButNotPropertyName_ReturnsFalse_CaseInsensitive()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
+
+        var result = recordPathFinder.TryGetValueByPath(record, "testField.nonExistentProperty", out var value);
+
+        result.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetValueFast_PathMatchesFieldName_ReturnsTrue()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(new[] { "testField" }, new object[] { "testValue" });
+
+        var result = recordPathFinder.TryGetValueFast(record, "testField", out var value);
+
+        result.Should().BeTrue();
+        value.Should().Be("testValue");
+    }
+
+    [Fact]
+    public void TryGetValueFast_PathDoesNotMatchFieldName_ReturnsFalse()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(new[] { "testField" }, new object[] { "testValue" });
+
+        var result = recordPathFinder.TryGetValueFast(record, "nonExistentField", out var value);
+
+        result.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetValueFast_PathContainsDotAndMatchesFieldNameAndPropertyName_ReturnsTrue()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
+
+        var result = recordPathFinder.TryGetValueFast(record, "testField.testProperty", out var value);
+
+        result.Should().BeTrue();
+        value.Should().Be("testValue");
+    }
+
+    [Fact]
+    public void TryGetValueFast_PathContainsDotButDoesNotMatchFieldName_ReturnsFalse()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
+
+        var result = recordPathFinder.TryGetValueFast(record, "nonExistentField.testProperty", out var value);
+
+        result.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetValueFast_PathContainsDotMatchesFieldNameButNotPropertyName_ReturnsFalse()
+    {
+        var recordPathFinder = new RecordPathFinder();
+        var record = new Record(
+            new[] { "testField" },
+            new object[] { new Dictionary<string, object> { { "testProperty", "testValue" } } });
+
+        var result = recordPathFinder.TryGetValueFast(record, "testField.nonExistentProperty", out var value);
+
+        result.Should().BeFalse();
+        value.Should().BeNull();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/DefaultMapper.cs
@@ -57,10 +57,14 @@ internal static class DefaultMapper
                 continue;
             }
 
+            // lower-case the first letter of the property name to be more likely to
+            // match the exact case of the property name in the record
+            var propertyName = char.ToLowerInvariant(property.Name[0]) + property.Name.Substring(1);
+
             // check if there is a MappingSourceAttribute: if there is, use the specified mapping source;
             // if not, look for a property on the entity with the same name as the property on the object
             var mappingSource = property.GetCustomAttribute<MappingSourceAttribute>()?.EntityMappingInfo ??
-                new EntityMappingInfo(property.Name, EntityMappingSource.Property);
+                new EntityMappingInfo(propertyName, EntityMappingSource.Property);
 
             // don't re-map any fields that were already mapped by the constructor
             if (!usedEntitySources.Contains(mappingSource.Path.ToLowerInvariant()))

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/RecordPathFinder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/RecordPathFinder.cs
@@ -82,7 +82,7 @@ internal class RecordPathFinder : IRecordPathFinder
         return false;
     }
 
-    private bool TryGetValueFast(IRecord record, string path, out object value)
+    public bool TryGetValueFast(IRecord record, string path, out object value)
     {
         value = null;
 


### PR DESCRIPTION
This change adds a method to RecordPathFinder that will check if the path supplied can be used directly as keys into the record rather than looping through all the fields in the record checking. If this fails then the old method is still used, however in tests the fast method was used most of the time.