### PR TITLE
[4.4]Reclassify the security exception to service unavailable

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -77,7 +77,7 @@ namespace Neo4j.Driver.Internal.Connector
                 }
                 catch (Exception e)
                 {
-                    throw new SecurityException($"Failed to establish encrypted connection with server {uri}.", e);
+                    throw new ServiceUnavailableException($"Failed to establish encrypted connection with server {uri}.", e);
                 }
             }
         }


### PR DESCRIPTION
when creating the SSL connection, the error thrown should be a service unavailable not security