### PR TITLE
Added missing methods to two public interfaces that should have been there

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -160,6 +160,16 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
         return BeginTransactionAsync(_defaultMode, action, disposeUnconsumedSessionResult);
     }
 
+    public Task<IAsyncTransaction> BeginTransactionAsync(AccessMode mode)
+    {
+        return BeginTransactionAsync(mode, null);
+    }
+
+    public Task<IAsyncTransaction> BeginTransactionAsync(AccessMode mode, Action<TransactionConfigBuilder> action)
+    {
+        return BeginTransactionAsync(mode, action, true);
+    }
+
     public async Task<IAsyncTransaction> BeginTransactionAsync(
         AccessMode mode,
         Action<TransactionConfigBuilder> action,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -50,6 +50,11 @@ internal sealed class Driver : IInternalDriver
     public bool Encrypted => Context.EncryptionManager.UseTls;
     public Config Config => Context.Config;
 
+    public IBookmarkManager GetExecutableQueryBookmarkManager()
+    {
+        return _bookmarkManager;
+    }
+
     public IAsyncSession AsyncSession()
     {
         return AsyncSession(null);

--- a/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
@@ -70,6 +70,42 @@ public interface IAsyncSession : IAsyncQueryRunner
     Task<IAsyncTransaction> BeginTransactionAsync(Action<TransactionConfigBuilder> action);
 
     /// <summary>
+    /// Asynchronously begin a new transaction specifying an access mode <see cref="Neo4j.Driver.AccessMode"/>
+    /// A session can have at most one transaction running at a time, if you want to run multiple concurrent transactions,
+    /// you should use multiple concurrent sessions. All data operations in Neo4j are transactional. However, for
+    /// convenience we provide a <see cref="IAsyncQueryRunner.RunAsync(Query)"/> method directly on this session
+    /// interface as well. When you use that method, your query automatically gets wrapped in a transaction. If you want
+    /// to run multiple queries in the same transaction, you should wrap them in a transaction using this method.
+    /// </summary>
+    /// <param name="mode">
+    /// Given a <see cref="Neo4j.Driver.AccessMode"/> specifying whether the query should be run on a read or write
+    /// server. 
+    /// </param>
+    /// <returns>A task of a new transaction.</returns>
+    Task<IAsyncTransaction> BeginTransactionAsync(AccessMode mode);
+
+    /// <summary>
+    /// Asynchronously begin a new transaction specifying an access mode <see cref="Neo4j.Driver.AccessMode"/> and with
+    /// a specific <see cref="TransactionConfig"/> in this session. A session can have at most one transaction running
+    /// at a time, if you want to run multiple concurrent transactions, you should use multiple concurrent sessions. All
+    /// data operations in Neo4j are transactional. However, for convenience we provide a
+    /// <see cref="IAsyncQueryRunner.RunAsync(Query)"/> method directly on this session interface as well. When you use
+    /// that method, your query automatically gets wrapped in a transaction. If you want to run multiple queries in the
+    /// same transaction, you should wrap them in a transaction using this method.
+    /// </summary>
+    /// <param name="mode">
+    /// Given a <see cref="Neo4j.Driver.AccessMode"/> specifying whether the query should be run on a read or write
+    /// server. 
+    /// </param>
+    /// <param name="action">
+    /// Given a <see cref="TransactionConfigBuilder"/>, defines how to set the configurations for the new
+    /// transaction. This configuration overrides server side default transaction configurations. See
+    /// <see cref="TransactionConfig"/>
+    /// </param>
+    /// <returns>A task of a new transaction.</returns>
+    Task<IAsyncTransaction> BeginTransactionAsync(AccessMode mode, Action<TransactionConfigBuilder> action);
+
+    /// <summary>
     /// Asynchronously execute given unit of work in a <see cref="AccessMode.Read"/> transaction with a specific
     /// <see cref="TransactionConfig"/>.
     /// </summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IDriver.cs
@@ -123,4 +123,13 @@ public interface IDriver : IDisposable, IAsyncDisposable
     /// <param name="authToken">Auth token to verify.</param>
     /// <returns> A task that represents the asynchronous operation. </returns>
     Task<bool> VerifyAuthenticationAsync(IAuthToken authToken);
+
+    /// <summary>
+    /// Returns an IBookmarkManager interface to the bookmark manager that the driver is using to ensure causal consistency
+    /// between calls to the ExecutableQuery interface. This can be used to have causal consistency
+    /// when using the API interfaces supplied by Session objects alongside calls to ExecutableQuery.
+    /// </summary>
+    /// <returns> An <see cref='Neo4j.Driver.IBookmarkManager'/> that can be used for causal consistency</returns>
+    IBookmarkManager GetExecutableQueryBookmarkManager();
 }
+


### PR DESCRIPTION
1. BeginTransaction - It was not possible to do this whilst specifying an AccessMode to override the sessions configured default. Two signatures added in the IAsyncSession interface and implementations in the concrete AsyncSession to enable this.

2. GetExecutableQueryBookmarkManager - added to IDriver interface and an implementation in the Driver class. This allows access to the bookmark manager used in ExecutableQueries so it can be passed to sessions and allow causal consistency between the two ways of running queries.