### PR TITLE
Add failing test for concurrency issue with default mapper and fix bug

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingConcurrencyTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingConcurrencyTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Neo4j.Driver.Internal.Mapping;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Neo4j.Driver.Tests.Mapping;
+
+public class MappingConcurrencyTests(ITestOutputHelper testOutputHelper)
+{
+    private interface ITestTask
+    {
+        Task Start();
+    }
+
+    private class TestTask<T> : ITestTask
+    {
+        public Task Start()
+        {
+            return Task.Run(
+                () =>
+                {
+                    for (var i = 0; i < 50; i++)
+                    {
+                        DefaultMapper.Get<T>();
+                        DefaultMapper.Reset();
+                    }
+                });
+        }
+    }
+
+    private record DummyType1(string Name, int Age);
+    private record DummyType2(string Name, int Age);
+    private record DummyType3(string Name, int Age);
+    private record DummyType4(string Name, int Age);
+
+    [Fact]
+    public async void DefaultMapperShouldBeThreadSafe()
+    {
+        List<ITestTask> threads =
+        [
+            new TestTask<DummyType1>(),
+            new TestTask<DummyType2>(),
+            new TestTask<DummyType3>(),
+            new TestTask<DummyType4>()
+        ];
+
+        // wait for all threads to finish
+        await Task.WhenAll(threads.Select(t => t.Start()));
+
+        testOutputHelper.WriteLine("All threads finished.");
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using Neo4j.Driver.Mapping;
@@ -22,7 +23,7 @@ namespace Neo4j.Driver.Internal.Mapping;
 
 internal static class DefaultMapper
 {
-    private static readonly Dictionary<Type, object> Mappers = new();
+    private static readonly ConcurrentDictionary<Type, object> Mappers = new();
 
     public static void Reset()
     {
@@ -75,7 +76,7 @@ internal static class DefaultMapper
         mapper = mappingBuilder.Build();
 
         // cache the mapper for future use
-        Mappers[type] = mapper;
+        Mappers.TryAdd(type, mapper);
         return (IRecordMapper<T>)mapper;
     }
 


### PR DESCRIPTION
"Failing" test now passes, obviously.