### PR TITLE
Fix for Stefan's category/classification issue in WithNotifications

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -294,10 +294,12 @@ public class ConfigTests
             var config = configBuilder.Build()
                 .NotificationsConfig.Should()
                 .BeOfType<NotificationsConfig>();
+
             config
                 .Which
                 .DisabledCategories.Should()
                 .BeEquivalentTo([outCat]);
+
             config
                 .Which
                 .MinimumSeverity.Should()
@@ -410,6 +412,32 @@ public class ConfigTests
                 .Which
                 .DisabledCategories.Should()
                 .BeEquivalentTo([]);
+
+            config
+                .Which
+                .MinimumSeverity.Should()
+                .Be(Severity.Warning);
+        }
+
+        [Fact]
+        public void WithNotifications_ShouldSetMultipleCategoriesAndClassifications()
+        {
+            var configBuilder = new ConfigBuilder(new Config());
+
+            // specify both categories and classifications
+            configBuilder.WithNotifications(
+                Severity.Warning,
+                [Category.Deprecation, Category.Hint],
+                [Classification.Deprecation, Classification.Topology]);
+
+            var config = configBuilder.Build()
+                .NotificationsConfig.Should()
+                .BeOfType<NotificationsConfig>();
+
+            config
+                .Which
+                .DisabledCategories.Should()
+                .BeEquivalentTo([Category.Deprecation, Category.Hint, Category.Topology]);
 
             config
                 .Which

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -256,7 +256,7 @@ public class ConfigTests
         {
             var configBuilder = new ConfigBuilder(new Config());
 
-            configBuilder.WithNotifications(null, [classification]);
+            configBuilder.WithNotifications(null, disabledClassifications: [classification]);
 
             var config = configBuilder.Build()
                 .NotificationsConfig.Should()
@@ -331,7 +331,9 @@ public class ConfigTests
         {
             var configBuilder = new ConfigBuilder(new Config());
 
-            configBuilder.WithNotifications(null, [Classification.Deprecation, Classification.Hint]);
+            configBuilder.WithNotifications(
+                null,
+                disabledClassifications: [Classification.Deprecation, Classification.Hint]);
 
             var config = configBuilder.Build()
                 .NotificationsConfig.Should()
@@ -375,7 +377,7 @@ public class ConfigTests
         {
             var configBuilder = new ConfigBuilder(new Config());
 
-            configBuilder.WithNotifications(Severity.Warning, Array.Empty<Classification>());
+            configBuilder.WithNotifications(Severity.Warning, disabledClassifications: Array.Empty<Classification>());
 
             var config = configBuilder.Build()
                 .NotificationsConfig.Should()
@@ -391,7 +393,30 @@ public class ConfigTests
                 .MinimumSeverity.Should()
                 .Be(Severity.Warning);
         }
-        
+
+        [Fact]
+        public void WithNotifications_ShouldWorkWithSecondParameterNull()
+        {
+            var configBuilder = new ConfigBuilder(new Config());
+
+            // this line would fail to compile before the fix
+            configBuilder.WithNotifications(Severity.Warning, null);
+
+            var config = configBuilder.Build()
+                .NotificationsConfig.Should()
+                .BeOfType<NotificationsConfig>();
+
+            config
+                .Which
+                .DisabledCategories.Should()
+                .BeEquivalentTo([]);
+
+            config
+                .Which
+                .MinimumSeverity.Should()
+                .Be(Severity.Warning);
+        }
+
         private class MockTlsNegotiator : ITlsNegotiator
         {
             /// <inheritdoc/>

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -366,7 +366,7 @@ public class ConfigTests
             config
                 .Which
                 .DisabledCategories.Should()
-                .BeEquivalentTo([]);
+                .BeNull();
 
             config
                 .Which
@@ -388,7 +388,7 @@ public class ConfigTests
             config
                 .Which
                 .DisabledCategories.Should()
-                .BeEquivalentTo([]);
+                .BeNull();
 
             config
                 .Which
@@ -411,7 +411,7 @@ public class ConfigTests
             config
                 .Which
                 .DisabledCategories.Should()
-                .BeEquivalentTo([]);
+                .BeNull();
 
             config
                 .Which
@@ -438,6 +438,29 @@ public class ConfigTests
                 .Which
                 .DisabledCategories.Should()
                 .BeEquivalentTo([Category.Deprecation, Category.Hint, Category.Topology]);
+
+            config
+                .Which
+                .MinimumSeverity.Should()
+                .Be(Severity.Warning);
+        }
+
+        [Fact]
+        public void WithNotifications_ShouldHaveNullExclusions()
+        {
+            var configBuilder = new ConfigBuilder(new Config());
+
+            // this line would fail to compile before the fix
+            configBuilder.WithNotifications(Severity.Warning, null);
+
+            var config = configBuilder.Build()
+                .NotificationsConfig.Should()
+                .BeOfType<NotificationsConfig>();
+
+            config
+                .Which
+                .DisabledCategories.Should()
+                .BeNull();
 
             config
                 .Which

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -366,7 +366,7 @@ public class ConfigTests
             config
                 .Which
                 .DisabledCategories.Should()
-                .BeNull();
+                .BeEmpty();
 
             config
                 .Which
@@ -388,7 +388,7 @@ public class ConfigTests
             config
                 .Which
                 .DisabledCategories.Should()
-                .BeNull();
+                .BeEmpty();
 
             config
                 .Which

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigBuilderTests.cs
@@ -146,7 +146,7 @@ public class SessionConfigBuilderTests
         config
             .Which
             .DisabledCategories.Should()
-            .BeEquivalentTo([]);
+            .BeNull();
 
         config
             .Which
@@ -168,7 +168,7 @@ public class SessionConfigBuilderTests
         config
             .Which
             .DisabledCategories.Should()
-            .BeEquivalentTo([]);
+            .BeNull();
 
         config
             .Which

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigBuilderTests.cs
@@ -146,7 +146,7 @@ public class SessionConfigBuilderTests
         config
             .Which
             .DisabledCategories.Should()
-            .BeNull();
+            .BeEmpty();
 
         config
             .Which
@@ -168,7 +168,7 @@ public class SessionConfigBuilderTests
         config
             .Which
             .DisabledCategories.Should()
-            .BeNull();
+            .BeEmpty();
 
         config
             .Which

--- a/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/SessionConfigBuilderTests.cs
@@ -38,7 +38,7 @@ public class SessionConfigBuilderTests
     {
         var configBuilder = new SessionConfigBuilder(new SessionConfig());
 
-        configBuilder.WithNotifications(null, [classification]);
+        configBuilder.WithNotifications(null, disabledClassifications: [classification]);
 
         var config = configBuilder.Build()
             .NotificationsConfig.Should()
@@ -115,7 +115,7 @@ public class SessionConfigBuilderTests
     {
         var configBuilder = new SessionConfigBuilder(new SessionConfig());
 
-        configBuilder.WithNotifications(null, [Classification.Deprecation, Classification.Hint]);
+        configBuilder.WithNotifications(null, disabledClassifications: [Classification.Deprecation, Classification.Hint]);
 
         var config = configBuilder.Build()
             .NotificationsConfig.Should()
@@ -159,7 +159,7 @@ public class SessionConfigBuilderTests
     {
         var configBuilder = new SessionConfigBuilder(new SessionConfig());
 
-        configBuilder.WithNotifications(Severity.Warning, Array.Empty<Classification>());
+        configBuilder.WithNotifications(Severity.Warning, disabledClassifications: Array.Empty<Classification>());
 
         var config = configBuilder.Build()
             .NotificationsConfig.Should()

--- a/Neo4j.Driver/Neo4j.Driver/Preview/GqlErrors/IGqlErrorPreview.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Preview/GqlErrors/IGqlErrorPreview.cs
@@ -49,7 +49,7 @@ public interface IGqlErrorPreview
     public Dictionary<string, object> GqlDiagnosticRecord { get; }
 }
 
-public static class Neo4jExceptionExtensions
+internal static class Neo4jExceptionExtensions
 {
     public static IGqlErrorPreview GetGqlErrorPreview(this Neo4jException exception)
     {

--- a/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
@@ -437,9 +437,15 @@ public sealed class ConfigBuilder
                 "are null, at least one must be non-null.");
         }
 
-        var classificationsAsCategories = disabledClassifications?.Select(x => (Category)(int)x).ToArray() ?? [];
-        var categoriesToDisable = (disabledCategories ?? []).Concat(classificationsAsCategories).ToArray();
+        Category[] categoriesToDisable = null;
+        if (disabledCategories != null || disabledClassifications != null)
+        {
+            var classificationsAsCategories = disabledClassifications?.Select(x => (Category)(int)x) ?? [];
+            categoriesToDisable = (disabledCategories ?? []).Concat(classificationsAsCategories).ToArray();
+        }
+
         _config.NotificationsConfig = new NotificationsConfig(minimumSeverity, categoriesToDisable);
+
         return this;
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
@@ -387,6 +387,18 @@ public sealed class ConfigBuilder
         return WithCertificateTrustRule(certificateTrustRule, certs);
     }
 
+    /// <summary>Disable all notifications for the lifetime of the driver.</summary>
+    /// <remarks>Cannot be used with: <see cref="WithNotifications(Severity?, Category[], Classification[])"/>.</remarks>
+    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
+    /// <seealso cref="WithNotifications(Severity?, Category[], Classification[])"/>
+    /// <seealso cref="SessionConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>
+    /// <seealso cref="SessionConfigBuilder.WithNotificationsDisabled"/>
+    public ConfigBuilder WithNotificationsDisabled()
+    {
+        _config.NotificationsConfig = new NotificationsDisabledConfig();
+        return this;
+    }
+
     /// <summary>
     /// Override configuration for which <see cref="INotification"/>s should be emitted for the lifetime of the
     /// driver. <br/> Unspecified configuration will be provided by configuration in the server. <br/> Disabling categories or
@@ -402,82 +414,32 @@ public sealed class ConfigBuilder
     /// an empty collection, all categories are enabled.<br/> By leaving null, the value will inherit configuration from the
     /// server.
     /// </param>
-    /// <exception cref="ArgumentException">Thrown when both parameters are null.</exception>
-    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
-    /// <seealso cref="WithNotificationsDisabled"/>
-    /// <seealso cref="SessionConfigBuilder.WithNotifications(Severity?, Category[])"/>"/>
-    /// <seealso cref="SessionConfigBuilder.WithNotificationsDisabled"/>
-    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
-    public ConfigBuilder WithNotifications(
-        Severity? minimumSeverity,
-        Category[] disabledCategories)
-    {
-        if (minimumSeverity == null && disabledCategories == null)
-        {
-            throw new ArgumentException(
-                $"Both {nameof(minimumSeverity)} and {nameof(disabledCategories)} are both null, at least one must be non-null.");
-        }
-
-        _config.NotificationsConfig = new NotificationsConfig(minimumSeverity, disabledCategories);
-        return this;
-    }
-
-    /// <summary>Disable all notifications for the lifetime of the driver.</summary>
-    /// <remarks>Cannot be used with: <see cref="WithNotifications(Severity?, Category[])"/>.</remarks>
-    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
-    /// <seealso cref="WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="SessionConfigBuilder.WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="SessionConfigBuilder.WithNotificationsDisabled"/>
-    public ConfigBuilder WithNotificationsDisabled()
-    {
-        _config.NotificationsConfig = new NotificationsDisabledConfig();
-        return this;
-    }
-
-        
-    /// <summary>
-    /// This is a preview API, This API may change between minor revisions.<br/>
-    /// 
-    /// Override configuration for which <see cref="IGqlStatusObject"/> and <see cref="INotification"/> should be emitted
-    /// for the lifetime of the session. <br/> Unspecified configuration will be provided by configuration specified in
-    /// the server or the driver's <see cref="ConfigBuilder.WithNotifications(Severity?, Classification[])"/> or
-    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/>. <br/> If the driver has disabled
-    /// notifications with <see cref="ConfigBuilder.WithNotificationsDisabled"/>, the unspecified values will be
-    /// provided by the server. <br/> Disabling categories, classifications or severities allows the server to skip
-    /// analysis for those which can speed up query execution.
-    /// </summary>
-    /// <remarks>Cannot be used with: <see cref="WithNotificationsDisabled"/> or
-    /// <see cref="WithNotifications(Severity?, Category[])"/>.</remarks>
-    /// <param name="minimumSeverity">
-    /// Optional parameter to override the minimum severity of notifications emitted. <br/> By
-    /// leaving null, the value will inherit configuration of <see cref="Config.NotificationsConfig"/> or the server.
-    /// </param>
     /// <param name="disabledClassifications">
-    /// Optional parameter to override the category of notifications and classifications of GQL Statuses emitted. <br/>
-    /// By passing an empty collection, all categories are enabled.<br/> By leaving null, the value will inherit
-    /// configuration from <see cref="Config.NotificationsConfig"/> or the server.
+    /// Optional parameter to override the classification of notifications emitted. <br/> By passing
+    /// an empty collection, all classifications are enabled.<br/> By leaving null, the value will inherit configuration from the
+    /// server.
     /// </param>
-    /// <exception cref="ArgumentException">Thrown when both parameters are null.</exception>
-    /// <returns>A <see cref="SessionConfigBuilder"/> instance for further configuration options.</returns>
+    /// <exception cref="ArgumentException">Thrown when all parameters are null.</exception>
+    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     /// <seealso cref="WithNotificationsDisabled"/>
-    /// <seealso cref="WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Classification[])"/>
-    /// <seealso cref="ConfigBuilder.WithNotificationsDisabled"/>
-    /// <since>5.23.0</since>
-    [Obsolete("This is a Preview API and may change between minor versions. Obsolete will be removed in a later revision.")]
+    /// <seealso cref="SessionConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>"/>
+    /// <seealso cref="SessionConfigBuilder.WithNotificationsDisabled"/>
+    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     public ConfigBuilder WithNotifications(
         Severity? minimumSeverity,
-        Classification[] disabledClassifications)
+        Category[] disabledCategories = null,
+        Classification[] disabledClassifications = null)
     {
-        if (minimumSeverity == null && disabledClassifications == null)
+        if (minimumSeverity == null && disabledCategories == null && disabledClassifications == null)
         {
             throw new ArgumentException(
-                $"Both {nameof(minimumSeverity)} and {nameof(disabledClassifications)} are both null, at least one must be non-null.");
+                $"All {nameof(minimumSeverity)}, {nameof(disabledCategories)} and {nameof(disabledClassifications)} " +
+                "are null, at least one must be non-null.");
         }
 
-        _config.NotificationsConfig = new NotificationsConfig(minimumSeverity,
-            disabledClassifications.Select(x => (Category)(int)x).ToArray());
+        var classificationsAsCategories = disabledClassifications?.Select(x => (Category)(int)x).ToArray() ?? [];
+        var categoriesToDisable = (disabledCategories ?? []).Concat(classificationsAsCategories).ToArray();
+        _config.NotificationsConfig = new NotificationsConfig(minimumSeverity, categoriesToDisable);
         return this;
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ExecutableQueryMappingExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ExecutableQueryMappingExtensions.cs
@@ -47,6 +47,7 @@ public static class ExecutableQueryMappingExtensions
     /// </summary>
     /// <seealso cref="RecordObjectMapping.Map{T}"/>
     /// <param name="recordsTask">The task that will return the records.</param>
+    /// <param name="blueprint">The blueprint to use for mapping.</param>
     /// <typeparam name="T">The type to map to.</typeparam>
     /// <returns>A task that will return the mapped objects.</returns>
     public static async Task<IReadOnlyList<T>> AsObjectsFromBlueprintAsync<T>(

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingFailedException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingFailedException.cs
@@ -22,10 +22,19 @@ namespace Neo4j.Driver.Mapping;
 /// </summary>
 public class MappingFailedException : Neo4jException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MappingFailedException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public MappingFailedException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MappingFailedException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public MappingFailedException(string message, Exception innerException) : base(message, innerException)
     {
     }

--- a/Neo4j.Driver/Neo4j.Driver/Public/SessionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/SessionConfig.cs
@@ -360,8 +360,13 @@ public sealed class SessionConfigBuilder
                 $"or {nameof(disabledClassifications)} must be set.");
         }
 
-        var classificationsAsCategories = disabledClassifications?.Select(x => (Category)(int)x) ?? [];
-        var categoriesToDisable = (disabledCategories ?? []).Concat(classificationsAsCategories).ToArray();
+        Category[] categoriesToDisable = null;
+        if (disabledCategories != null || disabledClassifications != null)
+        {
+            var classificationsAsCategories = disabledClassifications?.Select(x => (Category)(int)x) ?? [];
+            categoriesToDisable = (disabledCategories ?? []).Concat(classificationsAsCategories).ToArray();
+        }
+
         _config.NotificationsConfig = new NotificationsConfig(minimumSeverity, categoriesToDisable);
         return this;
     }

--- a/Neo4j.Driver/Neo4j.Driver/Public/SessionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/SessionConfig.cs
@@ -147,7 +147,7 @@ public sealed class SessionConfig
     /// Note: Configuration support was introduced in server version 5.7.<br/> Servers currently will analyze all
     /// queries for all <see cref="NotificationCategory"/>s and <see cref="NotificationSeverity"/>s.
     /// </remarks>
-    /// <seealso cref="SessionConfigBuilder.WithNotifications(Severity?, Category[])"/>
+    /// <seealso cref="SessionConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>
     /// <seealso cref="SessionConfigBuilder.WithNotificationsDisabled"/>
     /// <seealso cref="Config.NotificationsConfig"/>
     /// <seealso cref="INotification"/>
@@ -322,7 +322,7 @@ public sealed class SessionConfigBuilder
     /// <summary>
     /// Override configuration for which <see cref="INotification"/>s should be emitted for the lifetime of the
     /// session. <br/> Unspecified configuration will be provided by configuration specified in the server or the driver's
-    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/>. <br/> If the driver has disabled notifications
+    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>. <br/> If the driver has disabled notifications
     /// with <see cref="ConfigBuilder.WithNotificationsDisabled"/>, the unspecified values will be provided by the server.
     /// <br/> Disabling categories or severities allows the server to skip analysis for those, which can speed up query
     /// execution.
@@ -331,82 +331,46 @@ public sealed class SessionConfigBuilder
     /// <param name="minimumSeverity">
     /// Optional parameter to override the minimum severity of notifications emitted. <br/> By
     /// leaving null, the value will inherit configuration from
-    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/> or the server.
+    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/> or the server.
     /// </param>
     /// <param name="disabledCategories">
     /// Optional parameter to override the category of notifications emitted. <br/> By passing
     /// an empty collection, all categories are enabled.<br/> By leaving null, the value will inherit configuration from
-    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/> or the server.
-    /// </param>
-    /// <exception cref="ArgumentException">Thrown when both parameters are null.</exception>
-    /// <returns>A <see cref="SessionConfigBuilder"/> instance for further configuration options.</returns>
-    /// <seealso cref="WithNotificationsDisabled"/>
-    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="ConfigBuilder.WithNotificationsDisabled"/>
-    public SessionConfigBuilder WithNotifications(
-        Severity? minimumSeverity,
-        Category[] disabledCategories)
-    {
-        if (minimumSeverity == null && disabledCategories == null)
-        {
-            throw new ArgumentException(
-                $"Both {nameof(minimumSeverity)} and {nameof(disabledCategories)} are both null, at least one must be non-null.");
-        }
-
-        _config.NotificationsConfig = new NotificationsConfig(minimumSeverity, disabledCategories);
-        return this;
-    }
-    
-    /// <summary>
-    /// This is a preview API, This API may change between minor revisions.<br/> Override configuration for which
-    /// <see cref="IGqlStatusObject"/> and <see cref="INotification"/> should be emitted for the lifetime of the session. <br/>
-    /// Unspecified configuration will be provided by configuration specified in the server or the driver's
-    /// <see cref="Config.NotificationsConfig"/>. <br/> If the driver has disabled  notifications with <see cref="ConfigBuilder.WithNotificationsDisabled"/>, the unspecified values will be provided by
-    /// the server. <br/> Disabling categories or severities allows the server to skip analysis for those, which can speed up
-    /// query execution.
-    /// </summary>
-    /// <remarks>Cannot be used with: <see cref="WithNotificationsDisabled"/>.</remarks>
-    /// <param name="minimumSeverity">
-    /// Optional parameter to override the minimum severity of notifications emitted. <br/> By
-    /// leaving null, the value will inherit configuration from
-    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Classification[])"/> or the server.
+    /// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/> or the server.
     /// </param>
     /// <param name="disabledClassifications">
-    /// Optional parameter to override the category of notifications emitted. <br/> By
-    /// passing an empty collection, all categories are enabled.<br/> By leaving null, the value will inherit configuration
-    /// from <see cref="ConfigBuilder.WithNotifications(Severity?, Classification[])"/> or the server.
+    /// Optional parameter to override the classification of notifications emitted. <br/> By passing
+    /// an empty collection, all classifications are enabled.<br/> By leaving null, the value will inherit configuration from the
+    /// server.
     /// </param>
-    /// <exception cref="ArgumentException">Thrown when both parameters are null.</exception>
+    /// <exception cref="ArgumentException">Thrown when all parameters are null.</exception>
     /// <returns>A <see cref="SessionConfigBuilder"/> instance for further configuration options.</returns>
     /// <seealso cref="WithNotificationsDisabled"/>
-    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Classification[])"/>
+    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>
     /// <seealso cref="ConfigBuilder.WithNotificationsDisabled"/>
-    /// <since>5.23.0</since>
-    [Obsolete(
-        "This is a Preview API and may change between minor versions. Obsolete will be removed in a later revision.")]
     public SessionConfigBuilder WithNotifications(
         Severity? minimumSeverity,
-        Classification[] disabledClassifications)
+        Category[] disabledCategories = null,
+        Classification[] disabledClassifications = null)
     {
-        if (minimumSeverity == null && disabledClassifications == null)
+        if (minimumSeverity == null && disabledCategories == null && disabledClassifications == null)
         {
             throw new ArgumentException(
-                $"Both {nameof(minimumSeverity)} and {nameof(disabledClassifications)} are both null, at least one must be non-null.");
+                $"At least one of {nameof(minimumSeverity)}, {nameof(disabledCategories)}, " +
+                $"or {nameof(disabledClassifications)} must be set.");
         }
 
-        _config.NotificationsConfig = new NotificationsConfig(
-            minimumSeverity,
-            disabledClassifications.Select(x => (Category)(int)x).ToArray());
-
+        var classificationsAsCategories = disabledClassifications?.Select(x => (Category)(int)x) ?? [];
+        var categoriesToDisable = (disabledCategories ?? []).Concat(classificationsAsCategories).ToArray();
+        _config.NotificationsConfig = new NotificationsConfig(minimumSeverity, categoriesToDisable);
         return this;
     }
-    
+
     /// <summary>Disable all notifications for the lifetime of the session.</summary>
-    /// <remarks>Cannot be used with: <see cref="WithNotifications(Severity?, Category[])"/>.</remarks>
+    /// <remarks>Cannot be used with: <see cref="WithNotifications(Severity?, Category[], Classification[])"/>.</remarks>
     /// <returns>A <see cref="SessionConfigBuilder"/> instance for further configuration options.</returns>
-    /// <seealso cref="WithNotifications(Severity?, Category[])"/>
-    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/>
+    /// <seealso cref="WithNotifications(Severity?, Category[], Classification[])"/>
+    /// <seealso cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>
     /// <seealso cref="ConfigBuilder.WithNotificationsDisabled"/>
     public SessionConfigBuilder WithNotificationsDisabled()
     {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/IGqlStatusObject.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/IGqlStatusObject.cs
@@ -24,7 +24,6 @@ namespace Neo4j.Driver;
 /// </summary>
 /// <seealso cref="IResultSummary.GqlStatusObjects" />
 /// <since>5.23.0</since>
-[Obsolete("This is a Preview API and may change between minor versions. Obsolete will be removed in a later revision.")]
 public interface IGqlStatusObject
 {
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/IResultSummary.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/IResultSummary.cs
@@ -76,7 +76,6 @@ public interface IResultSummary
     /// </summary>
     /// <seealso cref="IGqlStatusObject">For more information about GQL Statuses</seealso>
     /// <since>5.23.0</since>
-    [Obsolete("This is a Preview API and may change between minor versions. Obsolete will be removed in a later revision.")]
     IList<IGqlStatusObject> GqlStatusObjects { get; }
     
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/NotificationClassification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/NotificationClassification.cs
@@ -23,7 +23,6 @@ namespace Neo4j.Driver;
 /// conjunction with <see cref="NotificationSeverity"/>.
 /// </summary>
 /// <since>5.23.0</since>
-[Obsolete("This is a Preview API and may change between minor versions. Obsolete will be removed in a later revision.")]
 public enum NotificationClassification
 {
     /// <summary>the <see cref="IGqlStatusObject"/>'s classification is a value unknown to this driver version.</summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Types/Category.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Types/Category.cs
@@ -18,8 +18,8 @@ namespace Neo4j.Driver;
 /// <summary>
 /// Used In conjunction with <see cref="Severity"/> to filter which <see cref="INotification"/>s will be sent in
 /// <see cref="IResultSummary.Notifications"/>.<br/><br/>
-/// Can be used in <see cref="ConfigBuilder.WithNotifications(Severity?, Category[])"/> and
-/// <see cref="SessionConfigBuilder.WithNotifications(Severity?, Category[])"/>.
+/// Can be used in <see cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/> and
+/// <see cref="SessionConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>.
 /// </summary>
 public enum Category
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Types/Classification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Types/Classification.cs
@@ -18,14 +18,12 @@ using System;
 namespace Neo4j.Driver;
 
 /// <summary>
-/// This is a preview API, This API may change between minor revisions.<br/> Used In conjunction with
 /// <see cref="Severity"/> to filter which <see cref="IGqlStatusObject"/> and <see cref="INotification"/>s will be sent in
 /// <see cref="IResultSummary.GqlStatusObjects"/> and  <see cref="IResultSummary.Notifications"/> .<br/> Can be used in
-/// <see cref="ConfigBuilder.WithNotifications(Severity?, Classification[])"/> and
-/// <see cref="SessionConfigBuilder.WithNotifications(Severity?, Classification[])"/>.
+/// <see cref="ConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/> and
+/// <see cref="SessionConfigBuilder.WithNotifications(Severity?, Category[], Classification[])"/>.
 /// </summary>
 /// <since>5.23.0</since>
-[Obsolete("This is a Preview API and may change between minor versions. Obsolete will be removed in a later revision.")]
 public enum Classification
 {
     /// <summary>Receive notifications when a hint in query cannot be satisfied.</summary>


### PR DESCRIPTION
This is a fix for [this issue](https://github.com/neo4j/neo4j-dotnet-driver/issues/831) Stefano raised.

At present, there are two overloads for the `WithNotifications` method on both the ConfigBuilder and SessionConfigBuilder:

```c#
// originally present
public ConfigBuilder WithNotifications(Severity? minimumSeverity, Category[] disabledCategories)

// added with the GQL Notifications work (which is in preview)
public ConfigBuilder WithNotifications(Severity? minimumSeverity, Classification[] disabledClassifications)
```

However, by adding the second overload, the following code will no longer compile:

```c#
builder.WithNotifications(Severity.Warning, null);
```
with the compiler giving the following error:
```
error CS0121: The call is ambiguous between the following methods or properties:
'ConfigBuilder.WithNotifications(Severity?, Category[])' and
'ConfigBuilder.WithNotifications(Severity?, Classification[])'
```

To solve the problem we can move or change the second overload since it is preview but code calling the first overload in whatever manner must compile with no changes.

The solution I went with was to combine both methods into a single overload with the following signature:

```c#
public ConfigBuilder WithNotifications(
        Severity? minimumSeverity,
        Category[] disabledCategories = null,
        Classification[] disabledClassifications = null)
```

This can be used as follows:

```c#
// same behaviour as before
.WithNotifications(Severity.Warning);

// same behaviour as before, although the IDE will point out that the
// second parameter is not required
.WithNotifications(Severity.Warning, null);

// same behaviour as before
.WithNotifications(Severity.Warning, [Category.Hint, Category.Unsupported]);

// also allowed, identical to previous line
.WithNotifications(
    Severity.Warning, 
    disabledCategories: [Category.Hint, Category.Unsupported]);

// to disable by classification
.WithNotifications(
    Severity.Warning, 
    disabledClassifications: [Classification.Hint, Classification.Unsupported]);

// or
.WithNotifications(
    Severity.Warning, 
    null,
    [Classification.Hint, Classification.Unsupported]);

// you can even do this
.WithNotifications(
    Severity.Warning, 
    [Category.Performance, Category.Topology],
    [Classification.Hint, Classification.Unsupported]);

```

In the last example, all four of the specified exclusions will apply.

I added a test that initially failed to compile, by passing null as the second parameter, and that test now works fine.

I also did some minor tidying re XML docs etc, and moved GQL Notifications out of preview.
