### PR TITLE
Custom type conversion added to object mapping

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/VarLongTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/VarLongTests.cs
@@ -15,7 +15,6 @@
 
 using System;
 using FluentAssertions;
-using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.Util;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/BuiltMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/BuiltMapperTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DelegateMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DelegateMapperTests.cs
@@ -355,7 +355,7 @@ public class DelegateMapperTests
     {
         var record = TestRecord.Create(("x", 69));
 
-        Action act = () => record.AsObject(
+        var act = () => record.AsObject(
             (int x) =>
             {
                 if (x == 69)

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DictAsRecordTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DictAsRecordTests.cs
@@ -16,6 +16,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DictAsRecordTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DictAsRecordTests.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Internal.Types;
-using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 using InvalidOperationException = System.InvalidOperationException;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/LabelCaptureTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/LabelCaptureTests.cs
@@ -23,13 +23,8 @@ using Xunit;
 
 namespace Neo4j.Driver.Tests.Mapping;
 
-public class LabelCaptureTests
+public class LabelCaptureTests : MappingTestWithGlobalState
 {
-    public LabelCaptureTests()
-    {
-        RecordObjectMapping.Reset();
-    }
-
     [Fact]
     public void ShouldCaptureSingleNodeLabel()
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.Mapping;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappableValueProviderTests.cs
@@ -13,11 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
 using Neo4j.Driver.Internal.Mapping;
+using Neo4j.Driver.Internal.Mapping.TypeConversion;
 using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.Mapping;
 using Xunit;
@@ -128,6 +130,32 @@ public class MappableValueProviderTests
 
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void GetConvertedValueShouldUseTypeConversion()
+    {
+        var expected = new Guid("b19f766c-4f74-41a9-a73d-6298697d81a7");
+        var entityMappingInfo = new EntityMappingInfo("field-name", EntityMappingSource.Property);
+        _mocker.GetMock<IMappingSourceDelegateBuilder>()
+            .Setup(x => x.GetMappingDelegate(entityMappingInfo))
+            .Returns(GetMockMappingDelegate(expected.ToString(), true));
+
+        object expectedObj = expected;
+        _mocker.GetMock<IMappingTypeConversionManager>()
+            .Setup(x => x.TryConvert(typeof(string), typeof(Guid), expected.ToString(), out expectedObj))
+            .Returns(true);
+
+        var subject = _mocker.CreateInstance<MappableValueProvider>(true);
+
+        var result = subject.GetConvertedValue(
+            Mock.Of<IRecord>(),
+            entityMappingInfo,
+            typeof(Guid));
+
+        result.Should().Be(expected);
+    }
+
+
 
     [Fact]
     public void ShouldReturnNullWhenValueIsNull()

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappedListCreatorTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappedListCreatorTests.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingBuilderTests.cs
@@ -15,6 +15,7 @@
 
 using System;
 using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Mapping;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingBuilderTests.cs
@@ -16,7 +16,6 @@
 using System;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Mapping;
-using Neo4j.Driver.Mapping;
 using Xunit;
 
 namespace Neo4j.Driver.Tests.Mapping;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingProviderTests.cs
@@ -21,13 +21,8 @@ using Xunit;
 
 namespace Neo4j.Driver.Tests.Mapping;
 
-public class MappingProviderTests
+public class MappingProviderTests : MappingTestWithGlobalState
 {
-    public MappingProviderTests()
-    {
-        RecordObjectMapping.Reset();
-    }
-
     [Fact]
     public void ShouldOverrideDefaultMapping()
     {

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingSourceDelegateBuilderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingSourceDelegateBuilderTests.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Internal.Types;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingTestWithGlobalState.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingTestWithGlobalState.cs
@@ -1,26 +1,33 @@
 ﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using Neo4j.Driver.Mapping;
+using Xunit;
 
-namespace Neo4j.Driver.Internal.Mapping.TypeConversion;
+namespace Neo4j.Driver.Tests.Mapping;
 
-internal interface IMappingTypeConversionManager
+[CollectionDefinition("UsesMappingGlobalState", DisableParallelization = true)]
+public class UsesMappingGlobalState
 {
-    bool TryConvert<TFrom, TTo>(TFrom from, out TTo to);
-    void RegisterConverter<TFrom, TTo>(Func<TFrom, TTo> converter);
-    bool TryConvert(Type fromType, Type toType, object from, out object to);
-    void Clear();
+}
+
+[Collection("UsesMappingGlobalState")]
+public class MappingTestWithGlobalState
+{
+    public MappingTestWithGlobalState()
+    {
+        RecordObjectMapping.Reset();
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordMappingTests.cs
@@ -676,7 +676,5 @@ public class RecordMappingTests
         public int Age => age;
     }
 
-    private record TestXY(int X, string Y)
-    {
-    }
+    private record TestXY(int X, string Y);
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
@@ -16,7 +16,6 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Mapping;
-using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/RecordPathFinderTests.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping;
 using Neo4j.Driver.Mapping;
 using Neo4j.Driver.Tests.TestUtil;
 using Xunit;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/TypeConversion/TypeConversionManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/TypeConversion/TypeConversionManagerTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using Neo4j.Driver.Internal.Mapping.TypeConversion;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Mapping.TypeConversion;
+
+public class TypeConversionManagerTests
+{
+    [Fact]
+    public void ShouldConvertTypes()
+    {
+        var manager = new MappingTypeConversionManager();
+        manager.RegisterConverter<int, string>(i => i.ToString());
+        manager.RegisterConverter<string, int>(int.Parse);
+
+        manager.TryConvert(42, out string str).Should().BeTrue();
+        str.Should().Be("42");
+
+        manager.TryConvert("42", out int i).Should().BeTrue();
+        i.Should().Be(42);
+    }
+
+    [Fact]
+    public void ShouldNotConvertTypes()
+    {
+        var manager = new MappingTypeConversionManager();
+        manager.RegisterConverter<int, string>(i => i.ToString());
+        manager.RegisterConverter<string, int>(int.Parse);
+
+        manager.TryConvert(42, out int _).Should().BeFalse();
+
+        manager.TryConvert("42", out string _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldNotConvertTypesWhenNoConverterRegistered()
+    {
+        var manager = new MappingTypeConversionManager();
+        manager.TryConvert(42, out string _).Should().BeFalse();
+        manager.TryConvert("42", out int _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldNotConvertTypesWhenConverterIsNotRegistered()
+    {
+        var manager = new MappingTypeConversionManager();
+        manager.RegisterConverter<int, string>(i => i.ToString());
+
+        manager.TryConvert(42, out int _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldConvertTypesCalledWithDifferentTypes()
+    {
+        var manager = new MappingTypeConversionManager();
+        manager.RegisterConverter<int, string>(i => i.ToString());
+        manager.RegisterConverter<string, int>(int.Parse);
+
+        manager.TryConvert(typeof(int), typeof(string), 42, out var str).Should().BeTrue();
+        str.Should().Be("42");
+
+        manager.TryConvert(typeof(string), typeof(int), "42", out var i).Should().BeTrue();
+        i.Should().Be(42);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/TypeConversion/TypeConversionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/TypeConversion/TypeConversionTests.cs
@@ -38,6 +38,12 @@ public class TypeConversionTests : MappingTestWithGlobalState
         public Guid Id { get; set; }
     }
 
+    private class UserWithConstructor(string name, Guid id)
+    {
+        public string Name => name;
+        public Guid Id => id;
+    }
+
     private class UserAndWebSite
     {
         public User User { get; set; }
@@ -129,5 +135,18 @@ public class TypeConversionTests : MappingTestWithGlobalState
         var mapped = record.AsObjectFromBlueprint(new { UriList = default(List<Uri>) });
 
         mapped.UriList.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldUseConverterWhenUsingConstructorMapping()
+    {
+        var guid = Guid.NewGuid();
+        var record = TestRecord.Create(("name", "John"), ("id", guid.ToString()));
+        RecordObjectMapping.RegisterTypeConverter((string s) => Guid.Parse(s));
+
+        var user = record.AsObject<UserWithConstructor>();
+
+        user.Name.Should().Be("John");
+        user.Id.Should().Be(guid);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/TypeConversion/TypeConversionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/TypeConversion/TypeConversionTests.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Neo4j.Driver.Internal.Types;
+using Neo4j.Driver.Mapping;
+using Neo4j.Driver.Tests.TestUtil;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Mapping.TypeConversion;
+
+public class TypeConversionTests : MappingTestWithGlobalState
+{
+    private class WebSite
+    {
+        public string Name { get; set; }
+        public Uri Uri { get; set; }
+    }
+
+    private class User
+    {
+        public string Name { get; set; }
+        public Guid Id { get; set; }
+    }
+
+    private class UserAndWebSite
+    {
+        public User User { get; set; }
+        public WebSite WebSite { get; set; }
+    }
+
+    [Fact]
+    public void ShouldFailToMapRecordToClassWithoutConversion()
+    {
+        var record = TestRecord.Create(("Name", "Neo4j"), ("Uri", "http://neo4j.com"));
+
+        var act = () => { _ = record.AsObject<WebSite>(); };
+
+        act.Should().Throw<MappingFailedException>();
+    }
+
+    [Fact]
+    public void ShouldMapRecordToClassWithConversion()
+    {
+        var record = TestRecord.Create(("Name", "Neo4j"), ("Uri", "http://neo4j.com"));
+        RecordObjectMapping.RegisterTypeConverter((string s) => new Uri(s));
+
+        var website = record.AsObject<WebSite>();
+
+        website.Name.Should().Be("Neo4j");
+        website.Uri.Should().Be(new Uri("http://neo4j.com"));
+    }
+
+    [Fact]
+    public void ShouldMapWhenUsingBlueprintMapping()
+    {
+        const string guidStr = "123e4567-e89b-12d3-a456-426614174000";
+        var record = TestRecord.Create(("Name", "Neo4j"), ("Id", guidStr));
+        RecordObjectMapping.RegisterTypeConverter((string s) => Guid.Parse(s));
+        var user = record.AsObjectFromBlueprint(new { Name = default(string), Id = default(Guid) });
+        user.Name.Should().Be("Neo4j");
+        user.Id.Should().Be(Guid.Parse(guidStr));
+    }
+
+    [Fact]
+    public void ShouldMapWhenUsingDelegateMapping()
+    {
+        const string guidStr = "123e4567-e89b-12d3-a456-426614174999";
+        var record = TestRecord.Create(("name", "Neo4j"), ("id", guidStr));
+        RecordObjectMapping.RegisterTypeConverter((string s) => Guid.Parse(s));
+
+        var user = record.AsObject((string name, Guid id) => new User { Name = name, Id = id });
+
+        user.Name.Should().Be("Neo4j");
+        user.Id.Should().Be(Guid.Parse(guidStr));
+    }
+
+    [Fact]
+    public void ShouldUseConverterDuringNestedMapping()
+    {
+        var websiteEntity = new Node(1, new[] {"WebSite"}, new Dictionary<string, object>
+        {
+            {"Name", "Neo4j"},
+            {"Uri", "http://neo4j.com"}
+        });
+
+        var userId = Guid.NewGuid();
+        var userEntity = new Node(2, new[] {"User"}, new Dictionary<string, object>
+        {
+            {"Name", "John"},
+            {"Id", userId.ToString()}
+        });
+
+        var testRecord = TestRecord.Create(("WebSite", websiteEntity), ("User", userEntity));
+        RecordObjectMapping.RegisterTypeConverter((string s) => Guid.Parse(s));
+        RecordObjectMapping.RegisterTypeConverter((string s) => new Uri(s));
+
+        var userAndWebSite = testRecord.AsObject<UserAndWebSite>();
+
+        userAndWebSite.User.Name.Should().Be("John");
+        userAndWebSite.User.Id.Should().Be(userId);
+        userAndWebSite.WebSite.Name.Should().Be("Neo4j");
+        userAndWebSite.WebSite.Uri.Should().Be(new Uri("http://neo4j.com"));
+    }
+
+    [Fact]
+    public void ShouldUseConverterWhenMappingLists()
+    {
+        var uriStringList = new List<string> {"http://neo4j.com", "http://google.com", "http://bing.com", "http://yahoo.com"};
+        var expected = uriStringList.Select(s => new Uri(s));
+        var record = TestRecord.Create(("UriList", uriStringList));
+        RecordObjectMapping.RegisterTypeConverter((string s) => new Uri(s));
+
+        var mapped = record.AsObjectFromBlueprint(new { UriList = default(List<Uri>) });
+
+        mapped.UriList.Should().BeEquivalentTo(expected);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/MappingExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/MappingExtensions.cs
@@ -17,7 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal;
 
 internal static class MappingExtensions
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/MappingExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/MappingExtensions.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Neo4j.Driver.Mapping;
 
 namespace Neo4j.Driver.Internal;
 
@@ -38,9 +39,16 @@ internal static class MappingExtensions
         {
             return asMethod.Invoke(null, [obj]);
         }
-        catch (TargetInvocationException tie)
+        catch (Exception ex)
         {
-            throw tie.InnerException!;
+            var inner = ex switch
+            {
+                TargetInvocationException tie => tie.InnerException,
+                _ => ex
+            };
+
+            throw new MappingFailedException(
+                $"Failed to map value to type {type.Name}.", inner);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/BuiltMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/BuiltMapper.cs
@@ -17,8 +17,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal class BuiltMapper<T> : IRecordMapper<T>
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/BuiltMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/BuiltMapper.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Neo4j.Driver.Mapping;
 
@@ -24,6 +23,7 @@ namespace Neo4j.Driver.Internal.Mapping;
 internal class BuiltMapper<T> : IRecordMapper<T>
 {
     private readonly IMappableValueProvider _mappableValueProvider = new MappableValueProvider();
+    private readonly IParameterMapper _parameterMapper = new ParameterMapper();
     private readonly List<Action<T, IRecord>> _propertyMappings = new();
 
     private Func<IRecord, T> _wholeObjectMapping;
@@ -43,14 +43,24 @@ internal class BuiltMapper<T> : IRecordMapper<T>
         {
             throw new MappingFailedException(
                 $"Cannot map record to type {typeof(T).Name} " +
-                $"because the mapping function threw an exception.",
+                $"because the mapping function threw an exception ({ex.Message}).",
                 ex);
         }
 
         // if there are individual mappings for the properties, apply them
         foreach (var mapping in _propertyMappings)
         {
-            mapping(result, record);
+            try
+            {
+                mapping(result, record);
+            }
+            catch (Exception ex)
+            {
+                throw new MappingFailedException(
+                    $"Cannot map record to type {typeof(T).Name} " +
+                    $"because the mapping function threw an exception ({ex.Message}).",
+                    ex.InnerException);
+            }
         }
 
         return result;
@@ -77,42 +87,7 @@ internal class BuiltMapper<T> : IRecordMapper<T>
 
     public void AddConstructorMapping(ConstructorInfo constructorInfo)
     {
-        // this part only happens once, at the time of building the mapper
-        var parameters = constructorInfo.GetParameters();
-        var paramMappings = parameters.Select(
-            parameter => new
-            {
-                parameter,
-                mapping = parameter.GetEntityMappingInfo()
-            });
-
-        _wholeObjectMapping = MapFromRecord;
-        return;
-
-        // this part happens every time a record is mapped
-        T MapFromRecord(IRecord record)
-        {
-            var args = new List<object>();
-            foreach (var p in paramMappings)
-            {
-                var success = _mappableValueProvider.TryGetMappableValue(
-                    record,
-                    r => _mappableValueProvider.GetConvertedValue(r, p.mapping, p.parameter.ParameterType, null),
-                    p.parameter.ParameterType,
-                    out var mappable);
-
-                if (!success)
-                {
-                    throw new MappingFailedException(
-                        $"Cannot map record to type {typeof(T).Name} because the record does not " +
-                        $"contain a value for the constructor parameter '{p.parameter.Name}'.");
-                }
-
-                args.Add(mappable);
-            }
-
-            return (T)constructorInfo.Invoke(args.ToArray());
-        }
+        _wholeObjectMapping = _parameterMapper.GetParameterMappedCall<T>(constructorInfo);
     }
 
     public void AddMappingBySetter(
@@ -153,7 +128,17 @@ internal class BuiltMapper<T> : IRecordMapper<T>
 
             if (mappableValueFound)
             {
-                propertySetter.Invoke(obj, [mappableValue]);
+                try
+                {
+                    propertySetter.Invoke(obj, [mappableValue]);
+                }
+                catch (Exception ex)
+                {
+                    throw new MappingFailedException(
+                        $"Cannot map record to type {typeof(T).Name} " +
+                        $"because the property setter '{propertySetter.Name}' threw an exception.",
+                        ex);
+                }
             }
             else if (!optional)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
@@ -16,8 +16,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal static class DefaultMapper
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DelegateMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DelegateMapper.cs
@@ -16,8 +16,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal class DelegateMapper
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DelegateMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DelegateMapper.cs
@@ -13,57 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using Neo4j.Driver.Mapping;
 
 namespace Neo4j.Driver.Internal.Mapping;
 
 internal class DelegateMapper
 {
+    private static readonly IParameterMapper ParameterMapper = new ParameterMapper();
+
     internal static T MapWithMethodInfo<T>(IRecord record, MethodInfo mapFunction, object target)
     {
-        var paramValues = new List<object>();
-        foreach (var param in mapFunction.GetParameters())
-        {
-            if (record.TryGet(param.Name, out object value))
-            {
-                object valueToUse;
-                try
-                {
-                    valueToUse = value.AsType(param.ParameterType);
-                }
-                catch (InvalidCastException) when (value is IEntity or IReadOnlyDictionary<string, object>)
-                {
-                    var objToMap = new DictAsRecord(value, null);
-                    valueToUse = RecordObjectMapping.Map(objToMap, param.ParameterType);
-                }
-                catch (Exception ex)
-                {
-                    throw new MappingFailedException(
-                        $"Failed to map parameter {param.Name}: " +
-                        $"Could not convert value of field {param.Name} to required type.",
-                        ex);
-                }
-
-                paramValues.Add(valueToUse);
-            }
-            else
-            {
-                throw new MappingFailedException($"Failed to map parameter {param.Name}: No such key in record.");
-            }
-        }
-
-        try
-        {
-            return (T)
-                mapFunction.Invoke(target, paramValues.ToArray());
-        }
-        catch (Exception ex)
-        {
-            var inner = ex is TargetInvocationException tie ? tie.InnerException : ex;
-            throw new MappingFailedException("Failed to map record.", inner);
-        }
+        var mapMethod = ParameterMapper.GetParameterMappedCall<T>(mapFunction, target);
+        return mapMethod(record);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DictAsRecord.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DictAsRecord.cs
@@ -18,7 +18,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal sealed class DictAsRecord : IRecord
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/EntityMappingInfo.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/EntityMappingInfo.cs
@@ -15,8 +15,9 @@
 
 using System.Linq;
 using System.Reflection;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal record EntityMappingInfo(
     string Path,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappableValueProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappableValueProvider.cs
@@ -16,7 +16,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using Neo4j.Driver.Internal.Mapping.TypeConversion;
 using Neo4j.Driver.Mapping;
 
 namespace Neo4j.Driver.Internal.Mapping;
@@ -41,15 +43,18 @@ internal class MappableValueProvider : IMappableValueProvider
     private readonly IMappedListCreator _mappedListCreator;
     private readonly IMappingSourceDelegateBuilder _mappingSourceDelegateBuilder;
     private readonly IRecordObjectMapping _recordObjectMapping;
+    private readonly IMappingTypeConversionManager _typeConversionManager;
 
     internal MappableValueProvider(
         IMappedListCreator mappedListCreator = null,
         IMappingSourceDelegateBuilder mappingSourceDelegateBuilder = null,
-        IRecordObjectMapping recordObjectMapping = null)
+        IRecordObjectMapping recordObjectMapping = null,
+        IMappingTypeConversionManager typeConversionManager = null)
     {
         _mappedListCreator = mappedListCreator ?? new MappedListCreator();
         _mappingSourceDelegateBuilder = mappingSourceDelegateBuilder ?? new MappingSourceDelegateBuilder();
-        _recordObjectMapping = recordObjectMapping ?? RecordObjectMapping.Instance;
+        _recordObjectMapping = recordObjectMapping;
+        _typeConversionManager = typeConversionManager;
     }
 
     public bool TryGetMappableValue(
@@ -75,7 +80,8 @@ internal class MappableValueProvider : IMappableValueProvider
             // if the value is an entity or dictionary, make it into a fake record and map that (indirectly recursive)
             case IEntity or IDictionary<string, object>:
                 var dictAsRecord = new DictAsRecord(value, record);
-                result = _recordObjectMapping.Map(dictAsRecord, desiredType);
+                var mapper = _recordObjectMapping ?? RecordObjectMapping.Instance;
+                result = mapper.Map(dictAsRecord, desiredType);
                 return true;
 
             // otherwise, just return the value
@@ -111,7 +117,29 @@ internal class MappableValueProvider : IMappableValueProvider
             ICollection list => _mappedListCreator.CreateMappedList(list, propertyType, record),
 
             // otherwise, convert the value to the type of the property
-            _ => value.AsType(propertyType)
+            _ => ConvertToType(value, propertyType)
         };
+    }
+
+    private object ConvertToType(object value, Type propertyType)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (propertyType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        var mapper = _recordObjectMapping ?? RecordObjectMapping.Instance;
+        var converter = _typeConversionManager ?? mapper.TypeConversionManager;
+        if (converter.TryConvert(value.GetType(), propertyType, value, out var convertedValue))
+        {
+            return convertedValue;
+        }
+
+        return value.AsType(propertyType);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappableValueProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappableValueProvider.cs
@@ -17,8 +17,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal interface IMappableValueProvider
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappedListCreator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappedListCreator.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Neo4j.Driver.Internal.Mapping.TypeConversion;
 using Neo4j.Driver.Mapping;
 
 namespace Neo4j.Driver.Internal.Mapping;
@@ -28,10 +29,14 @@ internal interface IMappedListCreator
 internal class MappedListCreator : IMappedListCreator
 {
     private readonly IRecordObjectMapping _recordObjectMapping;
+    private readonly IMappingTypeConversionManager _typeConversionManager;
 
-    internal MappedListCreator(IRecordObjectMapping recordObjectMapping = null)
+    internal MappedListCreator(
+        IRecordObjectMapping recordObjectMapping = null,
+        IMappingTypeConversionManager typeConversionManager = null)
     {
         _recordObjectMapping = recordObjectMapping ?? RecordObjectMapping.Instance;
+        _typeConversionManager = typeConversionManager ?? _recordObjectMapping.TypeConversionManager;
     }
 
     public IList CreateMappedList(IEnumerable list, Type desiredListType, IRecord record)
@@ -51,7 +56,14 @@ internal class MappedListCreator : IMappedListCreator
             else
             {
                 // otherwise, just convert the item to the type of the list
-                newList!.Add(item.AsType(desiredItemType));
+                if (_typeConversionManager.TryConvert(item.GetType(), desiredItemType, item, out var convertedValue))
+                {
+                    newList!.Add(convertedValue);
+                }
+                else
+                {
+                    newList!.Add(item.AsType(desiredItemType));
+                }
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappedListCreator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappedListCreator.cs
@@ -16,8 +16,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal interface IMappedListCreator
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappingBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappingBuilder.cs
@@ -16,8 +16,9 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Neo4j.Driver.Mapping;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 /// <summary>This class wraps the <see cref="BuiltMapper{T}"/> and exposes a fluent API for building the mapper.</summary>
 internal class MappingBuilder<T> : IMappingBuilder<T>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappingSourceDelegateBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappingSourceDelegateBuilder.cs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Neo4j.Driver.Mapping;
+using Neo4j.Driver.Mapping;
+
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal delegate bool MappingValueDelegate(IRecord record, out object value);
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/ParameterMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/ParameterMapper.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Neo4j.Driver.Mapping;
+
+namespace Neo4j.Driver.Internal.Mapping;
+
+internal interface IParameterMapper
+{
+    Func<IRecord, T> GetParameterMappedCall<T>(MethodBase methodBase, object target = null);
+}
+
+internal class ParameterMapper : IParameterMapper
+{
+    private readonly IMappableValueProvider _mappableValueProvider = new MappableValueProvider();
+
+    public Func<IRecord, T> GetParameterMappedCall<T>(MethodBase method, object target = null)
+    {
+        // this part only happens once, at the time of building the mapper
+        var parameters = method.GetParameters();
+        var paramMappings = parameters.Select(
+            parameter => new
+            {
+                parameter,
+                mapping = parameter.GetEntityMappingInfo()
+            });
+
+        return MapFromRecord;
+
+        // this part happens every time a record is mapped
+        T MapFromRecord(IRecord record)
+        {
+            var args = new List<object>();
+            foreach (var p in paramMappings)
+            {
+                var success = _mappableValueProvider.TryGetMappableValue(
+                    record,
+                    r => _mappableValueProvider.GetConvertedValue(r, p.mapping, p.parameter.ParameterType, null),
+                    p.parameter.ParameterType,
+                    out var mappable);
+
+                if (!success)
+                {
+                    throw new MappingFailedException(
+                        $"Cannot map record to type {typeof(T).Name} because the record does not " +
+                        $"contain a value for the parameter '{p.parameter.Name}'.");
+                }
+
+                args.Add(mappable);
+            }
+
+            try
+            {
+                return method switch
+                {
+                    ConstructorInfo constructorInfo => (T)constructorInfo.Invoke(args.ToArray()),
+                    MethodInfo methodInfo => (T)methodInfo.Invoke(target, args.ToArray()),
+                    _ => throw new NotSupportedException($"Unsupported method type: {method.GetType()}")
+                };
+            }
+            catch (TargetInvocationException tie)
+            {
+                throw new MappingFailedException(
+                    $"Cannot map record to type {typeof(T).Name} because the method '{method.Name}' threw an exception.",
+                    tie.InnerException);
+            }
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/RecordPathFinder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/RecordPathFinder.cs
@@ -15,7 +15,7 @@
 
 using System.Collections.Generic;
 
-namespace Neo4j.Driver.Mapping;
+namespace Neo4j.Driver.Internal.Mapping;
 
 internal interface IRecordPathFinder
 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/TypeConversion/IMappingTypeConversionManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/TypeConversion/IMappingTypeConversionManager.cs
@@ -1,30 +1,21 @@
 ﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Neo4j.Driver.Internal.Mapping;
+namespace Neo4j.Driver.Internal.Mapping.TypeConversion;
 
-namespace Neo4j.Driver.Mapping;
-
-/// <summary>Contains extensions for entities such as nodes and relationships.</summary>
-public static class EntityExtensions
+internal interface IMappingTypeConversionManager
 {
-    /// <summary>Converts the entity to a record.</summary>
-    /// <param name="entity">The entity to convert.</param>
-    /// <returns>The record.</returns>
-    public static IRecord AsRecord(this IEntity entity)
-    {
-        return new DictAsRecord(entity, null);
-    }
+    TResult Convert<TSource, TResult>(TSource value);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/TypeConversion/MappingTypeConversionManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/TypeConversion/MappingTypeConversionManager.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Neo4j.Driver.Internal.Mapping.TypeConversion;
+
+internal class MappingTypeConversionManager : IMappingTypeConversionManager
+{
+    private readonly ConcurrentDictionary<(Type From, Type To), Func<object, object>> _converters = new();
+
+    public void Clear() => _converters.Clear();
+
+    public bool TryConvert(Type fromType, Type toType, object from, out object to)
+    {
+        if (_converters.TryGetValue((fromType, toType), out var converter))
+        {
+            to = converter(from);
+            return true;
+        }
+
+        to = default!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryConvert<TFrom, TTo>(TFrom from, out TTo to)
+    {
+        var success = TryConvert(typeof(TFrom), typeof(TTo), from, out var result);
+        if (success)
+        {
+            to = (TTo)result;
+            return true;
+        }
+
+        to = default!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public void RegisterConverter<TFrom, TTo>(Func<TFrom, TTo> converter)
+    {
+        Trace.WriteLine("Registering converter in " + GetHashCode());
+        Func<object, object> func = o => converter((TFrom)o);
+        _converters.AddOrUpdate((typeof(TFrom), typeof(TTo)), func, (_, _) => func);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/RouteResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/RouteResponseHandler.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using Neo4j.Driver.Internal.HomeDbCaching;
 using Neo4j.Driver.Internal.MessageHandling.Metadata;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolHandlerFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolHandlerFactory.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.HomeDbCaching;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/IBoltProtocol.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/IBoltProtocol.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IDiscovery.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/IDiscovery.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.HomeDbCaching;

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -51,7 +51,4 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Internal\Mapping\" />
-    </ItemGroup>
 </Project>

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -51,4 +51,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     </ItemGroup>
+    <ItemGroup>
+      <Folder Include="Internal\Mapping\" />
+    </ItemGroup>
 </Project>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DelegateAsyncEnumerableExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DelegateAsyncEnumerableExtensions.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DelegateMappingRecordExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/DelegateMappingRecordExtensions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingSourceAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/MappingSourceAttribute.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Neo4j.Driver.Internal.Mapping;
+using Neo4j.Driver.Internal.Mapping.TypeConversion;
 
 namespace Neo4j.Driver.Mapping;
 
@@ -33,24 +34,29 @@ public interface IMappingRegistry
     IMappingRegistry RegisterMapping<T>(Action<IMappingBuilder<T>> mappingBuilder);
 }
 
-internal interface IRecordObjectMapping
+internal interface IRecordObjectMapping : IMappingRegistry
 {
     object Map(IRecord record, Type type);
     TResult MapFromBlueprint<TResult>(IRecord record, TResult blueprint);
+    IMappingTypeConversionManager TypeConversionManager { get; }
+    void RegisterTypeConverter<TFrom, TTo>(Func<TFrom, TTo> converter);
+    MethodInfo GetMapMethodForType(Type type);
 }
 
+internal delegate object MapDelegate(IRecord record);
+
 /// <summary>Controls global record mapping configuration.</summary>
-public class RecordObjectMapping : IMappingRegistry, IRecordObjectMapping
+public class RecordObjectMapping : IRecordObjectMapping
 {
     private readonly Dictionary<Type, MethodInfo> _mapMethods = new();
-
     private readonly Dictionary<Type, object> _mappers = new();
+    private readonly IMappingTypeConversionManager _typeConversionManager = new MappingTypeConversionManager();
 
     private RecordObjectMapping()
     {
     }
 
-    internal static RecordObjectMapping Instance { get; private set; } = new();
+    internal static readonly RecordObjectMapping Instance = new();
 
     IMappingRegistry IMappingRegistry.RegisterMapping<T>(Action<IMappingBuilder<T>> mappingBuilder)
     {
@@ -65,10 +71,11 @@ public class RecordObjectMapping : IMappingRegistry, IRecordObjectMapping
     {
         var mapMethod = Instance.GetMapMethodForType(type);
         var mapperForType = GetMapperForType(type);
+        var mapDelegate = (MapDelegate)mapMethod.CreateDelegate(typeof(MapDelegate), mapperForType);
 
         try
         {
-            return mapMethod.Invoke(mapperForType, [record]);
+            return mapDelegate(record);
         }
         catch (Exception ex)
         {
@@ -82,10 +89,24 @@ public class RecordObjectMapping : IMappingRegistry, IRecordObjectMapping
         return (T)Map(record, typeof(T));
     }
 
+    IMappingTypeConversionManager IRecordObjectMapping.TypeConversionManager => _typeConversionManager;
+
+    void IRecordObjectMapping.RegisterTypeConverter<TFrom, TTo>(Func<TFrom, TTo> converter)
+    {
+        _typeConversionManager.RegisterConverter(converter);
+    }
+
+    public static void RegisterTypeConverter<TFrom, TTo>(Func<TFrom, TTo> converter)
+    {
+        ((IRecordObjectMapping)Instance).RegisterTypeConverter(converter);
+    }
+
     internal static void Reset()
     {
-        // discard the current instance and create a new one, which will have no mappers registered
-        Instance = new RecordObjectMapping();
+        // clear all registered mappers and type converters
+        Instance._mappers.Clear();
+        Instance._mapMethods.Clear();
+        Instance._typeConversionManager.Clear();
         DefaultMapper.Reset();
     }
 
@@ -140,7 +161,7 @@ public class RecordObjectMapping : IMappingRegistry, IRecordObjectMapping
         provider.CreateMappers(Instance);
     }
 
-    private MethodInfo GetMapMethodForType(Type type)
+    public MethodInfo GetMapMethodForType(Type type)
     {
         if (_mapMethods.TryGetValue(type, out var method))
         {

--- a/Neo4j.Driver/Neo4j.Driver/Public/SessionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/SessionConfig.cs
@@ -16,9 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Neo4j.Driver.Internal;
-using Neo4j.Driver.Internal.Auth;
 using Neo4j.Driver.Internal.Types;
 
 namespace Neo4j.Driver;


### PR DESCRIPTION
This PR adds custom type conversion to the object mapping function of the driver.

Let's say you have two classes, `Customer` and `Order`, like so:

```c#
class User
{
    string Name { get; set; }
    Guid Id { get; set; }
}

class Order
{
    string Description { get; set; }
    Guid Id { get; set; }
}
```

And let's say that the `Id` values are stored in the database as string representations of GUIDs.

Previously, in order to map the string representations in the database to the Guid properties in the C# type, you would need to define a custom mapper for both the `User` and `Order` types. And indeed, any other types that had a Guid property that was going to need to be mapped from a string.

With this PR, you can provide a conversion to the mapping config so that if it ever needs a Guid and it has a string, it will call your provided conversion. At the time of setting up the driver, add the following code:

```c#
RecordObjectMapping.RegisterTypeConverter<string, Guid>(s => Guid.Parse(s));
```

Now, whenever it needs a Guid and it has a string, the mapper will know what to do. This will work with property mapping, constructor mapping, delegate mapping, blueprint mapping, and all other kinds of mapping functionality.

The example here is simple, but more complex scenarios could be handled with ease. For example, if the database has values stored as JSON, this feature could be used to map those values directly to typed objects.