### PR TITLE
Make property mapping fail when record is missing field, unless the property is marked with an attribute

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/BuiltMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/BuiltMapperTests.cs
@@ -38,7 +38,7 @@ public class BuiltMapperTests
     {
         var mapper = new BuiltMapper<NoParameterlessConstructor>();
         var act = () => mapper.Map(null);
-        act.Should().Throw<InvalidOperationException>();
+        act.Should().Throw<MappingFailedException>();
     }
 
     [Fact]
@@ -50,5 +50,38 @@ public class BuiltMapperTests
         mapper.AddConstructorMapping(constructor);
         var result = mapper.Map(TestRecord.Create(new[] { "value" }, new object[] { 48 }));
         result.Value.Should().Be(48);
+    }
+
+    private class TwoPropertyClass
+    {
+        public int Value1 { get; set; }
+        public int Value2 { get; set; }
+    }
+
+    [Fact]
+    public void ShouldMapProperties()
+    {
+        var builder = new MappingBuilder<TwoPropertyClass>();
+        builder.Map(x => x.Value1, "value1");
+        builder.Map(x => x.Value2, "value2");
+
+        var record = TestRecord.Create(["value1", "value2"], [42, 43]);
+        var mapper = builder.Build();
+        var result = mapper.Map(record);
+        result.Value1.Should().Be(42);
+        result.Value2.Should().Be(43);
+    }
+
+    [Fact]
+    public void ShouldThrowWhenPropertyNotFoundInRecord()
+    {
+        var builder = new MappingBuilder<TwoPropertyClass>();
+        builder.Map(x => x.Value1, "value1");
+        builder.Map(x => x.Value2, "value2");
+
+        var record = TestRecord.Create(["value1"], [42]);
+        var mapper = builder.Build();
+        var act = () => mapper.Map(record);
+        act.Should().Throw<MappingFailedException>();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
@@ -129,7 +129,7 @@ public class DefaultMapperTests
         var record = TestRecord.Create(new[] { "something" }, new object[] { 69 });
         var mapper = DefaultMapper.Get<Person>();
         var act = () => mapper.Map(record);
-        act.Should().Throw<InvalidOperationException>();
+        act.Should().Throw<MappingFailedException>();
     }
 
     [Fact]
@@ -291,8 +291,8 @@ public class DefaultMapperTests
             Occurrence = occurrence.ToLowerInvariant();
         }
 
-        public int Year { get; set; }
-        public string Occurrence { get; set; }
+        public int Year { get; }
+        public string Occurrence { get; }
 
         [MappingSource("description")]
         public string Description { get; set; }
@@ -323,8 +323,8 @@ public class DefaultMapperTests
             Occurrence = occurrence.ToLowerInvariant();
         }
 
-        public int Year { get; set; }
-        public string Occurrence { get; set; }
+        public int Year { get; }
+        public string Occurrence { get; }
 
         [MappingSource("description")]
         public string OtherText { get; set; }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/LabelCaptureTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/LabelCaptureTests.cs
@@ -28,12 +28,15 @@ public class LabelCaptureTests
     public class TestMappedClass
     {
         [MappingSource("Person", EntityMappingSource.NodeLabel)]
+        [MappingOptional]
         public string Label { get; set; }
 
         [MappingSource("Person", EntityMappingSource.NodeLabel)]
+        [MappingOptional]
         public List<string> Labels { get; set; }
 
         [MappingSource("Relationship", EntityMappingSource.RelationshipType)]
+        [MappingOptional]
         public string RelationshipType { get; set; }
     }
 
@@ -86,17 +89,20 @@ public class LabelCaptureTests
                         x => x.Label,
                         "Person",
                         EntityMappingSource.NodeLabel,
-                        x => string.Join("|", ((string[])x).Select(y => y.ToUpper())))
+                        x => string.Join("|", ((string[])x).Select(y => y.ToUpper())),
+                        optional: true)
                     .Map(
                         x => x.Labels,
                         "Person",
                         EntityMappingSource.NodeLabel,
-                        x => ((string[])x).Select(y => y.Replace("a", "x")).ToList())
+                        x => ((string[])x).Select(y => y.Replace("a", "x")).ToList(),
+                        optional: true)
                     .Map(
                         x => x.RelationshipType,
                         "Relationship",
                         EntityMappingSource.RelationshipType,
-                        x => x?.ToString()?.ToLower()));
+                        x => x?.ToString()?.ToLower(),
+                        optional: true));
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
@@ -27,7 +27,7 @@ public class MappingProviderTests
         [MappingSource("intValue")]
         public int IntValue { get; set; }
 
-        [MappingSource("texr")]
+        [MappingSource("stringValue")]
         public string Text { get; set; } = null!;
     }
 
@@ -48,6 +48,7 @@ public class MappingProviderTests
         [MappingSource("name")]
         public string Name { get; set; } = null!;
 
+        [MappingOptional]
         public int Age { get; set; }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/OptionalMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/OptionalMappingTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using FluentAssertions;
+using Neo4j.Driver.Preview.Mapping;
+using Neo4j.Driver.Tests.TestUtil;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Mapping;
+
+public class OptionalMappingTests
+{
+    private class ClassWithOptionalProperty
+    {
+        [MappingOptional]
+        public int Value { get; set; } = 1234;
+    }
+
+    [Fact]
+    public void ShouldNotThrowIfOptionalPropertyIsNotPresent()
+    {
+        var record = TestRecord.Create(["someField"], [69]);
+        var mapped = record.AsObject<ClassWithOptionalProperty>();
+
+        mapped.Value.Should().Be(1234);
+    }
+
+    private class ClassWithPropertyWithDefaultValue
+    {
+        [MappingDefaultValue(42)]
+        public int Value { get; set; }
+    }
+
+    [Fact]
+    public void ShouldUseDefaultValueIfOptionalPropertyIsNotPresent()
+    {
+        var record = TestRecord.Create(["someField"], [69]);
+        var mapped = record.AsObject<ClassWithPropertyWithDefaultValue>();
+
+        mapped.Value.Should().Be(42);
+    }
+
+    private class ClassWithConstructorParameterWithDefaultValue
+    {
+        public int Value { get; }
+
+        public ClassWithConstructorParameterWithDefaultValue([MappingDefaultValue(42)] int value)
+        {
+            Value = value;
+        }
+    }
+
+    [Fact]
+    public void ShouldMapConstructorParameterWithDefaultValue()
+    {
+        var record = TestRecord.Create(["someField"], [69]);
+        var mapped = record.AsObject<ClassWithConstructorParameterWithDefaultValue>();
+
+        mapped.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void ShouldNotUseDefaultValueIfPropertyIsPresent()
+    {
+        var record = TestRecord.Create(["Value"], [69]);
+        var mapped = record.AsObject<ClassWithPropertyWithDefaultValue>();
+
+        mapped.Value.Should().Be(69);
+    }
+
+    [Fact]
+    public void ShouldNotUseDefaultValueIfConstructorParameterIsPresent()
+    {
+        var record = TestRecord.Create(["value"], [69]);
+        var mapped = record.AsObject<ClassWithConstructorParameterWithDefaultValue>();
+
+        mapped.Value.Should().Be(69);
+    }
+    
+    private class ClassWithPropertyWithoutDefaultValue
+    {
+        public int Value { get; set; }
+    }
+
+    [Fact]
+    public void ShouldFailToCreateObject()
+    {
+        var record = TestRecord.Create(["NotTheValue"], [69]);
+        var act = () =>
+        {
+            _ = record.AsObject<ClassWithPropertyWithoutDefaultValue>();
+        };
+
+        act.Should().Throw<MappingFailedException>();
+    }
+
+    [Fact]
+    public void ShouldFailToCreateList()
+    {
+        var records = new[]
+        {
+            TestRecord.Create(["Value"], [1]),
+            TestRecord.Create(["NotTheValue"], [2]),
+            TestRecord.Create(["Value"], [3])
+        };
+
+        var act = () =>
+        {
+            _ = records.Select(r => r.AsObject<ClassWithPropertyWithoutDefaultValue>()).ToList();
+        };
+
+        act.Should().Throw<MappingFailedException>();
+    }
+
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
@@ -28,24 +28,30 @@ public class RecordMappingTests
 {
     private class TestPerson
     {
+        [MappingDefaultValue("A. Test Name")]
         [MappingSource("person.name")]
-        public string Name { get; set; } = "A. Test Name";
+        public string Name { get; set; }
 
+        [MappingOptional]
         [MappingSource("person.born")]
         public int? Born { get; set; }
 
+        [MappingOptional]
         [MappingSource("hobbies")]
         public List<string> Hobbies { get; set; } = null!;
     }
 
     private class SimpleTestPerson
     {
+        [MappingOptional]
         [MappingSource("name")]
         public string Name { get; set; } = "A. Test Name";
 
+        [MappingOptional]
         [MappingSource("born")]
         public int? Born { get; set; }
 
+        [MappingOptional]
         public List<string> Hobbies { get; set; } = null!;
     }
 
@@ -104,6 +110,7 @@ public class RecordMappingTests
         [MappingSource("released")]
         public int Released { get; set; }
 
+        [MappingOptional]
         [MappingSource("tagline")]
         public string Tagline { get; set; }
     }
@@ -332,8 +339,9 @@ public class RecordMappingTests
         [MappingSource("car.model")]
         public string Model { get; set; } = "";
 
+        [MappingDefaultValue("unset")]
         [MappingSource("car.madeup")]
-        public string MadeUp { get; set; } = "unset";
+        public string MadeUp { get; set; }
     }
 
     [Fact]
@@ -469,7 +477,7 @@ public class RecordMappingTests
 
         var act = () => record.AsObject<Song>();
 
-        act.Should().Throw<InvalidOperationException>();
+        act.Should().Throw<MappingFailedException>();
     }
 
     [Fact]
@@ -481,7 +489,7 @@ public class RecordMappingTests
 
         var act = () => record.AsObject<Song>();
 
-        act.Should().Throw<InvalidOperationException>();
+        act.Should().Throw<MappingFailedException>();
     }
 
     private class ClassWithInitProperties

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -23,7 +23,7 @@
         <LangVersion>latest</LangVersion>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Neo4j.Driver.xml</DocumentationFile>
         <Version>5.19.0</Version>
-        <LangVersion>10.0</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
         <TargetFrameworks>net6.0;netstandard2.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/EntityMappingInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/EntityMappingInfo.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using System.Reflection;
+
+namespace Neo4j.Driver.Preview.Mapping;
+
+internal record EntityMappingInfo(
+    string Path,
+    EntityMappingSource EntityMappingSource,
+    bool Optional = false,
+    object DefaultValue = null);
+
+internal static class ExtensionsForEntityMappingInfo
+{
+    public static EntityMappingInfo GetEntityMappingInfo(this PropertyInfo propertyInfo)
+    {
+        var path = propertyInfo.Name;
+        var result = new EntityMappingInfo(path, EntityMappingSource.Property);
+        result = GetEntityMappingInfoAffectedByAttributes(result, propertyInfo);
+        return result;
+    }
+
+    public static EntityMappingInfo GetEntityMappingInfo(this ParameterInfo parameterInfo)
+    {
+        var path = parameterInfo.Name;
+        var result = new EntityMappingInfo(path, EntityMappingSource.Property);
+        result = GetEntityMappingInfoAffectedByAttributes(result, parameterInfo);
+        return result;
+    }
+
+    private static EntityMappingInfo GetEntityMappingInfoAffectedByAttributes(
+        EntityMappingInfo info,
+        ICustomAttributeProvider provider)
+    {
+        // check for MappingSourceAttribute
+        var sourceAttribute =
+            provider.GetCustomAttributes(typeof(MappingSourceAttribute), false).FirstOrDefault() as MappingSourceAttribute;
+
+        if (sourceAttribute is not null)
+        {
+            info = info with
+            {
+                Path = sourceAttribute.EntityMappingInfo.Path,
+                EntityMappingSource = sourceAttribute.EntityMappingInfo.EntityMappingSource
+            };
+        }
+
+        var optional = provider.IsDefined(typeof(MappingOptionalAttribute), false);
+        var defaultValueAttribute =
+            provider.GetCustomAttributes(typeof(MappingDefaultValueAttribute), false).FirstOrDefault() as
+                MappingDefaultValueAttribute;
+
+        var defaultValue = defaultValueAttribute?.DefaultValue;
+        return info with { Optional = optional, DefaultValue = defaultValue };
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/IMappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/IMappingBuilder.cs
@@ -47,7 +47,8 @@ public interface IMappingBuilder<TObject>
         Expression<Func<TObject, TProperty>> destination,
         string path,
         EntityMappingSource entityMappingSource = EntityMappingSource.Property,
-        Func<object, TProperty> converter = null);
+        Func<object, TProperty> converter = null,
+        bool optional = false);
 
     /// <summary>
     /// Defines a mapping directly from the record to a property on the object.

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappableValueProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappableValueProvider.cs
@@ -68,7 +68,7 @@ internal class MappableValueProvider : IMappableValueProvider
 
         switch (value)
         {
-            // if null is returned, leave the property as the default value: the record may not have the given field
+            // if null is returned, the record may not have the given field
             case null: return false;
 
             // if the value is an entity or dictionary, make it into a fake record and map that (indirectly recursive)

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingBuilder.cs
@@ -39,11 +39,12 @@ internal class MappingBuilder<T> : IMappingBuilder<T>
         Expression<Func<T, TProperty>> destination,
         string path,
         EntityMappingSource entityMappingSource = EntityMappingSource.Property,
-        Func<object, TProperty> converter = null)
+        Func<object, TProperty> converter = null,
+        bool optional = false)
     {
         _builtMapper.AddMappingBySetter(
             GetPropertySetter(destination),
-            new EntityMappingInfo(path, entityMappingSource),
+            new EntityMappingInfo(path, entityMappingSource, optional),
             converter is null ? null : o => converter.Invoke(o));
 
         return this;

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingFailedException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingFailedException.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Preview.Mapping;
+
+public class MappingFailedException : Exception
+{
+    // the standard constructors for an exception
+    public MappingFailedException(string message) : base(message)
+    {
+    }
+
+    public MappingFailedException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingFailedException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingFailedException.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace Neo4j.Driver.Preview.Mapping;
 
-public class MappingFailedException : Exception
+public class MappingFailedException : Neo4jException
 {
     // the standard constructors for an exception
     public MappingFailedException(string message) : base(message)

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingOptionalAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingOptionalAttribute.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Preview.Mapping;
+
+/// <summary>
+/// If a property or is decorated with this attribute, it will be considered optional. The
+/// mapper will not throw an exception if it cannot find the named value in the record. This
+/// attribute will have no effect when using custom-defined mappers.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class MappingOptionalAttribute : Attribute
+{
+}
+
+/// <summary>
+/// If a property is decorated with this attribute, it will be considered optional. The
+/// mapper will not throw an exception if it cannot find the named value in the record; instead,
+/// it will use the default value provided. This attribute will have no effect when using
+/// custom-defined mappers.
+/// </summary>
+/// <param name="defaultValue">The default value to use if the property is not present in the record.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+public class MappingDefaultValueAttribute(object defaultValue) : MappingOptionalAttribute
+{
+    /// <summary>
+    /// The default value to use if the property is not present in the record.
+    /// </summary>
+    public object DefaultValue => defaultValue;
+}

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingSourceAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingSourceAttribute.cs
@@ -43,8 +43,6 @@ public enum EntityMappingSource
     NodeLabel
 }
 
-internal record EntityMappingInfo(string Path, EntityMappingSource EntityMappingSource);
-
 /// <summary>
 /// Instructs the default mapper to use a different field than the property name when mapping a value to the
 /// marked property. This attribute does not affect custom-defined mappers. A path may consist of the name of the
@@ -53,7 +51,7 @@ internal record EntityMappingInfo(string Path, EntityMappingSource EntityMapping
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
 public class MappingSourceAttribute : Attribute
 {
-    internal EntityMappingInfo EntityMappingInfo { get; }
+    internal EntityMappingInfo EntityMappingInfo { get; private set; }
 
     /// <summary>
     /// Instructs the default mapper to use a different field than the property name when mapping a value to the

--- a/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingSourceDelegateBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/Mapping/MappingSourceDelegateBuilder.cs
@@ -34,8 +34,8 @@ internal class MappingSourceDelegateBuilder : IMappingSourceDelegateBuilder
         {
             if (!_pathFinder.TryGetValueByPath(record, entityMappingInfo.Path, out var foundValue))
             {
-                value = null;
-                return false;
+                value = entityMappingInfo.DefaultValue;
+                return entityMappingInfo.Optional;
             }
 
             switch (entityMappingInfo)


### PR DESCRIPTION
This changes the behaviour of property mapping so that if a property is in the class but it cannot be populated, an exception is thrown, instead of it silently doing nothing. Two new attributes have been added:

* `[MappingOptional]` (properties only)
  This marks the property as optional. If a value is not found in the record, the mapper does nothing (the old default behaviour).
* `[MappingDefaultValue(someValue)]` (properties and constructor parameters)
  This provides a default value which will be put into the property or constructor if a suitable value is not found in the record.

Tests were added for the new features, as well as the specific issues raised that led to this change.