### PR TITLE
[4.4] ZoneDateTime comparison

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Types/ZonedDateTime.cs
@@ -734,13 +734,8 @@ public sealed class ZonedDateTime : TemporalValue, IEquatable<ZonedDateTime>, IC
     {
         unchecked
         {
-            var hashCode = Year;
-            hashCode = (hashCode * 397) ^ Month;
-            hashCode = (hashCode * 397) ^ Day;
-            hashCode = (hashCode * 397) ^ Hour;
-            hashCode = (hashCode * 397) ^ Second;
+            var hashCode = Zone.GetHashCode();
             hashCode = (hashCode * 397) ^ Nanosecond;
-            hashCode = (hashCode * 397) ^ Zone.GetHashCode();
             hashCode = (hashCode * 397) ^ UtcSeconds.GetHashCode();
             return hashCode;
         }


### PR DESCRIPTION
when we compare zoned date times we should use the instant values and the zone to decide if they are equal as when ambiguous times are specified they can change when sent to the server