### PR TITLE
Check IP6 resolve before running test

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Direct/DriverIT.cs
@@ -54,7 +54,7 @@ public sealed class DriverIT : DirectDriverTestBase
     public async Task ShouldConnectIPv6AddressIfEnabled()
     {
         await using var driver = GraphDatabase.Driver(
-            "bolt://[::1]:7687",
+            DefaultInstallation.BoltUri,
             AuthToken,
             o => o.WithIpv6Enabled(true));
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/IntegrationTestAttribute.cs
@@ -14,7 +14,11 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
+using Neo4j.Driver.IntegrationTests.Internals;
 using Neo4j.Driver.Internal.Util;
 using Xunit;
 
@@ -295,6 +299,32 @@ public sealed class RequireServerWithIPv6FactAttribute : RequireServerFactAttrib
             {
                 Skip = "IPv6 is disabled";
             }
+
+            if (string.IsNullOrEmpty(Skip))
+            {
+                var host = DefaultInstallation.BoltHost;
+                if (!CanResolveToIPv6(host))
+                {
+                    Skip = $"Hostname '{host}' cannot resolve to an IPv6 address";
+                }
+            }
+        }
+    }
+
+    private static bool CanResolveToIPv6(string hostname)
+    {
+        try
+        {
+            // Get host addresses
+            var hostAddresses = Dns.GetHostAddresses(hostname);
+
+            // Check if any of the addresses is an IPv6 address
+            return hostAddresses.Any(address => address.AddressFamily == AddressFamily.InterNetworkV6);
+        }
+        catch (Exception)
+        {
+            // If an exception occurs (like the hostname is not valid or not reachable), return false
+            return false;
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/DefaultInstallation.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/DefaultInstallation.cs
@@ -26,7 +26,7 @@ public static class DefaultInstallation
     public const string HttpUri = "http://127.0.0.1:7474";
 
     public const string BoltHeader = "bolt://";
-    private static readonly string BoltHost = "127.0.0.1";
+    public static readonly string BoltHost = "127.0.0.1";
     public static readonly string BoltPort = "7687";
 
     static DefaultInstallation()


### PR DESCRIPTION
[::1] was hardcoded as the IP6 address to try to connect to, which will fail if as the DBMS isn't running on the same host. This was changed to use Neo4jDefaultInstallation.BoltUri instead. In addition the test is skipped if Neo4jDefaultInstallation.BoltHost cannot be resolved to an IPv6 address.