### PR TITLE
move mapping api out of preview namespace

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/BuiltMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/BuiltMapperTests.cs
@@ -15,7 +15,7 @@
 
 using System;
 using FluentAssertions;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
@@ -17,7 +17,7 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DictAsRecordTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DictAsRecordTests.cs
@@ -18,7 +18,7 @@ using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/LabelCaptureTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/LabelCaptureTests.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
@@ -18,7 +18,7 @@ using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Xunit;
 
 namespace Neo4j.Driver.Tests.Mapping;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappedListCreatorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappedListCreatorTests.cs
@@ -20,7 +20,7 @@ using System.Linq;
 using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingBuilderTests.cs
@@ -15,7 +15,7 @@
 
 using System;
 using FluentAssertions;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Xunit;
 
 namespace Neo4j.Driver.Tests.Mapping;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 using FluentAssertions;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingSourceDelegateBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingSourceDelegateBuilderTests.cs
@@ -16,7 +16,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/OptionalMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/OptionalMappingTests.cs
@@ -15,7 +15,7 @@
 
 using System.Linq;
 using FluentAssertions;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
@@ -15,7 +15,7 @@
 
 using System.Collections.Generic;
 using FluentAssertions;
-using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/AsyncEnumerableExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/AsyncEnumerableExtensions.cs
@@ -18,7 +18,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Contains extension methods for <see cref="IAsyncEnumerable{T}"/>.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/BuiltMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/BuiltMapper.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal class BuiltMapper<T> : IRecordMapper<T>
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DefaultMapper.cs
@@ -15,10 +15,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal static class DefaultMapper
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DictAsRecord.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DictAsRecord.cs
@@ -20,7 +20,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal sealed class DictAsRecord : IRecord
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/EntityExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/EntityExtensions.cs
@@ -1,30 +1,32 @@
 ﻿// Copyright (c) "Neo4j"
-// Neo4j Sweden AB [http://neo4j.com]
-//
-// This file is part of Neo4j.
-//
+// Neo4j Sweden AB [https://neo4j.com]
+// 
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
-/// Interface to be implemented by a class that provides mappers to the mapping system.
+/// Contains extensions for entities such as nodes and relationships.
 /// </summary>
-public interface IMappingProvider
+public static class EntityExtensions
 {
     /// <summary>
-    /// This method is called on mapping providers to allow them to register their mappers with the mapping system.
+    /// Converts the entity to a record.
     /// </summary>
-    /// <param name="registry">The registry in which mappers should be registered.</param>
-    void CreateMappers(IMappingRegistry registry);
+    /// <param name="entity">The entity to convert.</param>
+    /// <returns>The record.</returns>
+    public static IRecord AsRecord(this IEntity entity)
+    {
+        return new DictAsRecord(entity, null);
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/EntityMappingInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/EntityMappingInfo.cs
@@ -16,7 +16,7 @@
 using System.Linq;
 using System.Reflection;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal record EntityMappingInfo(
     string Path,

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ExecutableQueryMappingExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ExecutableQueryMappingExtensions.cs
@@ -18,7 +18,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Contains extensions for using the global mapping system with the driver's <see cref="ExecutableQuery{TIn,TOut}"/>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/IMappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/IMappingBuilder.cs
@@ -16,7 +16,7 @@
 using System;
 using System.Linq.Expressions;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Defines a builder for mapping objects from <see cref="IRecord"/>s.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/IMappingProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/IMappingProvider.cs
@@ -1,30 +1,30 @@
 ﻿// Copyright (c) "Neo4j"
-// Neo4j Sweden AB [https://neo4j.com]
-// 
+// Neo4j Sweden AB [http://neo4j.com]
+//
+// This file is part of Neo4j.
+//
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+namespace Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Preview.Mapping;
-
-public class MappingFailedException : Neo4jException
+/// <summary>
+/// Interface to be implemented by a class that provides mappers to the mapping system.
+/// </summary>
+public interface IMappingProvider
 {
-    // the standard constructors for an exception
-    public MappingFailedException(string message) : base(message)
-    {
-    }
-
-    public MappingFailedException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
+    /// <summary>
+    /// This method is called on mapping providers to allow them to register their mappers with the mapping system.
+    /// </summary>
+    /// <param name="registry">The registry in which mappers should be registered.</param>
+    void CreateMappers(IMappingRegistry registry);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/IRecordMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/IRecordMapper.cs
@@ -13,16 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
-/// Instructs the default object mapper not to attempt to map any value to this property.
-/// This attribute does not affect custom-defined mappers.
+/// Interface to be implemented by a class that maps records to objects of type <typeparamref name="T"/>.
 /// </summary>
-[AttributeUsage(AttributeTargets.Property)]
-public class MappingIgnoredAttribute : Attribute
+/// <typeparam name="T">The type of object to which records will be mapped.</typeparam>
+public interface IRecordMapper<out T>
 {
-    
+    /// <summary>
+    /// Maps the given record to an object of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="record">The record to map.</param>
+    /// <returns>The mapped object.</returns>
+    T Map(IRecord record);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappableValueProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappableValueProvider.cs
@@ -18,7 +18,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal interface IMappableValueProvider
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappedListCreator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappedListCreator.cs
@@ -17,7 +17,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal interface IMappedListCreator
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingBuilder.cs
@@ -19,7 +19,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// This class wraps the <see cref="BuiltMapper{T}"/> and exposes a fluent API for building the mapper.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingConstructorAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingConstructorAttribute.cs
@@ -15,7 +15,7 @@
 
 using System;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Indicates that the constructor should be used when mapping a record to an object.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingExtensions.cs
@@ -17,7 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal static class MappingExtensions
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingFailedException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingFailedException.cs
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.Preview.Mapping;
+using System;
 
-/// <summary>
-/// Interface to be implemented by a class that maps records to objects of type <typeparamref name="T"/>.
-/// </summary>
-/// <typeparam name="T">The type of object to which records will be mapped.</typeparam>
-public interface IRecordMapper<out T>
+namespace Neo4j.Driver.Mapping;
+
+public class MappingFailedException : Neo4jException
 {
-    /// <summary>
-    /// Maps the given record to an object of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="record">The record to map.</param>
-    /// <returns>The mapped object.</returns>
-    T Map(IRecord record);
+    // the standard constructors for an exception
+    public MappingFailedException(string message) : base(message)
+    {
+    }
+
+    public MappingFailedException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingIgnoredAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingIgnoredAttribute.cs
@@ -13,20 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.Preview.Mapping;
+using System;
+
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
-/// Contains extensions for entities such as nodes and relationships.
+/// Instructs the default object mapper not to attempt to map any value to this property.
+/// This attribute does not affect custom-defined mappers.
 /// </summary>
-public static class EntityExtensions
+[AttributeUsage(AttributeTargets.Property)]
+public class MappingIgnoredAttribute : Attribute
 {
-    /// <summary>
-    /// Converts the entity to a record.
-    /// </summary>
-    /// <param name="entity">The entity to convert.</param>
-    /// <returns>The record.</returns>
-    public static IRecord AsRecord(this IEntity entity)
-    {
-        return new DictAsRecord(entity, null);
-    }
+    
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingOptionalAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingOptionalAttribute.cs
@@ -15,7 +15,7 @@
 
 using System;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// If a property or is decorated with this attribute, it will be considered optional. The

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingSourceAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingSourceAttribute.cs
@@ -17,7 +17,7 @@
 
 using System;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Represents a mapping from an entity itself rather than any of its properties.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingSourceDelegateBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingSourceDelegateBuilder.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal delegate bool MappingValueDelegate(IRecord record, out object value);
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordExtensions.cs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Contains extensions for accessing values simply from records and entities.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -19,7 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 /// <summary>
 /// Contains methods for registering a mapping with the global mapping configuration.

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordPathFinder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordPathFinder.cs
@@ -15,7 +15,7 @@
 
 using System.Collections.Generic;
 
-namespace Neo4j.Driver.Preview.Mapping;
+namespace Neo4j.Driver.Mapping;
 
 internal interface IRecordPathFinder
 {


### PR DESCRIPTION
Move all the mapping classes out of the preview namespace and into `Neo4j.Driver.Mapping`.