### PR TITLE
Fix default mapper bug

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
@@ -355,7 +355,7 @@ public class DefaultMapperTests
     [Fact]
     public void ShouldThrowIfClassHasNoConstructors()
     {
-        var act = DefaultMapper.Get<NoConstructors>;
+        var act = () => DefaultMapper.Get<NoConstructors>(null);
         act.Should().Throw<InvalidOperationException>();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
@@ -247,6 +247,6 @@ public class MappingProviderTests
             new MappingProviderThatUsesDefaultMappingAndOverridesAGuidProperty(false));
 
         var act = () => testRecord.AsObject<NameAndGuid>();
-        act.Should().Throw<InvalidCastException>();
+        act.Should().Throw<MappingFailedException>();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -22,6 +22,7 @@
         <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
+        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/BuiltMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/BuiltMapper.cs
@@ -154,7 +154,7 @@ internal class BuiltMapper<T> : IRecordMapper<T>
 
             if (mappableValueFound)
             {
-                propertySetter.Invoke(obj, new[] { mappableValue });
+                propertySetter.Invoke(obj, [mappableValue]);
             }
             else if(!optional)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/BuiltMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/BuiltMapper.cs
@@ -28,6 +28,7 @@ internal class BuiltMapper<T> : IRecordMapper<T>
 
     private Func<IRecord, T> _wholeObjectMapping;
     private readonly List<Action<T, IRecord>> _propertyMappings = new();
+    public HashSet<MethodInfo> MappedSetters { get; } = [];
 
     public T Map(IRecord record)
     {
@@ -139,6 +140,7 @@ internal class BuiltMapper<T> : IRecordMapper<T>
     {
         // this part only happens once, at the time of building the mapper
         _propertyMappings.Add(MapFromRecord);
+        MappedSetters.Add(propertySetter);
         return;
 
         // this part happens every time a record is mapped

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DefaultMapper.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -23,6 +22,11 @@ namespace Neo4j.Driver.Mapping;
 internal static class DefaultMapper
 {
     private static readonly Dictionary<Type, object> Mappers = new();
+
+    public static void Reset()
+    {
+        Mappers.Clear();
+    }
 
     public static IRecordMapper<T> Get<T>(HashSet<MethodInfo> mappedSetters = null)
     {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingBuilder.cs
@@ -74,7 +74,7 @@ internal class MappingBuilder<T> : IMappingBuilder<T>
     /// <inheritdoc />
     public IMappingBuilder<T> UseDefaultMapping()
     {
-        _builtMapper.AddWholeObjectMapping(r => DefaultMapper.Get<T>().Map(r));
+        _builtMapper.AddWholeObjectMapping(r => DefaultMapper.Get<T>(_builtMapper.MappedSetters).Map(r));
         return this;
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -84,7 +84,7 @@ public class RecordObjectMapping : IMappingRegistry, IRecordObjectMapping
         // no mapper registered for this type, so use the default mapper
         var openGenericMethod = typeof(DefaultMapper).GetMethod(nameof(DefaultMapper.Get));
         var closedGenericMethod = openGenericMethod!.MakeGenericMethod(type);
-        return closedGenericMethod.Invoke(null, null);
+        return closedGenericMethod.Invoke(null, [null]);
     }
 
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -60,6 +60,7 @@ public class RecordObjectMapping : IMappingRegistry, IRecordObjectMapping
     {
         // discard the current instance and create a new one, which will have no mappers registered
         Instance = new RecordObjectMapping();
+        DefaultMapper.Reset();
     }
 
     /// <summary>


### PR DESCRIPTION
This fixes a design flaw that meant when a user used the `.UseDefaultMapping()` method when building a mapper, and then specifically mapped a property using `.Map()`, the default mapper would run as normal - so if the default mapper does not know how to map the property that has been overridden, it will throw an exception before the custom mapping gets to run.

This was solved by keeping track of which properties have been explicitly mapped during building of the mapper, and then passing this list to the creation of the default mapper so that it can exclude these properties from its process.

A couple of tests have been added to verify this. 

Also there was an untested method in the mapping of an asynchronous list of records to blueprinted objects, so I put a couple in for that too.