### PR TITLE
Don't try to use localhost for IP6 connections

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
@@ -45,7 +45,9 @@ namespace Neo4j.Driver.IntegrationTests.Direct
             try
             {
                 var cursor = await session.RunAsync(
-                    "CREATE (a {value: $value}) RETURN a.value", new Dictionary<string, object> {{"value", byteArray}});
+                    "CREATE (a {value: $value}) RETURN a.value",
+                    new Dictionary<string, object> { { "value", byteArray } });
+
                 var value = await cursor.SingleAsync(r => r["a.value"].As<byte[]>());
 
                 // Then
@@ -60,8 +62,10 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         [RequireServerWithIPv6Fact("3.1.0", VersionComparison.GreaterThanOrEqualTo)]
         public async Task ShouldConnectIPv6AddressIfEnabled()
         {
-            using (var driver = GraphDatabase.Driver("bolt://[::1]:7687", AuthToken,
-                o => o.WithIpv6Enabled(true)))
+            using (var driver = GraphDatabase.Driver(
+                       Neo4jDefaultInstallation.BoltUri,
+                       AuthToken,
+                       o => o.WithIpv6Enabled(true)))
             {
                 var session = driver.AsyncSession();
                 try
@@ -81,8 +85,10 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         [RequireServerFact("3.1.0", VersionComparison.GreaterThanOrEqualTo)]
         public async Task ShouldNotConnectIPv6AddressIfDisabled()
         {
-            using (var driver = GraphDatabase.Driver("bolt://[::1]:7687", AuthToken,
-                o => o.WithIpv6Enabled(false)))
+            using (var driver = GraphDatabase.Driver(
+                       Neo4jDefaultInstallation.BoltUri,
+                       AuthToken,
+                       o => o.WithIpv6Enabled(false)))
             {
                 var session = driver.AsyncSession();
                 try
@@ -119,8 +125,10 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         [RequireServerWithIPv6Fact]
         public async Task ShouldConnectIPv4AddressIfIpv6Enabled()
         {
-            using (var driver = GraphDatabase.Driver(Neo4jDefaultInstallation.BoltUri, AuthToken,
-                o => o.WithIpv6Enabled(true)))
+            using (var driver = GraphDatabase.Driver(
+                       Neo4jDefaultInstallation.BoltUri,
+                       AuthToken,
+                       o => o.WithIpv6Enabled(true)))
             {
                 var session = driver.AsyncSession();
                 try
@@ -143,11 +151,14 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         public async Task ShouldCloseAgedIdleConnections(int sessionCount)
         {
             // Given
-            using (var driver = GraphDatabase.Driver(Neo4jDefaultInstallation.BoltUri, AuthToken, o=>
-            {
-                o.WithMetricsEnabled(true);
-                o.WithConnectionIdleTimeout(TimeSpan.Zero); // enable but always timeout idle connections
-            }))
+            using (var driver = GraphDatabase.Driver(
+                       Neo4jDefaultInstallation.BoltUri,
+                       AuthToken,
+                       o =>
+                       {
+                           o.WithMetricsEnabled(true);
+                           o.WithConnectionIdleTimeout(TimeSpan.Zero); // enable but always timeout idle connections
+                       }))
             {
                 // When
                 for (var i = 0; i < sessionCount; i++)
@@ -170,7 +181,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
                 }
 
                 // Then
-                var metrics = ((Internal.Driver) driver).GetMetrics();
+                var metrics = ((Internal.Driver)driver).GetMetrics();
                 var m = metrics.ConnectionPoolMetrics.Single().Value;
                 Output.WriteLine(m.ToString());
                 m.Created.Should().Be(sessionCount);

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
@@ -86,7 +86,7 @@ namespace Neo4j.Driver.IntegrationTests.Direct
         public async Task ShouldNotConnectIPv6AddressIfDisabled()
         {
             using (var driver = GraphDatabase.Driver(
-                       Neo4jDefaultInstallation.BoltUri,
+                       "bolt://[::1]:7687",
                        AuthToken,
                        o => o.WithIpv6Enabled(false)))
             {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestAttribute.cs
@@ -16,6 +16,8 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
+using System.Net;
 using System.Text;
 using Neo4j.Driver.IntegrationTests.Internals;
 using Neo4j.Driver.Internal.Util;
@@ -125,6 +127,33 @@ namespace Neo4j.Driver.IntegrationTests
                 if (!TestConfiguration.IpV6Available())
                     Skip = "IPv6 is not available";
                 else if (!TestConfiguration.IpV6Enabled()) Skip = "IPv6 is disabled";
+            }
+
+            if (string.IsNullOrEmpty(Skip))
+            {
+                var host = Neo4jDefaultInstallation.BoltHost;
+                if (!CanResolveToIPv6(host))
+                {
+                    Skip = $"Hostname '{host}' cannot resolve to an IPv6 address";
+                }
+            }
+        }
+
+        private bool CanResolveToIPv6(string hostname)
+        {
+            try
+            {
+                // Get host addresses
+                var hostAddresses = Dns.GetHostAddresses(hostname);
+
+                // Check if any of the addresses is an IPv6 address
+                return hostAddresses.Any(
+                    address => address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6);
+            }
+            catch (Exception)
+            {
+                // If an exception occurs (like the hostname is not valid or not reachable), return false
+                return false;
             }
         }
     }


### PR DESCRIPTION
[::1] was hardcoded as the IP6 address to try to connect to, which will fail if as the DBMS isn't running on the same host. This was changed to use `Neo4jDefaultInstallation.BoltUri` instead. In addition the test is skipped if `Neo4jDefaultInstallation.BoltHost` cannot be resolved to an IPv6 address.