### PR TITLE
Improved IsRetriable method reference description (#861)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
@@ -32,8 +32,10 @@ public sealed class TransactionConfig
     /// <summary>
     /// Constructor with two optional parameters
     /// </summary>
-    /// <param name="metadata"></param>
-    /// <param name="timeout"></param>
+    /// <param name="metadata">A dictionary of key-value pairs to attach as metadata to the transaction.</param>
+    /// <param name="timeout">The transaction timeout. Transactions running longer than this duration will be terminated
+    /// by the database. If null, the server's default timeout is used. A value of zero means the transaction will
+    /// execute indefinitely.</param>
     public TransactionConfig(IDictionary<string, object> metadata = null, TimeSpan? timeout = null)
     {
         Metadata = metadata ?? new Dictionary<string, object>();


### PR DESCRIPTION
(Cherry-picking an improvement that was made on the 5.0 brancvh after 6.x was created)

* Improved IsRetriable method reference description to highlight that the flag does not apply safely to Session.Run because of things like periodic commit and call in tx.

Tidied up some compiler warning from incomplete or erroneous XML comments.