### PR TITLE
Fix for incorrect reporting of a type mismatch when object mapping fails and a Vector type is involved.

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ValueExtensionsTests.cs
@@ -236,6 +236,30 @@ public class ValueExtensionsTests
             var ex = Record.Exception(() => value.As<int>());
             ex.Should().BeOfType<InvalidCastException>();
         }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenCastFromVectorToNonVector()
+        {
+            object value = new Vector<float>(new[] { 1.0f, 2.0f, 3.0f, 4.0f });
+            var ex = Record.Exception(() => value.As<int>());
+            ex.Should().BeOfType<InvalidCastException>();
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenCastFromNonVectorToVector()
+        {
+            object value = (int)10;
+            var ex = Record.Exception(() => value.As<Vector<int>>());
+            ex.Should().BeOfType<InvalidCastException>();
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenCastingBetweenMismatchedVectors()
+        {
+            object value = new Vector<float>(new[] { 1.0f, 2.0f, 3.0f, 4.0f });
+            var ex = Record.Exception(() => value.As<Vector<double>>());
+            ex.Should().BeOfType<InvalidCastException>();
+        }
     }
 
     public class AsCollectionTypeMethod

--- a/Neo4j.Driver/Neo4j.Driver/Public/Extensions/ValueExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Extensions/ValueExtensions.cs
@@ -149,6 +149,11 @@ public static class ValueExtensions
         {
             return Convert.ChangeType(value, targetType).AsItIs<T>();
         }
+        
+        if (value is IVector)
+        {
+            return value.AsItIs<T>();
+        }                 
 
         // force to cast to a dict or list
         var typeInfo = targetType.GetTypeInfo();

--- a/Neo4j.Driver/Neo4j.Driver/Public/Extensions/ValueExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Extensions/ValueExtensions.cs
@@ -150,10 +150,12 @@ public static class ValueExtensions
             return Convert.ChangeType(value, targetType).AsItIs<T>();
         }
         
+        //If the source type (value) is a vector then it can not be cast to anything else. We also want to 
+        //make sure that it is not attempting to cast into a vector of another type. 
         if (value is IVector)
         {
-            return value.AsItIs<T>();
-        }                 
+            return AsVector<T>(value);
+        }                
 
         // force to cast to a dict or list
         var typeInfo = targetType.GetTypeInfo();
@@ -200,6 +202,17 @@ public static class ValueExtensions
         }
 
         return list.AsItIs<T>();
+    }
+
+    private static T AsVector<T>(this object value)
+    {   
+        if (value is T result)
+        {
+            return result;
+        }
+        
+        throw new InvalidCastException($"Cannot cast differing vector types. Attempting from `" +
+            $" { typeof(T) }` to `{value.GetType()}");
     }
 
 #region Helper Methods


### PR DESCRIPTION
Before the fix the error reported when trying to map from, for example, a Vector<float> to a Vector<double> was: 

`System.InvalidOperationException: The expected value 'Neo4j.Driver.Vector'1[System.Single]' is different from the actual value 'System.Collections.Generic.List'1[System.Single]' `

This was occurring because the ValueExtensions As method did not contain a clause for IVector, this caused the logic to fall through to the IEnumerable clause (which a vector implements) which converted the vector into a list, and then failed the type conversion on that list.

Now that a clause for IVector is added you get the correct error. e.g. For the Vector<float> -> Vector<double> example: 

`System.InvalidCastException: Cannot cast differing vector types. Attempting from Neo4j.Driver.Vector'1[System.Double]' to 'Neo4j.Driver.Vector'1[System.Single]`