### PR TITLE
Improved IsRetriable method reference description

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/ConventionTranslation/NoOpConventionTranslator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/ConventionTranslation/NoOpConventionTranslator.cs
@@ -17,7 +17,7 @@ using Neo4j.Driver.Mapping.ConventionTranslation;
 
 namespace Neo4j.Driver.Internal.Mapping.ConventionTranslation;
 
-public class NoOpConventionTranslator : IConventionTranslator
+internal class NoOpConventionTranslator : IConventionTranslator
 {
     /// <inheritdoc />
     public string Translate(string input)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -59,6 +59,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
     /// <summary>TEST ONLY.</summary>
     /// <param name="clusterConnPool"></param>
     /// <param name="routingTableManager"></param>
+    /// <param name="driverContext"></param>
     internal LoadBalancer(
         IClusterConnectionPool clusterConnPool,
         IRoutingTableManager routingTableManager,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/VarLong.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/VarLong.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace Neo4j.Driver.Internal.Util;
 
-public class VarLong
+internal class VarLong
 {
     public long Value { get; private set; }
     private byte _position = 0;

--- a/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
@@ -86,7 +86,15 @@ public class Neo4jException : Exception, IGqlErrorPreview
         Code = code;
     }
 
-    /// <summary>Gets whether the exception retriable or not.</summary>
+    /// <summary>
+    /// Gets whether the exception is retryable or not.  
+    /// Important Note: Methods that use Autocommit transactions  
+    /// <see cref="Neo4j.Driver.IAsyncSession.RunAsync(string, System.Action{Neo4j.Driver.TransactionConfigBuilder})"/>,  
+    /// <see cref="Neo4j.Driver.IAsyncSession.RunAsync(string, System.Collections.Generic.IDictionary{string, object}, System.Action{Neo4j.Driver.TransactionConfigBuilder})"/>,  
+    /// and  
+    /// <see cref="Neo4j.Driver.IAsyncSession.RunAsync(Neo4j.Driver.Query, System.Action{Neo4j.Driver.TransactionConfigBuilder})"/>  
+    /// are not retryable regardless of this value.
+    /// </summary>
     public virtual bool IsRetriable => false;
 
     /// <summary>Gets or sets the code of a Neo4j exception.</summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
@@ -185,10 +185,10 @@ public interface IAsyncSession : IAsyncQueryRunner
     Task CloseAsync();
 
     /// <summary>
-    /// Asynchronously run a query with the specific <see cref="TransactionConfig"/> and return a task of result
-    /// stream. This method accepts a String representing a Cypher query which will be compiled into a query object that can be
-    /// used to efficiently execute this query multiple times. This method optionally accepts a set of parameters which will be
-    /// injected into the query object query by Neo4j.
+    /// Asynchronously run a query within an AutoCommit transaction. Uses the specific <see cref="TransactionConfig"/>
+    /// and returns a task of result stream. This method accepts a String representing a Cypher query which will be
+    /// compiled into a query object that can be used to efficiently execute this query multiple times. This method
+    /// optionally accepts a set of parameters which will be injected into the query object query by Neo4j.
     /// </summary>
     /// <param name="query">A Cypher query.</param>
     /// <param name="action">
@@ -199,10 +199,10 @@ public interface IAsyncSession : IAsyncQueryRunner
     Task<IResultCursor> RunAsync(string query, Action<TransactionConfigBuilder> action = null);
 
     /// <summary>
-    /// Asynchronously run a query with the customized <see cref="TransactionConfig"/> and return a task of result
-    /// stream. This method accepts a String representing a Cypher query which will be compiled into a query object that can be
-    /// used to efficiently execute this query multiple times. This method optionally accepts a set of parameters which will be
-    /// injected into the query object query by Neo4j.
+    /// Asynchronously run a query within an AutoCommit transaction. Uses the specific <see cref="TransactionConfig"/>
+    /// and returns a task of result stream. This method accepts a String representing a Cypher query which will be
+    /// compiled into a query object that can be used to efficiently execute this query multiple times. This method
+    /// optionally accepts a set of parameters which will be injected into the query object query by Neo4j.
     /// </summary>
     /// <param name="query">A Cypher query.</param>
     /// <param name="parameters">Input parameters for the query.</param>
@@ -217,8 +217,8 @@ public interface IAsyncSession : IAsyncQueryRunner
         Action<TransactionConfigBuilder> action = null);
 
     /// <summary>
-    /// Asynchronously execute a query with the specific <see cref="TransactionConfig"/> and return a task of result
-    /// stream.
+    /// Asynchronously run a query within an AutoCommit transaction. Uses the specific <see cref="TransactionConfig"/>
+    /// and return a task of result stream.
     /// </summary>
     /// <param name="query">A Cypher query, <see cref="Query"/>.</param>
     /// <param name="action">

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ConventionTranslation/StandardCaseParser.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ConventionTranslation/StandardCaseParser.cs
@@ -31,7 +31,7 @@ public class StandardCaseParser : IIdentifierParser<IReadOnlyList<string>>
     /// Initializes a new instance of the <see cref="StandardCaseParser"/> class.
     /// </summary>
     /// <param name="convention">The naming convention to use.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when an unsupported convention is provided.</exception>
+    /// <exception cref="System.ArgumentOutOfRangeException">Thrown when an unsupported convention is provided.</exception>
     public StandardCaseParser(IdentifierCaseConvention convention)
     {
         (_validationRegex, _splitRegex) = convention switch

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -128,7 +128,7 @@ public class RecordObjectMapping : IRecordObjectMapping
         _conventionTranslator = conventionTranslator;
     }
 
-    public static void TranslateIdentifiers(IConventionTranslator conventionTranslator)
+    private static void TranslateIdentifiers(IConventionTranslator conventionTranslator)
     {
         ((IRecordObjectMapping)Instance).TranslateIdentifiers(conventionTranslator);
     }

--- a/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
@@ -33,7 +33,8 @@ public sealed class TransactionConfig
     /// Constructor with two optional parameters
     /// </summary>
     /// <param name="metadata"></param>
-    /// <param name="timeout"></param>
+    /// <param name="metadata">The transaction metadata to attach to the transaction. If null, an empty dictionary is used.</param>
+    /// <param name="timeout">The transaction timeout. Transactions running longer than this duration will be terminated by the database. If null, the server's default timeout is used. A value of zero means the transaction will execute indefinitely.</param>
     public TransactionConfig(IDictionary<string, object> metadata = null, TimeSpan? timeout = null)
     {
         Metadata = metadata ?? new Dictionary<string, object>();

--- a/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
@@ -29,7 +29,11 @@ public sealed class TransactionConfig
     private IDictionary<string, object> _metadata = new Dictionary<string, object>();
     private TimeSpan? _timeout;
 
-    // constructor with two optional parameters
+    /// <summary>
+    /// Constructor with two optional parameters
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <param name="timeout"></param>
     public TransactionConfig(IDictionary<string, object> metadata = null, TimeSpan? timeout = null)
     {
         Metadata = metadata ?? new Dictionary<string, object>();

--- a/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
@@ -32,7 +32,7 @@ public sealed class TransactionConfig
     /// <summary>
     /// Constructor with two optional parameters
     /// </summary>
-    /// <param name="metadata"></param>
+    /// <param name="metadata">A dictionary of key-value pairs to attach as metadata to the transaction.</param>
     /// <param name="timeout"></param>
     public TransactionConfig(IDictionary<string, object> metadata = null, TimeSpan? timeout = null)
     {


### PR DESCRIPTION
Improved IsRetriable method reference description to highlight that the flag does not apply safely to Session.Run because of things like periodic commit and call in tx.

Tidied up some compiler warning from incomplete or erroneous XML comments.