### PR TITLE
Renamed ILogger to INeo4jLogger in preparation for integration with standard logging framework

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Reactive/DriverExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/DriverExtensions.cs
@@ -48,6 +48,6 @@ public static class DriverExtensions
 
         return new InternalRxSession(
             reactiveDriver.Session(action, true),
-            new RxRetryLogic(reactiveDriver.Config.MaxTransactionRetryTime, reactiveDriver.Config.Logger));
+            new RxRetryLogic(reactiveDriver.Config.MaxTransactionRetryTime, reactiveDriver.Config.Neo4JLogger));
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxRetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Internal/RxRetryLogic.cs
@@ -30,18 +30,18 @@ internal class RxRetryLogic : IRxRetryLogic
     private readonly double _delayJitter;
     private readonly double _delayMultiplier;
     private readonly double _initialDelay;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly int _maxRetryTimeout;
     private readonly Random _random;
 
-    public RxRetryLogic(TimeSpan maxRetryTimeout, ILogger logger)
+    public RxRetryLogic(TimeSpan maxRetryTimeout, INeo4jLogger neo4JLogger)
     {
         _maxRetryTimeout = (int)maxRetryTimeout.TotalMilliseconds;
         _initialDelay = TimeSpan.FromSeconds(1).TotalMilliseconds;
         _delayMultiplier = 2.0;
         _delayJitter = 0.2;
         _random = new Random(Guid.NewGuid().GetHashCode());
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
     }
 
     public IObservable<T> Retry<T>(IObservable<T> work)
@@ -76,7 +76,7 @@ internal class RxRetryLogic : IRxRetryLogic
                         var delayDuration = TimeSpan.FromMilliseconds(ComputeNextDelay(delay));
                         delay *= _delayMultiplier;
                         retryCount++;
-                        _logger?.Warn(exc, $"Transaction failed and will be retried in {delay} ms.");
+                        _neo4JLogger?.Warn(exc, $"Transaction failed and will be retried in {delay} ms.");
                         return Observable.Return(1).Delay(delayDuration);
                     });
             });

--- a/Neo4j.Driver/Neo4j.Driver.Simple/DriverExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/DriverExtensions.cs
@@ -48,7 +48,7 @@ public static class DriverExtensions
 
         return new InternalSession(
             driver.AsyncSession(action).CastOrThrow<IInternalAsyncSession>(),
-            new RetryLogic(asyncDriver.Config.MaxTransactionRetryTime, asyncDriver.Config.Logger),
+            new RetryLogic(asyncDriver.Config.MaxTransactionRetryTime, asyncDriver.Config.Neo4JLogger),
             new BlockingExecutor());
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Simple/Internal/RetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Simple/Internal/RetryLogic.cs
@@ -30,18 +30,18 @@ internal class RetryLogic : IRetryLogic
     private readonly double _delayJitter;
     private readonly double _delayMultiplier;
     private readonly double _initialDelay;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly int _maxRetryTimeout;
     private readonly Random _random;
 
-    public RetryLogic(TimeSpan maxRetryTimeout, ILogger logger)
+    public RetryLogic(TimeSpan maxRetryTimeout, INeo4jLogger neo4JLogger)
     {
         _maxRetryTimeout = (int)maxRetryTimeout.TotalMilliseconds;
         _initialDelay = TimeSpan.FromSeconds(1).TotalMilliseconds;
         _delayMultiplier = 2.0;
         _delayJitter = 0.2;
         _random = new Random(Guid.NewGuid().GetHashCode());
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
     }
 
     public T Retry<T>(Func<T> work)
@@ -69,7 +69,7 @@ internal class RetryLogic : IRetryLogic
                 if (shouldRetry)
                 {
                     var delay = TimeSpan.FromMilliseconds(ComputeNextDelay(delayMs));
-                    _logger?.Warn(e, $"Transaction failed and will be retried in {delay}ms.");
+                    _neo4JLogger?.Warn(e, $"Transaction failed and will be retried in {delay}ms.");
                     Thread.Sleep(delay);
                     delayMs *= _delayMultiplier;
                 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/ExamplesAsync.cs
@@ -620,7 +620,7 @@ public class ExamplesAsync
                 _driver = GraphDatabase.Driver(
                     uri,
                     AuthTokens.Basic(user, password),
-                    configBuilder => configBuilder.WithLogger(new SimpleLogger()));
+                    configBuilder => configBuilder.WithLogger(new SimpleNeo4JLogger()));
             }
 
             public void Dispose()
@@ -732,7 +732,7 @@ public class ExamplesAsync
             }
         }
 
-        internal class SimpleLogger : ILogger
+        internal class SimpleNeo4JLogger : INeo4jLogger
         {
             public void Debug(string message, params object[] args)
             {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/DefaultInstallation.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/DefaultInstallation.cs
@@ -58,8 +58,8 @@ public static class DefaultInstallation
     {
         var configuredLevelStr = Environment.GetEnvironmentVariable("NEOLOGLEVEL");
         var logger = Enum.TryParse<ExtendedLogLevel>(configuredLevelStr ?? "", true, out var configuredLevel)
-            ? new TestLogger(Console.WriteLine, configuredLevel)
-            : new TestLogger(s => Debug.WriteLine(s), ExtendedLogLevel.Debug);
+            ? new TestNeo4JLogger(Console.WriteLine, configuredLevel)
+            : new TestNeo4JLogger(s => Debug.WriteLine(s), ExtendedLogLevel.Debug);
 
         return GraphDatabase.Driver(boltUri, authToken, o => { o.WithLogger(logger); });
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/BoltV4IT.cs
@@ -35,7 +35,7 @@ public sealed class BoltV4IT : RoutingDriverTestBase
         _driver = GraphDatabase.Driver(
             Cluster.BoltRoutingUri,
             Cluster.AuthToken,
-            o => o.WithLogger(TestLogger.Create(output)));
+            o => o.WithLogger(TestNeo4JLogger.Create(output)));
     }
 
     [RequireClusterFact("4.0.0", GreaterThanOrEqualTo)]

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverTestBase.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Routing/RoutingDriverTestBase.cs
@@ -34,7 +34,7 @@ public abstract class RoutingDriverTestBase : IDisposable
             AuthToken,
             builder =>
             {
-                builder.WithLogger(TestLogger.Create(output));
+                builder.WithLogger(TestNeo4JLogger.Create(output));
                 Cluster.Configure(builder);
             });
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/StressTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stress/StressTest.cs
@@ -84,7 +84,7 @@ public abstract class StressTest : IDisposable
             builder =>
             {
                 builder
-                    .WithLogger(new StressTestLogger(_output, minLevel))
+                    .WithLogger(new StressTestNeo4JLogger(_output, minLevel))
                     .WithMaxConnectionPoolSize(100)
                     .WithConnectionAcquisitionTimeout(TimeSpan.FromMinutes(1));
 
@@ -109,12 +109,12 @@ public abstract class StressTest : IDisposable
         None
     }
 
-    private class StressTestLogger : ILogger
+    private class StressTestNeo4JLogger : INeo4jLogger
     {
         private readonly StressTestMinLogLevel _minLevel;
         private readonly ITestOutputHelper _output;
 
-        public StressTestLogger(ITestOutputHelper output, StressTestMinLogLevel minLevel)
+        public StressTestNeo4JLogger(ITestOutputHelper output, StressTestMinLogLevel minLevel)
         {
             _output = output ?? throw new ArgumentNullException(nameof(output));
             _minLevel = minLevel;

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/DirectDriverTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/DirectDriverTests.cs
@@ -31,7 +31,7 @@ public sealed class DirectDriverTests
     {
         SetupConfig = o => o
             .WithEncryptionLevel(EncryptionLevel.None)
-            .WithLogger(TestLogger.Create(output));
+            .WithLogger(TestNeo4JLogger.Create(output));
     }
 
     private Action<ConfigBuilder> SetupConfig { get; }
@@ -44,7 +44,7 @@ public sealed class DirectDriverTests
         void SetupConfig(ConfigBuilder o)
         {
             o.WithEncryptionLevel(EncryptionLevel.None);
-            o.WithLogger(new TestLogger(logs.Add, ExtendedLogLevel.Debug));
+            o.WithLogger(new TestNeo4JLogger(logs.Add, ExtendedLogLevel.Debug));
         }
 
         using var _ = BoltStubServer.Start("V4/accessmode_reader_implicit", 9001);

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/MultiDatabasesTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/MultiDatabasesTests.cs
@@ -30,7 +30,7 @@ public sealed class MultiDatabasesTests
 
     public MultiDatabasesTests(ITestOutputHelper output)
     {
-        _setupConfig = o => o.WithLogger(TestLogger.Create(output));
+        _setupConfig = o => o.WithLogger(TestNeo4JLogger.Create(output));
     }
 
     [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/ResultStreamingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Stub/ResultStreamingTests.cs
@@ -34,7 +34,7 @@ public sealed class ResultStreamingTests
     public ResultStreamingTests(ITestOutputHelper output)
     {
         _output = output;
-        _setupConfig = o => o.WithLogger(TestLogger.Create(output));
+        _setupConfig = o => o.WithLogger(TestNeo4JLogger.Create(output));
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public sealed class ResultStreamingTests
         await using var driver = GraphDatabase.Driver(
             "bolt://127.0.0.1:9001",
             AuthTokens.None,
-            o => o.WithLogger(TestLogger.Create(_output)).WithFetchSize(2));
+            o => o.WithLogger(TestNeo4JLogger.Create(_output)).WithFetchSize(2));
 
         await using var session = driver.AsyncSession();
         var cursor =
@@ -78,7 +78,7 @@ public sealed class ResultStreamingTests
         using var driver = GraphDatabase.Driver(
             "bolt://127.0.0.1:9001",
             AuthTokens.None,
-            o => o.WithLogger(TestLogger.Create(_output)).WithFetchSize(2));
+            o => o.WithLogger(TestNeo4JLogger.Create(_output)).WithFetchSize(2));
 
         var session = driver.RxSession();
 
@@ -99,7 +99,7 @@ public sealed class ResultStreamingTests
         using var driver = GraphDatabase.Driver(
             "bolt://127.0.0.1:9001",
             AuthTokens.None,
-            o => o.WithLogger(TestLogger.Create(_output)).WithFetchSize(2));
+            o => o.WithLogger(TestNeo4JLogger.Create(_output)).WithFetchSize(2));
 
         var session = driver.RxSession();
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/NewDriver.cs
@@ -182,7 +182,7 @@ internal class NewDriver : ProtocolObject
                 TimeSpan.FromMilliseconds(data.livenessCheckTimeoutMs.Value));
         }
 
-        var logger = new SimpleLogger();
+        var logger = new SimpleNeo4JLogger();
         configBuilder.WithLogger(logger);
     }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/SimpleNeo4JLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Driver/SimpleNeo4JLogger.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace Neo4j.Driver.Tests.TestBackend.Protocol.Driver;
 
-internal class SimpleLogger : ILogger
+internal class SimpleNeo4JLogger : INeo4jLogger
 {
     private string Now => DateTime.UtcNow.ToString("HH:mm:ss");
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncRetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncRetryLogicTests.cs
@@ -33,7 +33,7 @@ public class AsyncRetryLogicTests
     [MemberData(nameof(NonTransientErrors))]
     public async Task ShouldNotRetryOnNonTransientErrors(Exception error)
     {
-        var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(5), new TestLogger(Console.WriteLine));
+        var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(5), new TestNeo4JLogger(Console.WriteLine));
         var work = CreateFailingWork(0, error);
 
         var exc = await Record.ExceptionAsync(() => retryLogic.RetryAsync(() => work.Work(null)));
@@ -46,7 +46,7 @@ public class AsyncRetryLogicTests
     [MemberData(nameof(TransientErrors))]
     public async Task ShouldRetryOnTransientErrors(Exception error)
     {
-        var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(5), NullLogger.Instance);
+        var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(5), NullNeo4JLogger.Instance);
         var work = CreateFailingWork(5, error);
 
         var result = await retryLogic.RetryAsync(() => work.Work(null));
@@ -58,7 +58,7 @@ public class AsyncRetryLogicTests
     [Fact]
     public async Task ShouldNotRetryOnSuccess()
     {
-        var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(5), NullLogger.Instance);
+        var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(5), NullNeo4JLogger.Instance);
         var work = CreateFailingWork(5);
 
         var result = await retryLogic.RetryAsync(() => work.Work(null));
@@ -74,7 +74,7 @@ public class AsyncRetryLogicTests
     public async Task ShouldLogRetries(int errorCount)
     {
         var error = new TransientException("code", "message");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new AsyncRetryLogic(TimeSpan.FromMinutes(1), logger.Object);
         var work = CreateFailingWork(
             1,
@@ -94,7 +94,7 @@ public class AsyncRetryLogicTests
     public async Task ShouldRetryAtLeastTwice()
     {
         var error = new TransientException("code", "message");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(1), logger.Object);
         var work = CreateFailingWork(TimeSpan.FromSeconds(2), 1, error);
 
@@ -117,7 +117,7 @@ public class AsyncRetryLogicTests
             .Cast<Exception>()
             .ToArray();
 
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new AsyncRetryLogic(TimeSpan.FromSeconds(2), logger.Object);
         var work = CreateFailingWork(TimeSpan.FromSeconds(1), 1, exceptions);
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
@@ -35,11 +35,11 @@ namespace Neo4j.Driver.Tests;
 
 public class AsyncSessionTests
 {
-    internal static AsyncSession NewSession(IConnection connection, bool reactive = false, ILogger logger = null)
+    internal static AsyncSession NewSession(IConnection connection, bool reactive = false, INeo4jLogger neo4JLogger = null)
     {
         return new AsyncSession(
             new TestConnectionProvider(connection),
-            logger ?? NullLogger.Instance,
+            neo4JLogger ?? NullNeo4JLogger.Instance,
             null,
             0,
             new Driver.SessionConfig(),
@@ -302,7 +302,7 @@ public class AsyncSessionTests
 
             var session = new AsyncSession(
                 new TestConnectionProvider(mockConn.Object),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 new AsyncRetryLogic(TimeSpan.Zero, null),
                 0,
                 new Driver.SessionConfig(),

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -37,7 +37,7 @@ public class ConfigTests
             var config = new Config();
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
             config.ConnectionTimeout.Should().Be(TimeSpan.FromSeconds(30));
             config.TlsVersion.Should().Be(SslProtocols.Tls12);
@@ -93,7 +93,7 @@ public class ConfigTests
 
             config.EncryptionLevel.Should().Be(EncryptionLevel.Encrypted);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
         }
 
@@ -116,11 +116,11 @@ public class ConfigTests
         [Fact]
         public void WithLoggingShouldModifyTheSingleValue()
         {
-            var mockLogger = new Mock<ILogger>();
+            var mockLogger = new Mock<INeo4jLogger>();
             var config = Config.Builder.WithLogger(mockLogger.Object).Build();
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().Be(mockLogger.Object);
+            config.Neo4JLogger.Should().Be(mockLogger.Object);
             config.MaxIdleConnectionPoolSize.Should().Be(100);
         }
 
@@ -130,7 +130,7 @@ public class ConfigTests
             var config = Config.Builder.WithLogger(null).Build();
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().Be(NullLogger.Instance);
+            config.Neo4JLogger.Should().Be(NullNeo4JLogger.Instance);
             config.MaxIdleConnectionPoolSize.Should().Be(100);
         }
 
@@ -140,7 +140,7 @@ public class ConfigTests
             var config = Config.Builder.WithMaxIdleConnectionPoolSize(3).Build();
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(3);
         }
 
@@ -151,7 +151,7 @@ public class ConfigTests
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.NullableEncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
         }
 
@@ -161,7 +161,7 @@ public class ConfigTests
             var config = Config.Builder.WithTrustManager(TrustManager.CreateChainTrust()).Build();
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeOfType<ChainTrustManager>();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
         }
 
@@ -170,18 +170,18 @@ public class ConfigTests
         {
             var config = new Config();
             var config1 = Config.Builder.WithMaxIdleConnectionPoolSize(3).Build();
-            var mockLogger = new Mock<ILogger>();
+            var mockLogger = new Mock<INeo4jLogger>();
             var config2 = Config.Builder.WithLogger(mockLogger.Object).Build();
 
-            config2.Logger.Should().Be(mockLogger.Object);
+            config2.Neo4JLogger.Should().Be(mockLogger.Object);
             config2.MaxIdleConnectionPoolSize.Should().Be(100);
 
             config1.MaxIdleConnectionPoolSize.Should().Be(3);
-            config1.Logger.Should().BeOfType<NullLogger>();
+            config1.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
 
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
         }
 
@@ -192,7 +192,7 @@ public class ConfigTests
             var config = Config.Builder.WithClientCertificateProvider(provider.Object).Build();
             config.EncryptionLevel.Should().Be(EncryptionLevel.None);
             config.TrustManager.Should().BeNull();
-            config.Logger.Should().BeOfType<NullLogger>();
+            config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
             config.ClientCertificateProvider.Should().Be(provider.Object);
         }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -957,7 +957,7 @@ public class ConnectionPoolTests
                     AuthTokenManagers.None,
                     new Config
                     {
-                        Logger = mockLogger.Object
+                        Neo4JLogger = mockLogger.Object
                     }),
                 new TestConnectionValidator());
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/BoltHandshakerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/BoltHandshakerTests.cs
@@ -74,7 +74,7 @@ public class BoltHandshakerTests
 
         var boltProtocolVersion = await BoltHandshaker.Default.DoHandshakeAsync(
             socket.Object,
-            new Mock<ILogger>().Object,
+            new Mock<INeo4jLogger>().Object,
             CancellationToken.None);
 
         boltProtocolVersion.Should().Be(version);
@@ -103,7 +103,7 @@ public class BoltHandshakerTests
 
         var boltProtocolVersion = await BoltHandshaker.Default.DoHandshakeAsync(
             socket.Object,
-            new Mock<ILogger>().Object,
+            new Mock<INeo4jLogger>().Object,
             CancellationToken.None);
 
         boltProtocolVersion.Should().Be(new BoltProtocolVersion(BoltProtocolVersion.LatestVersion.MajorVersion, 
@@ -137,7 +137,7 @@ public class BoltHandshakerTests
         var exception = await Record.ExceptionAsync(
                 () => BoltHandshaker.Default.DoHandshakeAsync(
                     socket.Object,
-                    new Mock<ILogger>().Object,
+                    new Mock<INeo4jLogger>().Object,
                     CancellationToken.None))
             .ConfigureAwait(false);
 
@@ -156,7 +156,7 @@ public class BoltHandshakerTests
         var exception = await Record.ExceptionAsync(
             () => BoltHandshaker.Default.DoHandshakeAsync(
                 socket.Object,
-                new Mock<ILogger>().Object,
+                new Mock<INeo4jLogger>().Object,
                 CancellationToken.None));
 
         exception.Should().BeOfType<IOException>();
@@ -191,7 +191,7 @@ public class BoltHandshakerTests
 
         var exception = await Record.ExceptionAsync(() => BoltHandshaker.Default.DoHandshakeAsync(
             socket.Object,
-            new Mock<ILogger>().Object,
+            new Mock<INeo4jLogger>().Object,
             CancellationToken.None)).ConfigureAwait(false);
 
         exception.Should().BeOfType<ProtocolException>();    

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketClientTests.cs
@@ -50,7 +50,7 @@ public class SocketClientTests
                 .Setup(
                     x => x.DoHandshakeAsync(
                         It.IsAny<ITcpSocketClient>(),
-                        It.IsAny<ILogger>(),
+                        It.IsAny<INeo4jLogger>(),
                         It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Version));
         }
@@ -58,7 +58,7 @@ public class SocketClientTests
         return new SocketClient(
             FakeUri,
             TestDriverContext.With(FakeUri),
-            Mock.Of<ILogger>(),
+            Mock.Of<INeo4jLogger>(),
             factory.Object,
             mockPackstreamFactory.Object,
             boltHandshaker.Object);
@@ -73,7 +73,7 @@ public class SocketClientTests
 
         var mockIoFactory = new Mock<IConnectionIoFactory>();
         mockIoFactory
-            .Setup(x => x.TcpSocketClient(It.IsAny<DriverContext>(), It.IsAny<ILogger>()))
+            .Setup(x => x.TcpSocketClient(It.IsAny<DriverContext>(), It.IsAny<INeo4jLogger>()))
             .Returns(connMock.Object);
 
         configureFactory?.Invoke(mockIoFactory);
@@ -93,17 +93,17 @@ public class SocketClientTests
             new ChunkWriter(
                 new MemoryStream(),
                 TestDriverContext.MockContext,
-                Mock.Of<ILogger>());
+                Mock.Of<INeo4jLogger>());
 
         var mr = messageReader ?? Mock.Of<IMessageReader>();
         var mw = messageWriter ?? Mock.Of<IMessageWriter>();
 
         factory
-            .Setup(x => x.MessageReader(It.IsAny<ITcpSocketClient>(), It.IsAny<DriverContext>(), It.IsAny<ILogger>()))
+            .Setup(x => x.MessageReader(It.IsAny<ITcpSocketClient>(), It.IsAny<DriverContext>(), It.IsAny<INeo4jLogger>()))
             .Returns(mr);
 
         factory
-            .Setup(x => x.Writers(It.IsAny<ITcpSocketClient>(), It.IsAny<DriverContext>(), It.IsAny<ILogger>()))
+            .Setup(x => x.Writers(It.IsAny<ITcpSocketClient>(), It.IsAny<DriverContext>(), It.IsAny<INeo4jLogger>()))
             .Returns((cw, mw));
 
         factory.Setup(x => x.Format(Version, TestDriverContext.MockContext)).Returns(fmt);
@@ -121,7 +121,7 @@ public class SocketClientTests
                 .Setup(
                     x => x.DoHandshakeAsync(
                         It.IsAny<ITcpSocketClient>(),
-                        It.IsAny<ILogger>(),
+                        It.IsAny<INeo4jLogger>(),
                         It.IsAny<CancellationToken>()))
                 .ThrowsAsync(exception);
 
@@ -132,7 +132,7 @@ public class SocketClientTests
             mockHandshaker.Verify(
                 x => x.DoHandshakeAsync(
                     It.IsAny<ITcpSocketClient>(),
-                    It.IsAny<ILogger>(),
+                    It.IsAny<INeo4jLogger>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/SocketConnectionTests.cs
@@ -35,7 +35,7 @@ public class SocketConnectionTests
 {
     private static IAuthToken AuthToken => AuthTokens.None;
     private static string UserAgent => Config.DefaultUserAgent;
-    private static ILogger Logger => new Mock<ILogger>().Object;
+    private static INeo4jLogger Neo4JLogger => new Mock<INeo4jLogger>().Object;
     private static Uri uri => new("http://neo4j.com");
     private static ServerInfo Server => new(uri);
     private static ISocketClient SocketClient => new Mock<ISocketClient>().Object;
@@ -44,7 +44,7 @@ public class SocketConnectionTests
         ISocketClient socketClient = null,
         IResponsePipeline pipeline = null,
         ServerInfo server = null,
-        ILogger logger = null,
+        INeo4jLogger neo4JLogger = null,
         IBoltProtocolFactory boltProtocolFactory = null,
         DriverContext context = null)
     {
@@ -53,7 +53,7 @@ public class SocketConnectionTests
         return new SocketConnection(
             socketClient,
             AuthToken,
-            logger ?? Logger,
+            neo4JLogger ?? Neo4JLogger,
             server,
             pipeline,
             AuthTokenManagers.None,
@@ -102,7 +102,7 @@ public class SocketConnectionTests
                 .Throws(new IOException("I will stop socket conn from initialization"));
 
             // ReSharper disable once ObjectCreationAsStatement
-            var conn = new SocketConnection(mockClient.Object, AuthToken, Logger, Server);
+            var conn = new SocketConnection(mockClient.Object, AuthToken, Neo4JLogger, Server);
             // When
             var error = await Record.ExceptionAsync(() => conn.InitAsync());
             // Then
@@ -339,13 +339,13 @@ public class SocketConnectionTests
         public async void ShouldNotThrowAndLogIfSocketDisposedAsync(Exception exc)
         {
             // Given
-            var logger = new Mock<ILogger>();
+            var logger = new Mock<INeo4jLogger>();
 
             var protocol = new Mock<IBoltProtocol>();
             protocol.Setup(x => x.LogoutAsync(It.IsAny<IConnection>())).ThrowsAsync(exc);
 
             var mockClient = new Mock<ISocketClient>();
-            var conn = NewSocketConnection(mockClient.Object, logger: logger.Object);
+            var conn = NewSocketConnection(mockClient.Object, neo4JLogger: logger.Object);
             conn.BoltProtocol = protocol.Object;
 
             var ex = await Record.ExceptionAsync(() => conn.CloseAsync());

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkReaderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkReaderTests.cs
@@ -285,7 +285,7 @@ public class ChunkReaderTests
             new StaticAuthTokenManager(AuthTokens.None),
             new Config());
 
-        var writer = new ChunkWriter(stream, cs, new Mock<ILogger>().Object);
+        var writer = new ChunkWriter(stream, cs, new Mock<INeo4jLogger>().Object);
 
         writer.OpenChunk();
         writer.Write(buffer, 0, buffer.Length);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkWriterTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/IO/ChunkWriterTests.cs
@@ -28,7 +28,7 @@ namespace Neo4j.Driver.Tests.Internal.IO;
 
 public class ChunkWriterTests
 {
-    private readonly Mock<ILogger> _logger = new();
+    private readonly Mock<INeo4jLogger> _logger = new();
 
     private static DriverContext TestContext(int defaultRead, int defaultWrite, int maxRead, int maxWrite)
     {
@@ -204,7 +204,7 @@ public class ChunkWriterTests
     {
         var buffer = new byte[messageSize];
         var stream = new MemoryStream();
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var context = TestContext(defaultBufferSize, defaultBufferSize, maxBufferSize, maxBufferSize);
         var writer = new ChunkWriter(stream, context, logger.Object);
 
@@ -230,7 +230,7 @@ public class ChunkWriterTests
     {
         var buffer = new byte[messageSize];
         var stream = new MemoryStream();
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var context = TestContext(defaultBufferSize, defaultBufferSize, maxBufferSize, maxBufferSize);
         var writer = new ChunkWriter(
             stream,
@@ -260,7 +260,7 @@ public class ChunkWriterTests
     {
         var buffer = new byte[messageSize];
         var stream = new MemoryStream();
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var context = TestContext(defaultBufferSize, defaultBufferSize, maxBufferSize, maxBufferSize);
         var writer = new ChunkWriter(stream, context, logger.Object);
 
@@ -284,7 +284,7 @@ public class ChunkWriterTests
     {
         var buffer = new byte[messageSize];
         var stream = new MemoryStream();
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var context = TestContext(defaultBufferSize, defaultBufferSize, maxBufferSize, maxBufferSize);
 
         var writer = new ChunkWriter(stream, context, logger.Object);
@@ -303,7 +303,7 @@ public class ChunkWriterTests
     {
         var buffer = new byte[1536];
         var stream = new MemoryStream();
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var settings = TestContext(512, 512, 1024, 1024);
         var writer = new ChunkWriter(stream, settings, logger.Object);
 
@@ -327,7 +327,7 @@ public class ChunkWriterTests
     {
         var buffer = new byte[1536];
         var stream = new MemoryStream();
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var context = TestContext(512, 512, 1024, 1024);
         var writer = new ChunkWriter(stream, context, logger.Object);
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/ResponsePipelineTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/ResponsePipelineTests.cs
@@ -103,9 +103,9 @@ public class ResponsePipelineTests
         pipeline.HasNoPendingMessages.Should().BeTrue();
     }
 
-    private static ResponsePipeline CreatePipelineWithHandler(ILogger logger = null)
+    private static ResponsePipeline CreatePipelineWithHandler(INeo4jLogger neo4JLogger = null)
     {
-        var pipeline = new ResponsePipeline(logger ?? NullLogger.Instance);
+        var pipeline = new ResponsePipeline(neo4JLogger ?? NullNeo4JLogger.Instance);
 
         var handler = new Mock<IResponseHandler>();
         pipeline.Enqueue(handler.Object);
@@ -118,7 +118,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldLog()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(true);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -132,7 +132,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldNotLogIfDebugDisabled()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(false);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -159,7 +159,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldInvokeHandler()
         {
-            var pipeline = new ResponsePipeline(NullLogger.Instance);
+            var pipeline = new ResponsePipeline(NullNeo4JLogger.Instance);
 
             var handler = new Mock<IResponseHandler>();
             pipeline.Enqueue(handler.Object);
@@ -176,7 +176,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldLog()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(true);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -190,7 +190,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldNotLogIfDebugDisabled()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(false);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -219,7 +219,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldInvokeHandler()
         {
-            var pipeline = new ResponsePipeline(NullLogger.Instance);
+            var pipeline = new ResponsePipeline(NullNeo4JLogger.Instance);
 
             var handler = new Mock<IResponseHandler>();
             pipeline.Enqueue(handler.Object);
@@ -236,7 +236,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldLog()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(true);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -254,7 +254,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldNotLogIfDebugDisabled()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(false);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -281,7 +281,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldInvokeHandler()
         {
-            var pipeline = new ResponsePipeline(NullLogger.Instance);
+            var pipeline = new ResponsePipeline(NullNeo4JLogger.Instance);
             var (code, message) = ("Neo.TransientError.Transaction.Terminated", "transaction terminated.");
 
             var handler = new Mock<IResponseHandler>();
@@ -327,7 +327,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldRecordErrorAndThrowOnAssertNoProtocolViolation()
         {
-            var pipeline = new ResponsePipeline(NullLogger.Instance);
+            var pipeline = new ResponsePipeline(NullNeo4JLogger.Instance);
             var (code, message) = ("Neo.ClientError.Request.Invalid", "protocol exception.");
 
             var handler = new Mock<IResponseHandler>();
@@ -350,7 +350,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldLog()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(true);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -363,7 +363,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldNotLogIfDebugDisabled()
         {
-            var log = new Mock<ILogger>();
+            var log = new Mock<INeo4jLogger>();
             log.Setup(x => x.IsDebugEnabled()).Returns(false);
 
             var pipeline = CreatePipelineWithHandler(log.Object);
@@ -388,7 +388,7 @@ public class ResponsePipelineTests
         [Fact]
         public void ShouldInvokeHandler()
         {
-            var pipeline = new ResponsePipeline(NullLogger.Instance);
+            var pipeline = new ResponsePipeline(NullNeo4JLogger.Instance);
 
             var handler = new Mock<IResponseHandler>();
             pipeline.Enqueue(handler.Object);

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/TransactionTimeoutTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/TransactionTimeoutTests.cs
@@ -48,7 +48,7 @@ public class TransactionTimeoutTests
         if (expectedTimeout != inputMilliseconds)
         {
             // only logs if it changes the timeout
-            autoMocker.GetMock<ILogger>()
+            autoMocker.GetMock<INeo4jLogger>()
                 .Setup(
                     x => x.Info(
                         It.Is<string>(s => s.Contains("rounded up")),
@@ -57,7 +57,7 @@ public class TransactionTimeoutTests
         }
 
         var sut =
-            new TransactionConfigBuilder(autoMocker.GetMock<ILogger>().Object, TransactionConfig.Default)
+            new TransactionConfigBuilder(autoMocker.GetMock<INeo4jLogger>().Object, TransactionConfig.Default)
                 .WithTimeout(totalInput);
 
         var result = sut.Build().Timeout;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/RxRetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Reactive/Internal/RxRetryLogicTests.cs
@@ -89,7 +89,7 @@ public class RxRetryLogicTests : AbstractRxTest
     public void ShouldLogRetries(int errorCount)
     {
         var error = new TransientException("code", "message");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new RxRetryLogic(TimeSpan.FromMinutes(1), logger.Object);
 
         retryLogic
@@ -113,7 +113,7 @@ public class RxRetryLogicTests : AbstractRxTest
     public void ShouldRetryAtLeastTwice()
     {
         var error = new TransientException("code", "message");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new RxRetryLogic(TimeSpan.FromSeconds(1), logger.Object);
 
         retryLogic
@@ -139,7 +139,7 @@ public class RxRetryLogicTests : AbstractRxTest
             .Cast<Exception>()
             .ToArray();
 
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new RxRetryLogic(TimeSpan.FromSeconds(2), logger.Object);
 
         retryLogic

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LeastConnectedLoadBalancingStrategyTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/LeastConnectedLoadBalancingStrategyTests.cs
@@ -183,7 +183,7 @@ public class LeastConnectedLoadBalancingStrategyTests
     public void ShouldIncludeDatabaseNameInLogMessageForReader()
     {
         var address = new Uri("reader:7687");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         logger.Setup(x => x.IsDebugEnabled()).Returns(true);
         var connectionPoolMock = new Mock<IClusterConnectionPool>();
         var strategy = NewLeastConnectedStrategy(connectionPoolMock.Object, logger.Object);
@@ -202,7 +202,7 @@ public class LeastConnectedLoadBalancingStrategyTests
     public void ShouldIncludeDatabaseNameInLogMessageForWriter()
     {
         var address = new Uri("reader:7687");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         logger.Setup(x => x.IsDebugEnabled()).Returns(true);
         var connectionPoolMock = new Mock<IClusterConnectionPool>();
         var strategy = NewLeastConnectedStrategy(connectionPoolMock.Object, logger.Object);
@@ -219,8 +219,8 @@ public class LeastConnectedLoadBalancingStrategyTests
 
     private static LeastConnectedLoadBalancingStrategy NewLeastConnectedStrategy(
         IClusterConnectionPool connectionPool,
-        ILogger logger = null)
+        INeo4jLogger neo4JLogger = null)
     {
-        return new LeastConnectedLoadBalancingStrategy(connectionPool, logger ?? Mock.Of<ILogger>());
+        return new LeastConnectedLoadBalancingStrategy(connectionPool, neo4JLogger ?? Mock.Of<INeo4jLogger>());
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
@@ -47,7 +47,7 @@ public static class RoutingTableManagerTests
         IClusterConnectionPoolManager poolManager,
         IDiscovery discovery = null,
         IInitialServerAddressProvider addressProvider = null,
-        ILogger logger = null)
+        INeo4jLogger neo4JLogger = null)
     {
         if (addressProvider == null)
         {
@@ -63,7 +63,7 @@ public static class RoutingTableManagerTests
             addressProvider,
             discovery,
             poolManager,
-            logger ?? NullLogger.Instance,
+            neo4JLogger ?? NullNeo4JLogger.Instance,
             TimeSpan.Zero,
             routingTable);
     }
@@ -361,14 +361,14 @@ public static class RoutingTableManagerTests
                         It.IsAny<IHomeDbCache>()))
                 .Throws(error);
 
-            var logger = new Mock<ILogger>();
+            var logger = new Mock<INeo4jLogger>();
             logger.Setup(x => x.Warn(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<object[]>()));
 
             var manager = NewRoutingTableManager(
                 routingTable,
                 poolManagerMock.Object,
                 discovery.Object,
-                logger: logger.Object);
+                neo4JLogger: logger.Object);
 
             await manager.UpdateRoutingTableAsync(routingTable, AccessMode.Read, "", null, Bookmarks.Empty);
 
@@ -395,14 +395,14 @@ public static class RoutingTableManagerTests
                         It.IsAny<IHomeDbCache>()))
                 .Throws(error);
 
-            var logger = new Mock<ILogger>();
+            var logger = new Mock<INeo4jLogger>();
             logger.Setup(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<object[]>()));
 
             var manager = NewRoutingTableManager(
                 routingTable,
                 poolManagerMock.Object,
                 discovery.Object,
-                logger: logger.Object);
+                neo4JLogger: logger.Object);
 
             var exc = await Record.ExceptionAsync(
                 () =>
@@ -432,14 +432,14 @@ public static class RoutingTableManagerTests
                         It.IsAny<IHomeDbCache>()))
                 .Throws(error);
 
-            var logger = new Mock<ILogger>();
+            var logger = new Mock<INeo4jLogger>();
             logger.Setup(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<object[]>()));
 
             var manager = NewRoutingTableManager(
                 routingTable,
                 poolManagerMock.Object,
                 discovery.Object,
-                logger: logger.Object);
+                neo4JLogger: logger.Object);
 
             var exc = await Record.ExceptionAsync(
                 () =>
@@ -591,7 +591,7 @@ public static class RoutingTableManagerTests
                 .Setup(x => x.DiscoverAsync(connE, "", null, Bookmarks.Empty, It.IsAny<IHomeDbCache>()))
                 .ReturnsAsync(routingTable);
 
-            var logger = new Mock<ILogger>();
+            var logger = new Mock<INeo4jLogger>();
             logger.Setup(
                 x => x.Warn(It.IsAny<ServiceUnavailableException>(), It.IsAny<string>(), It.IsAny<object[]>()));
 
@@ -600,7 +600,7 @@ public static class RoutingTableManagerTests
                 existingRoutingTable,
                 poolManager.Object,
                 discovery.Object,
-                logger: logger.Object);
+                neo4JLogger: logger.Object);
 
             // When
             var result = await manager
@@ -666,7 +666,7 @@ public static class RoutingTableManagerTests
                     x => x.DiscoverAsync(connE, "", null, Bookmarks.Empty, It.IsAny<IHomeDbCache>()))
                 .ReturnsAsync(routingTable);
 
-            var logger = new Mock<ILogger>();
+            var logger = new Mock<INeo4jLogger>();
             logger.Setup(
                 x =>
                     x.Warn(It.IsAny<ServiceUnavailableException>(), It.IsAny<string>(), It.IsAny<object[]>()));
@@ -677,7 +677,7 @@ public static class RoutingTableManagerTests
                     existingRoutingTable,
                     poolManager.Object,
                     discovery.Object,
-                    logger: logger.Object);
+                    neo4JLogger: logger.Object);
 
             // When
             var result =
@@ -731,7 +731,7 @@ public static class RoutingTableManagerTests
                 Mock.Of<IInitialServerAddressProvider>(),
                 Mock.Of<IDiscovery>(),
                 Mock.Of<IClusterConnectionPoolManager>(),
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue,
                 defaultRoutingTable,
                 fooRoutingTable,
@@ -773,7 +773,7 @@ public static class RoutingTableManagerTests
                 Mock.Of<IInitialServerAddressProvider>(),
                 Mock.Of<IDiscovery>(),
                 Mock.Of<IClusterConnectionPoolManager>(),
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue,
                 defaultRoutingTable,
                 fooRoutingTable,
@@ -850,7 +850,7 @@ public static class RoutingTableManagerTests
                 initialAddressProvider.Object,
                 discovery.Object,
                 poolManager.Object,
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue);
 
             // When
@@ -910,7 +910,7 @@ public static class RoutingTableManagerTests
                 initialAddressProvider.Object,
                 discovery.Object,
                 poolManager.Object,
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.FromSeconds(1));
 
             // When
@@ -979,7 +979,7 @@ public static class RoutingTableManagerTests
                 initialAddressProvider.Object,
                 discovery.Object,
                 poolManager.Object,
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue);
 
             // When
@@ -1027,7 +1027,7 @@ public static class RoutingTableManagerTests
                 initialAddressProvider.Object,
                 discovery.Object,
                 poolManager.Object,
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue);
 
             manager.Awaiting(
@@ -1065,7 +1065,7 @@ public static class RoutingTableManagerTests
                 initialAddressProvider.Object,
                 discovery.Object,
                 poolManager.Object,
-                Mock.Of<ILogger>(),
+                Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue);
 
             var routingTable =

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Synchronous/Internal/SyncRetryLogicTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Synchronous/Internal/SyncRetryLogicTests.cs
@@ -71,7 +71,7 @@ public class SyncRetryLogicTests
     public void ShouldLogRetries(int errorCount)
     {
         var error = new TransientException("code", "message");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new RetryLogic(TimeSpan.FromMinutes(1), logger.Object);
         var work = CreateFailingWork(
             1,
@@ -91,7 +91,7 @@ public class SyncRetryLogicTests
     public void ShouldRetryAtLeastTwice()
     {
         var error = new TransientException("code", "message");
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new RetryLogic(TimeSpan.FromSeconds(1), logger.Object);
         var work = CreateFailingWork(TimeSpan.FromSeconds(2), 1, error);
 
@@ -114,7 +114,7 @@ public class SyncRetryLogicTests
             .Cast<Exception>()
             .ToArray();
 
-        var logger = new Mock<ILogger>();
+        var logger = new Mock<INeo4jLogger>();
         var retryLogic = new RetryLogic(TimeSpan.FromSeconds(2), logger.Object);
         var work = CreateFailingWork(TimeSpan.FromSeconds(1), 1, exceptions);
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/LoggingHelper.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/LoggingHelper.cs
@@ -19,9 +19,9 @@ namespace Neo4j.Driver.Tests.TestUtil;
 
 public static class LoggingHelper
 {
-    public static Mock<ILogger> GetTraceEnabledLogger()
+    public static Mock<INeo4jLogger> GetTraceEnabledLogger()
     {
-        var mockLogger = new Mock<ILogger>();
+        var mockLogger = new Mock<INeo4jLogger>();
         mockLogger.Setup(x => x.IsTraceEnabled()).Returns(true);
         mockLogger.Setup(x => x.IsDebugEnabled()).Returns(true);
         return mockLogger;

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/Neo4jUriTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/Neo4jUriTests.cs
@@ -193,7 +193,7 @@ public class Neo4jUriTests
         public void ShouldBeNoEncryptionNoTrust(string scheme)
         {
             var raw = new Uri($"{scheme}://localhost/?");
-            var manager = Neo4jUri.ParseUriSchemeToEncryptionManager(raw, NullLogger.Instance);
+            var manager = Neo4jUri.ParseUriSchemeToEncryptionManager(raw, NullNeo4JLogger.Instance);
 
             manager.UseTls.Should().BeFalse();
             manager.TrustManager.Should().BeNull();
@@ -205,12 +205,12 @@ public class Neo4jUriTests
         public void ShouldBeEncryptionWithChainTrust(string scheme)
         {
             var raw = new Uri($"{scheme}://localhost/?");
-            var log = new Mock<ILogger>().Object;
+            var log = new Mock<INeo4jLogger>().Object;
             var manager = Neo4jUri.ParseUriSchemeToEncryptionManager(raw, log);
 
             manager.UseTls.Should().BeTrue();
             manager.TrustManager.Should().BeOfType<ChainTrustManager>();
-            manager.TrustManager.Logger.Should().Be(log);
+            manager.TrustManager.Neo4JLogger.Should().Be(log);
         }
 
         [Theory]
@@ -219,12 +219,12 @@ public class Neo4jUriTests
         public void ShouldBeEncryptionWithInsecureTrust(string scheme)
         {
             var raw = new Uri($"{scheme}://localhost/?");
-            var log = new Mock<ILogger>().Object;
+            var log = new Mock<INeo4jLogger>().Object;
             var manager = Neo4jUri.ParseUriSchemeToEncryptionManager(raw, log);
 
             manager.UseTls.Should().BeTrue();
             manager.TrustManager.Should().BeOfType<InsecureTrustManager>();
-            manager.TrustManager.Logger.Should().Be(log);
+            manager.TrustManager.Neo4JLogger.Should().Be(log);
         }
 
         [Theory]
@@ -235,7 +235,7 @@ public class Neo4jUriTests
         public void ShouldErrorForUnknownBoltUri(string scheme)
         {
             var raw = new Uri($"{scheme}://localhost/?");
-            var ex = Record.Exception(() => Neo4jUri.ParseUriSchemeToEncryptionManager(raw, NullLogger.Instance));
+            var ex = Record.Exception(() => Neo4jUri.ParseUriSchemeToEncryptionManager(raw, NullNeo4JLogger.Instance));
             ex.Should().BeOfType<NotSupportedException>();
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/TestDriverLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TestUtil/TestDriverLogger.cs
@@ -18,18 +18,18 @@ using Xunit.Abstractions;
 
 namespace Neo4j.Driver.Tests.TestUtil;
 
-public class TestLogger : ILogger
+public class TestNeo4JLogger : INeo4jLogger
 {
     private readonly ExtendedLogLevel _level;
     private readonly Action<string> _logMethod;
 
-    public TestLogger(ITestOutputHelper output, ExtendedLogLevel level = ExtendedLogLevel.Info)
+    public TestNeo4JLogger(ITestOutputHelper output, ExtendedLogLevel level = ExtendedLogLevel.Info)
     {
         _level = level;
         _logMethod = output.WriteLine;
     }
 
-    public TestLogger(Action<string> logMethod, ExtendedLogLevel level = ExtendedLogLevel.Info)
+    public TestNeo4JLogger(Action<string> logMethod, ExtendedLogLevel level = ExtendedLogLevel.Info)
     {
         _level = level;
         _logMethod = logMethod;
@@ -88,7 +88,7 @@ public class TestLogger : ILogger
         _logMethod(formattableString);
     }
 
-    public static ILogger Create(ITestOutputHelper output)
+    public static INeo4jLogger Create(ITestOutputHelper output)
     {
         var logLevel = ExtendedLogLevel.Error;
         var logLevelStr = Environment.GetEnvironmentVariable("NEOLOGLEVEL");
@@ -97,7 +97,7 @@ public class TestLogger : ILogger
             logLevel = Enum.Parse<ExtendedLogLevel>(logLevelStr, true);
         }
 
-        return new TestLogger(output, logLevel);
+        return new TestNeo4JLogger(output, logLevel);
     }
 }
 

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionConfigTests.cs
@@ -72,7 +72,7 @@ public class TransactionConfigTests
         public void ShouldRoundUpWithBuilder()
         {
             var ts = TimeSpan.FromTicks(1);
-            var builder = new TransactionConfigBuilder(NullLogger.Instance, TransactionConfig.Default);
+            var builder = new TransactionConfigBuilder(NullNeo4JLogger.Instance, TransactionConfig.Default);
             builder.WithTimeout(ts);
 
             var config = builder.Build();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/TransactionTests.cs
@@ -72,7 +72,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new ("bolt://localhost"), null, new Config()));
 
             await tx.BeginTransactionAsync(
@@ -97,7 +97,7 @@ public class TransactionTests
         {
             var mockProtocol = new Mock<IBoltProtocol>();
             var mockConn = NewMockedConnection(mockProtocol);
-            var tx = new AsyncTransaction(mockConn.Object, Mock.Of<ITransactionResourceHandler>(), NullLogger.Instance,
+            var tx = new AsyncTransaction(mockConn.Object, Mock.Of<ITransactionResourceHandler>(), NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             var query = new Query("lala");
@@ -123,7 +123,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             tx.TransactionError = new Exception();
@@ -141,7 +141,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             var query = new Query("lala");
@@ -172,7 +172,7 @@ public class TransactionTests
             var mockProtocol = new Mock<IBoltProtocol>();
             var mockConn = NewMockedConnection(mockProtocol);
             var mockHandler = new Mock<ITransactionResourceHandler>();
-            var tx = new AsyncTransaction(mockConn.Object, mockHandler.Object, NullLogger.Instance,
+            var tx = new AsyncTransaction(mockConn.Object, mockHandler.Object, NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -188,7 +188,7 @@ public class TransactionTests
             var mockProtocol = new Mock<IBoltProtocol>();
             var mockConn = NewMockedConnection(mockProtocol);
             var mockHandler = new Mock<ITransactionResourceHandler>();
-            var tx = new AsyncTransaction(mockConn.Object, mockHandler.Object, NullLogger.Instance,
+            var tx = new AsyncTransaction(mockConn.Object, mockHandler.Object, NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -202,7 +202,7 @@ public class TransactionTests
         {
             var mockConn = NewMockedConnection();
             var mockHandler = new Mock<ITransactionResourceHandler>();
-            var tx = new AsyncTransaction(mockConn.Object, mockHandler.Object, NullLogger.Instance,
+            var tx = new AsyncTransaction(mockConn.Object, mockHandler.Object, NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -220,7 +220,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -238,7 +238,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -260,7 +260,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -281,7 +281,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             mockConn.Invocations.Clear();
@@ -299,7 +299,7 @@ public class TransactionTests
         public async Task ShouldBeOpenWhenConstructed()
         {
             var mockConn = NewMockedConnection();
-            var tx = new AsyncTransaction(mockConn.Object, Mock.Of<ITransactionResourceHandler>(), NullLogger.Instance,
+            var tx = new AsyncTransaction(mockConn.Object, Mock.Of<ITransactionResourceHandler>(), NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             await tx.BeginTransactionAsync(
@@ -316,7 +316,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             await tx.BeginTransactionAsync(
@@ -335,7 +335,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             await tx.BeginTransactionAsync(
@@ -354,7 +354,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             await tx.BeginTransactionAsync(
@@ -373,7 +373,7 @@ public class TransactionTests
             var tx = new AsyncTransaction(
                 mockConn.Object,
                 Mock.Of<ITransactionResourceHandler>(),
-                NullLogger.Instance,
+                NullNeo4JLogger.Instance,
                 driverContext: new DriverContext(new("bolt://localhost"), null, new Config()));
 
             await tx.BeginTransactionAsync(

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncRetryLogic.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncRetryLogic.cs
@@ -34,14 +34,14 @@ internal class AsyncRetryLogic : IAsyncRetryLogic
     private readonly double _initialRetryDelayMs;
     private readonly double _jitterFactor;
 
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly double _maxRetryTimeMs;
     private readonly double _multiplier;
 
-    public AsyncRetryLogic(TimeSpan maxRetryTimeout, ILogger logger)
+    public AsyncRetryLogic(TimeSpan maxRetryTimeout, INeo4jLogger neo4JLogger)
     {
         _maxRetryTimeMs = maxRetryTimeout.TotalMilliseconds;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _initialRetryDelayMs = InitialRetryDelayMs;
         _multiplier = RetryDelayMultiplier;
         _jitterFactor = RetryDelayJitterFactor;
@@ -73,7 +73,7 @@ internal class AsyncRetryLogic : IAsyncRetryLogic
                 if (shouldRetry)
                 {
                     delay = TimeSpan.FromMilliseconds(ComputeDelayWithJitter(delayMs));
-                    _logger.Warn(e, $"Transaction failed and will be retried in {delay} ms.");
+                    _neo4JLogger.Warn(e, $"Transaction failed and will be retried in {delay} ms.");
                     await Task.Delay(delay).ConfigureAwait(false); // blocking for this delay
                     delayMs *= _multiplier;
                 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -37,7 +37,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
     private readonly DriverContext _driverContext;
     private readonly long _fetchSize;
 
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly INotificationsConfig _notificationsConfig;
     private readonly bool _reactive;
 
@@ -56,7 +56,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
 
     public AsyncSession(
         IConnectionProvider provider,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         IAsyncRetryLogic retryLogic,
         long defaultFetchSize,
         SessionConfig config,
@@ -65,7 +65,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
     {
         SessionConfig = config;
         _connectionProvider = provider;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _retryLogic = retryLogic;
         _reactive = reactive;
         _driverContext = config.DriverContext;;
@@ -102,12 +102,12 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
 
         if (string.IsNullOrWhiteSpace(_database))
         {
-            _logger.Info($"Database '{db}' is pinned to the session.");
+            _neo4JLogger.Info($"Database '{db}' is pinned to the session.");
             _database = db;
         }
         else
         {
-            _logger.Info($"Database {_database} is already pinned to the session, ignoring {db}.");
+            _neo4JLogger.Info($"Database {_database} is already pinned to the session, ignoring {db}.");
         }
     }
 
@@ -174,7 +174,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
     {
         var config = BuildTransactionConfig(action);
         return await TryExecuteAsync(
-                _logger,
+                _neo4JLogger,
                 () => BeginTransactionWithoutLoggingAsync(
                     mode,
                     config,
@@ -190,7 +190,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
     {
         var options = BuildTransactionConfig(action);
         var result = TryExecuteAsync(
-            _logger,
+            _neo4JLogger,
             async () =>
             {
                 await EnsureCanRunMoreQuerysAsync(disposeUnconsumedSessionResult).ConfigureAwait(false);
@@ -312,7 +312,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
             return TransactionConfig.Default;
         }
 
-        var builder = new TransactionConfigBuilder(_logger, new TransactionConfig());
+        var builder = new TransactionConfigBuilder(_neo4JLogger, new TransactionConfig());
         action.Invoke(builder);
         return builder.Build();
     }
@@ -351,7 +351,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
     {
         transactionInfo ??= new TransactionInfo(QueryApiType.TransactionFunction, TelemetryEnabled, true);
         return TryExecuteAsync(
-            _logger,
+            _neo4JLogger,
             () => _retryLogic.RetryAsync(
                 async () =>
                 {
@@ -397,7 +397,7 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
         var tx = new AsyncTransaction(
             _connection,
             this,
-            _logger,
+            _neo4JLogger,
             _database,
             LastBookmarks,
             _reactive,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSessionResourceManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSessionResourceManager.cs
@@ -47,7 +47,7 @@ internal partial class AsyncSession : IResultResourceHandler, ITransactionResour
     public Task CloseAsync()
     {
         return TryExecuteAsync(
-            _logger,
+            _neo4JLogger,
             async () =>
             {
                 if (_isOpen)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncTransaction.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncTransaction.cs
@@ -34,7 +34,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
     private readonly IConnection _connection;
     private readonly DriverContext _driverContext;
     private readonly long _fetchSize;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly INotificationsConfig _notificationsConfig;
     private readonly bool _reactive;
     private readonly ITransactionResourceHandler _resourceHandler;
@@ -50,7 +50,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
     public AsyncTransaction(
         IConnection connection,
         ITransactionResourceHandler resourceHandler,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         string database = null,
         Bookmarks bookmark = null,
         bool reactive = false,
@@ -62,7 +62,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         _connection = new TransactionConnection(this, connection);
         _resourceHandler = resourceHandler ?? throw new ArgumentNullException(nameof(resourceHandler));
         _bookmarks = bookmark;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _reactive = reactive;
         Database = database;
         _fetchSize = fetchSize;
@@ -108,7 +108,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         var result = _state.RunAsync(
             query,
             _connection,
-            _logger,
+            _neo4JLogger,
             _reactive,
             _fetchSize,
             this,
@@ -257,7 +257,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         Task<IResultCursor> RunAsync(
             Query query,
             IConnection connection,
-            ILogger logger,
+            INeo4jLogger neo4JLogger,
             bool reactive,
             long fetchSize,
             AsyncTransaction transaction,
@@ -280,7 +280,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         public Task<IResultCursor> RunAsync(
             Query query,
             IConnection connection,
-            ILogger logger,
+            INeo4jLogger neo4JLogger,
             bool reactive,
             long fetchSize,
             AsyncTransaction transaction,
@@ -315,7 +315,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         public Task<IResultCursor> RunAsync(
             Query query,
             IConnection connection,
-            ILogger logger,
+            INeo4jLogger neo4JLogger,
             bool reactive,
             long fetchSize,
             AsyncTransaction transaction,
@@ -350,7 +350,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         public Task<IResultCursor> RunAsync(
             Query query,
             IConnection connection,
-            ILogger logger,
+            INeo4jLogger neo4JLogger,
             bool reactive,
             long fetchSize,
             AsyncTransaction transaction,
@@ -385,7 +385,7 @@ internal class AsyncTransaction : AsyncQueryRunner, IInternalAsyncTransaction, I
         public Task<IResultCursor> RunAsync(
             Query query,
             IConnection connection,
-            ILogger logger,
+            INeo4jLogger neo4JLogger,
             bool reactive,
             long fetchSize,
             AsyncTransaction transaction,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Auth/DefaultTlsNegotiator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Auth/DefaultTlsNegotiator.cs
@@ -23,11 +23,11 @@ namespace Neo4j.Driver.Internal.Auth;
 internal sealed class DefaultTlsNegotiator : ITlsNegotiator
 {
     private readonly EncryptionManager _encryptionManager;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
 
-    public DefaultTlsNegotiator(ILogger logger, EncryptionManager encryptionManager)
+    public DefaultTlsNegotiator(INeo4jLogger neo4JLogger, EncryptionManager encryptionManager)
     {
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _encryptionManager = encryptionManager;
     }
 
@@ -41,7 +41,7 @@ internal sealed class DefaultTlsNegotiator : ITlsNegotiator
             {
                 if (errors.HasFlag(SslPolicyErrors.RemoteCertificateNotAvailable))
                 {
-                    _logger?.Error(null, $"{GetType().Name}: Certificate not available.");
+                    _neo4JLogger?.Error(null, $"{GetType().Name}: Certificate not available.");
                     return false;
                 }
 
@@ -53,11 +53,11 @@ internal sealed class DefaultTlsNegotiator : ITlsNegotiator
 
                 if (trust)
                 {
-                    _logger?.Debug("Trust is established, resuming connection.");
+                    _neo4JLogger?.Debug("Trust is established, resuming connection.");
                 }
                 else
                 {
-                    _logger?.Error(null, "Trust not established, aborting communication.");
+                    _neo4JLogger?.Error(null, "Trust not established, aborting communication.");
                 }
 
                 return trust;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -42,7 +42,7 @@ internal sealed class ConnectionPool : IConnectionPool
     private readonly BlockingCollection<IPooledConnection> _idleConnections = new();
     private readonly ConcurrentHashSet<IPooledConnection> _inUseConnections = new();
 
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
 
     private readonly IConnectionPoolListener _poolMetricsListener;
 
@@ -64,7 +64,7 @@ internal sealed class ConnectionPool : IConnectionPool
     {
         _uri = uri;
         _id = $"pool-{_uri.Host}:{_uri.Port}";
-        _logger = new PrefixLogger(driverContext.Logger, $"[{_id}]");
+        _neo4JLogger = new PrefixNeo4JLogger(driverContext.Neo4JLogger, $"[{_id}]");
 
         _connectionFactory = connectionFactory;
         DriverContext = driverContext;
@@ -130,7 +130,7 @@ internal sealed class ConnectionPool : IConnectionPool
             do
             {
                 var connection = await TryExecuteAsync(
-                        _logger,
+                        _neo4JLogger,
                         () => AcquireOrTimeoutAsync(database, sessionConfig, mode, ConnectionAcquisitionTimeout),
                         "Failed to acquire a connection from connection pool asynchronously.")
                     .ConfigureAwait(false);
@@ -158,7 +158,7 @@ internal sealed class ConnectionPool : IConnectionPool
                 }
                 catch (ReauthException ex)
                 {
-                    _logger.Debug(ex.ToString());
+                    _neo4JLogger.Debug(ex.ToString());
                     if (ex.IsUserSwitching)
                     {
                         throw;
@@ -178,7 +178,7 @@ internal sealed class ConnectionPool : IConnectionPool
     public async Task ReleaseAsync(IPooledConnection connection)
     {
         await TryExecuteAsync(
-                _logger,
+                _neo4JLogger,
                 async () =>
                 {
                     if (IsClosed)
@@ -625,7 +625,7 @@ internal sealed class ConnectionPool : IConnectionPool
         var allCloseTasks = new List<Task>();
         while (_idleConnections.TryTake(out var connection))
         {
-            _logger.Debug($"Disposing Available Connection {connection}");
+            _neo4JLogger.Debug($"Disposing Available Connection {connection}");
             allCloseTasks.Add(DestroyConnectionAsync(connection));
         }
 
@@ -658,7 +658,7 @@ internal sealed class ConnectionPool : IConnectionPool
 
         foreach (var inUseConnection in _inUseConnections)
         {
-            _logger.Info($"Disposing In Use Connection {inUseConnection}");
+            _neo4JLogger.Info($"Disposing In Use Connection {inUseConnection}");
 
             if (_inUseConnections.TryRemove(inUseConnection))
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/BoltHandshaker.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/BoltHandshaker.cs
@@ -30,7 +30,7 @@ internal interface IBoltHandshaker
 {
     Task<BoltProtocolVersion> DoHandshakeAsync(
         ITcpSocketClient socketClient,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         CancellationToken cancellationToken);
 }
 
@@ -42,7 +42,7 @@ internal sealed class BoltHandshaker : IBoltHandshaker
     {
     }
 
-    private static async Task<(BoltProtocolVersion version, int range)> ParseProtocolVersionResponse(ITcpSocketClient socketClient, ILogger logger, CancellationToken cancellationToken)
+    private static async Task<(BoltProtocolVersion version, int range)> ParseProtocolVersionResponse(ITcpSocketClient socketClient, INeo4jLogger neo4JLogger, CancellationToken cancellationToken)
     {
         var responseBytes = new byte[4];
 
@@ -51,7 +51,7 @@ internal sealed class BoltHandshaker : IBoltHandshaker
             .ReadAsync(responseBytes, 0, responseBytes.Length, cancellationToken)
             .ConfigureAwait(false);
 
-        logger.Debug("S: [HANDSHAKE] Suggested protocol version - {0}", responseBytes.ToHexString());
+        neo4JLogger.Debug("S: [HANDSHAKE] Suggested protocol version - {0}", responseBytes.ToHexString());
 
         if (read < responseBytes.Length)
         {
@@ -68,7 +68,7 @@ internal sealed class BoltHandshaker : IBoltHandshaker
         return (version.MajorVersion == BoltProtocolVersion.ManifestSchema);
     }
 
-    private static async Task<VarLong> ReadVariableLengthData(ITcpSocketClient socketClient, ILogger logger, CancellationToken cancellationToken)
+    private static async Task<VarLong> ReadVariableLengthData(ITcpSocketClient socketClient, INeo4jLogger neo4JLogger, CancellationToken cancellationToken)
     {
         VarLong resultVariable = new VarLong();
         var responseByte = new byte[1];
@@ -89,25 +89,25 @@ internal sealed class BoltHandshaker : IBoltHandshaker
             serverResponse += responseByte.ToHexString() + " ";
         }
 
-        logger.Debug("S: [HANDSHAKE] VarInt -  {0}", serverResponse);
+        neo4JLogger.Debug("S: [HANDSHAKE] VarInt -  {0}", serverResponse);
         return resultVariable;
     }
 
     private static async Task<long> ParseNumProtocolVersions(
         ITcpSocketClient socketClient,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         CancellationToken cancellationToken)
     {   
-        var numProtocolVersions = await ReadVariableLengthData(socketClient, logger, cancellationToken).ConfigureAwait(false);
+        var numProtocolVersions = await ReadVariableLengthData(socketClient, neo4JLogger, cancellationToken).ConfigureAwait(false);
         return numProtocolVersions.Value;
     }
     
     private static async Task<List<BoltProtocolVersion>> ParseSupportedProtocolVersions(
         ITcpSocketClient sockeClient,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         CancellationToken cancellationToken)
     {
-        var numProtocolVersions = await ParseNumProtocolVersions(sockeClient, logger, cancellationToken)
+        var numProtocolVersions = await ParseNumProtocolVersions(sockeClient, neo4JLogger, cancellationToken)
             .ConfigureAwait(false);
 
         if (numProtocolVersions <= 0)
@@ -126,7 +126,7 @@ internal sealed class BoltHandshaker : IBoltHandshaker
                 .ReadAsync(responseBytes, 0, responseBytes.Length, cancellationToken)
                 .ConfigureAwait(false);
 
-            logger.Debug("S: [HANDSHAKE] Supported protocol version and range - {0}", responseBytes.ToHexString());
+            neo4JLogger.Debug("S: [HANDSHAKE] Supported protocol version and range - {0}", responseBytes.ToHexString());
 
             var protocolVersionAndRange = BoltProtocolFactory.UnpackAgreedVersion(responseBytes);
             var lowestVersion = new BoltProtocolVersion(protocolVersionAndRange.version.MajorVersion,
@@ -147,10 +147,10 @@ internal sealed class BoltHandshaker : IBoltHandshaker
 
     private static async Task<long> ParseCapabilityBitmask(
         ITcpSocketClient socketClient,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         CancellationToken cancellationToken)
     {
-        var bitmask = await ReadVariableLengthData(socketClient, logger, cancellationToken).ConfigureAwait(false);
+        var bitmask = await ReadVariableLengthData(socketClient, neo4JLogger, cancellationToken).ConfigureAwait(false);
         return bitmask.Value;
     }
 
@@ -165,7 +165,7 @@ internal sealed class BoltHandshaker : IBoltHandshaker
         ITcpSocketClient socketClient,
         BoltProtocolVersion selectedVersion,
         long capabilitiesBitMask,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         CancellationToken cancellationToken)
     {
         var versionData = PackStreamBitConverter.GetBytes(selectedVersion.PackToInt());
@@ -182,7 +182,7 @@ internal sealed class BoltHandshaker : IBoltHandshaker
 
         await socketClient.WriterStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-        logger.Debug("C: [HANDSHAKE] Selected version and capabilities {0}", byteData.ToHexString());
+        neo4JLogger.Debug("C: [HANDSHAKE] Selected version and capabilities {0}", byteData.ToHexString());
     }
 
     private static void CheckManifestVersion(BoltProtocolVersion version, Uri connectionUri)
@@ -196,18 +196,18 @@ internal sealed class BoltHandshaker : IBoltHandshaker
 
     public async Task<BoltProtocolVersion> DoHandshakeAsync(
         ITcpSocketClient socketClient,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         CancellationToken cancellationToken)
     {
         var data = BoltProtocolFactory.PackSupportedVersions();
         await socketClient.WriterStream.WriteAsync(data, 0, data.Length, cancellationToken).ConfigureAwait(false);
         await socketClient.WriterStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-        logger.Debug("C: [HANDSHAKE] Driver supported versions - {0}", data.ToHexString());
+        neo4JLogger.Debug("C: [HANDSHAKE] Driver supported versions - {0}", data.ToHexString());
 
         //if the server has not responded indicating a manifest handshake is in effect
         //then it has responded with a protocol version that the driver should use. 
-        var serverVersionResponse = await ParseProtocolVersionResponse(socketClient, logger, cancellationToken).ConfigureAwait(false);
+        var serverVersionResponse = await ParseProtocolVersionResponse(socketClient, neo4JLogger, cancellationToken).ConfigureAwait(false);
         if (!IsManifestSytleHandshake(serverVersionResponse.version))
         {
             return serverVersionResponse.version;
@@ -217,13 +217,13 @@ internal sealed class BoltHandshaker : IBoltHandshaker
 
         CheckManifestVersion(serverVersionResponse.version, socketClient.ConnectionUri);
         
-        var protocolVersions = await ParseSupportedProtocolVersions(socketClient, logger, cancellationToken).ConfigureAwait(false);
+        var protocolVersions = await ParseSupportedProtocolVersions(socketClient, neo4JLogger, cancellationToken).ConfigureAwait(false);
 
-        var capabilitiesBitMask = await ParseCapabilityBitmask(socketClient, logger, cancellationToken).ConfigureAwait(false);
+        var capabilitiesBitMask = await ParseCapabilityBitmask(socketClient, neo4JLogger, cancellationToken).ConfigureAwait(false);
         
         var selectedVersion = SelectProtocolVersion(protocolVersions);
 
-        await EncodeAndSendHandshakeResponseAsync(socketClient, selectedVersion, capabilitiesBitMask, logger, cancellationToken);
+        await EncodeAndSendHandshakeResponseAsync(socketClient, selectedVersion, capabilitiesBitMask, neo4JLogger, cancellationToken);
 
         return selectedVersion;
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -29,7 +29,7 @@ internal sealed class SocketClient : ISocketClient
     private const string MessagePattern = "C: {0}";
     private readonly IConnectionIoFactory _connectionIoFactory;
     private readonly IBoltHandshaker _handshaker;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly IPackStreamFactory _packstreamFactory;
     private readonly ITcpSocketClient _tcpSocketClient;
 
@@ -45,7 +45,7 @@ internal sealed class SocketClient : ISocketClient
     public SocketClient(
         Uri uri,
         DriverContext context,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         IConnectionIoFactory connectionIoFactory,
         IPackStreamFactory packstreamFactory = null,
         IBoltHandshaker boltHandshaker = null)
@@ -53,13 +53,13 @@ internal sealed class SocketClient : ISocketClient
         Context = context;
         Version = BoltProtocolVersion.Unknown;
         _uri = uri;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
 
         _packstreamFactory = packstreamFactory ?? PackStreamFactory.Default;
         _connectionIoFactory = connectionIoFactory ?? SocketClientIoFactory.Default;
         _handshaker = boltHandshaker ?? BoltHandshaker.Default;
 
-        _tcpSocketClient = _connectionIoFactory.TcpSocketClient(context, _logger);
+        _tcpSocketClient = _connectionIoFactory.TcpSocketClient(context, _neo4JLogger);
     }
 
     public DriverContext Context { get; }
@@ -71,15 +71,15 @@ internal sealed class SocketClient : ISocketClient
     {
         await _tcpSocketClient.ConnectAsync(_uri, cancellationToken).ConfigureAwait(false);
 
-        _logger.Debug($"~~ [CONNECT] {_uri}");
+        _neo4JLogger.Debug($"~~ [CONNECT] {_uri}");
 
         Version = await _handshaker
-            .DoHandshakeAsync(_tcpSocketClient, _logger, cancellationToken)
+            .DoHandshakeAsync(_tcpSocketClient, _neo4JLogger, cancellationToken)
             .ConfigureAwait(false);
 
         _format = _connectionIoFactory.Format(Version, Context);
-        _messageReader = _connectionIoFactory.MessageReader(_tcpSocketClient, Context, _logger);
-        (_chunkWriter, _messageWriter) = _connectionIoFactory.Writers(_tcpSocketClient, Context, _logger);
+        _messageReader = _connectionIoFactory.MessageReader(_tcpSocketClient, Context, _neo4JLogger);
+        (_chunkWriter, _messageWriter) = _connectionIoFactory.Writers(_tcpSocketClient, Context, _neo4JLogger);
         SetOpened();
     }
 
@@ -93,14 +93,14 @@ internal sealed class SocketClient : ISocketClient
             foreach (var message in messages)
             {
                 _messageWriter.Write(message, writer);
-                _logger.Debug(MessagePattern, message);
+                _neo4JLogger.Debug(MessagePattern, message);
             }
 
             await _chunkWriter.SendAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            _logger.Warn(ex, $"Unable to send message to server {_uri}, connection will be terminated. ({ex.Message})");
+            _neo4JLogger.Warn(ex, $"Unable to send message to server {_uri}, connection will be terminated. ({ex.Message})");
             await DisposeAsync().ConfigureAwait(false);
             throw;
         }
@@ -122,7 +122,7 @@ internal sealed class SocketClient : ISocketClient
         }
         catch (Exception ex)
         {
-            _logger.Error(
+            _neo4JLogger.Error(
                 ex,
                 $"Unable to read message from server {_uri}, connection will be terminated. ({ex.Message})");
             await DisposeAsync().ConfigureAwait(false);
@@ -136,7 +136,7 @@ internal sealed class SocketClient : ISocketClient
         }
         catch (ProtocolException exc)
         {
-            _logger.Warn(
+            _neo4JLogger.Warn(
                 exc,
                 "A bolt protocol error has occurred with server {0}, connection will be terminated.",
                 _uri.ToString());

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClientIoFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClientIoFactory.cs
@@ -20,15 +20,15 @@ namespace Neo4j.Driver.Internal.Connector;
 
 internal interface IConnectionIoFactory
 {
-    ITcpSocketClient TcpSocketClient(DriverContext context, ILogger logger);
+    ITcpSocketClient TcpSocketClient(DriverContext context, INeo4jLogger neo4JLogger);
     MessageFormat Format(BoltProtocolVersion version, DriverContext context);
 
     IMessageReader MessageReader(
         ITcpSocketClient client,
         DriverContext context,
-        ILogger logger);
+        INeo4jLogger neo4JLogger);
 
-    (IChunkWriter, IMessageWriter) Writers(ITcpSocketClient client, DriverContext context, ILogger logger);
+    (IChunkWriter, IMessageWriter) Writers(ITcpSocketClient client, DriverContext context, INeo4jLogger neo4JLogger);
 }
 
 internal sealed class SocketClientIoFactory : IConnectionIoFactory
@@ -39,9 +39,9 @@ internal sealed class SocketClientIoFactory : IConnectionIoFactory
     {
     }
 
-    public ITcpSocketClient TcpSocketClient(DriverContext context, ILogger logger)
+    public ITcpSocketClient TcpSocketClient(DriverContext context, INeo4jLogger neo4JLogger)
     {
-        return new TcpSocketClient(context, logger);
+        return new TcpSocketClient(context, neo4JLogger);
     }
 
     public MessageFormat Format(BoltProtocolVersion version, DriverContext context)
@@ -52,19 +52,19 @@ internal sealed class SocketClientIoFactory : IConnectionIoFactory
     public IMessageReader MessageReader(
         ITcpSocketClient client,
         DriverContext context,
-        ILogger logger)
+        INeo4jLogger neo4JLogger)
     {
         if (context.Config.MessageReaderConfig.DisablePipelinedMessageReader)
         {
-            return new MessageReader(new ChunkReader(client.ReaderStream), context, logger);
+            return new MessageReader(new ChunkReader(client.ReaderStream), context, neo4JLogger);
         }
 
         return new PipelinedMessageReader(client.ReaderStream, context);
     }
 
-    public (IChunkWriter, IMessageWriter) Writers(ITcpSocketClient client, DriverContext context, ILogger logger)
+    public (IChunkWriter, IMessageWriter) Writers(ITcpSocketClient client, DriverContext context, INeo4jLogger neo4JLogger)
     {
-        var chunkWriter = new ChunkWriter(client.WriterStream, context, logger);
+        var chunkWriter = new ChunkWriter(client.WriterStream, context, neo4JLogger);
         var messageWriter = new MessageWriter(chunkWriter);
         return (chunkWriter, messageWriter);
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -34,7 +34,7 @@ internal sealed class SocketConnection : IConnection
     private readonly ISocketClient _client;
     private readonly string _idPrefix;
 
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
 
     private readonly Queue<IRequestMessage> _messages = new();
     private readonly IBoltProtocolFactory _protocolFactory;
@@ -52,16 +52,16 @@ internal sealed class SocketConnection : IConnection
     {
         _idPrefix = $"conn-{uri.Host}:{uri.Port}-";
         _id = $"{_idPrefix}{UniqueIdGenerator.GetId()}";
-        _logger = context.Logger != NullLogger.Instance
-            ? new PrefixLogger(context.Logger, FormatPrefix(_id))
-            : context.Logger;
+        _neo4JLogger = context.Neo4JLogger != NullNeo4JLogger.Instance
+            ? new PrefixNeo4JLogger(context.Neo4JLogger, FormatPrefix(_id))
+            : context.Neo4JLogger;
 
-        _client = new SocketClient(uri, context, _logger, null);
+        _client = new SocketClient(uri, context, _neo4JLogger, null);
         Context = context;
         AuthToken = authToken;
         _serverInfo = new ServerInfo(uri);
 
-        _responsePipeline = new ResponsePipeline(_logger);
+        _responsePipeline = new ResponsePipeline(_neo4JLogger);
         AuthTokenManager = context.AuthTokenManager;
         _protocolFactory = BoltProtocolFactory.Default;
     }
@@ -70,7 +70,7 @@ internal sealed class SocketConnection : IConnection
     internal SocketConnection(
         ISocketClient socketClient,
         IAuthToken authToken,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         ServerInfo server,
         IResponsePipeline responsePipeline = null,
         IAuthTokenManager authTokenManager = null,
@@ -82,8 +82,8 @@ internal sealed class SocketConnection : IConnection
         _serverInfo = server ?? throw new ArgumentNullException(nameof(server));
         AuthTokenManager = authTokenManager;
         _id = $"{_idPrefix}{UniqueIdGenerator.GetId()}";
-        _logger = new PrefixLogger(logger, FormatPrefix(_id));
-        _responsePipeline = responsePipeline ?? new ResponsePipeline(logger);
+        _neo4JLogger = new PrefixNeo4JLogger(neo4JLogger, FormatPrefix(_id));
+        _responsePipeline = responsePipeline ?? new ResponsePipeline(neo4JLogger);
         _protocolFactory = protocolFactory ?? BoltProtocolFactory.Default;
         Context = context;
     }
@@ -286,14 +286,14 @@ internal sealed class SocketConnection : IConnection
 
     public void UpdateId(string newConnId)
     {
-        _logger.Debug(
+        _neo4JLogger.Debug(
             "Connection '{0}' renamed to '{1}'. The new name identifies the connection uniquely both on the client side and the server side.",
             _id,
             newConnId);
 
         _id = newConnId;
 
-        if (_logger is PrefixLogger logger)
+        if (_neo4JLogger is PrefixNeo4JLogger logger)
         {
             logger.Prefix = FormatPrefix(_id);
         }
@@ -330,7 +330,7 @@ internal sealed class SocketConnection : IConnection
             }
             catch (Exception e)
             {
-                _logger.Debug($"Failed to logout user before closing connection due to error: {e.Message}");
+                _neo4JLogger.Debug($"Failed to logout user before closing connection due to error: {e.Message}");
             }
 
             await _client.DisposeAsync().ConfigureAwait(false);
@@ -338,7 +338,7 @@ internal sealed class SocketConnection : IConnection
         catch (Exception e)
         {
             // only log the exception if failed to close connection
-            _logger.Warn(e, "Failed to close connection properly.");
+            _neo4JLogger.Warn(e, "Failed to close connection properly.");
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/TcpSocketClient.cs
@@ -30,15 +30,15 @@ namespace Neo4j.Driver.Internal.Connector;
 
 internal sealed class TcpSocketClient : ITcpSocketClient
 {
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     public Uri ConnectionUri { get; private set; }
 
     private Socket _client;
 
-    public TcpSocketClient(DriverContext driverContext, ILogger logger = null)
+    public TcpSocketClient(DriverContext driverContext, INeo4jLogger neo4JLogger = null)
     {
         DriverContext = driverContext;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
     }
 
     private DriverContext DriverContext { get; }
@@ -192,7 +192,7 @@ internal sealed class TcpSocketClient : ITcpSocketClient
         catch (Exception e)
         {
             var timeoutValue = DriverContext.Config.ConnectionTimeout;
-            _logger?.Error(
+            _neo4JLogger?.Error(
                 e,
                 $"Failed to close connect to the server {address}:{port}" +
                 $" after connection timed out {timeoutValue.TotalMilliseconds}ms.");
@@ -219,7 +219,7 @@ internal sealed class TcpSocketClient : ITcpSocketClient
     private SslStream CreateSecureStream(Uri uri)
     {
         var negotiator = DriverContext.Config.TlsNegotiator ??
-            new DefaultTlsNegotiator(_logger, DriverContext.EncryptionManager);
+            new DefaultTlsNegotiator(_neo4JLogger, DriverContext.EncryptionManager);
 
         return negotiator.NegotiateTls(uri, ReaderStream);
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
@@ -45,7 +45,7 @@ internal sealed class CertificateTrustManager : TrustManager
         {
             if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))
             {
-                Logger.Error(
+                Neo4JLogger.Error(
                     null,
                     $"{nameof(CertificateTrustManager)}: Certificate '{certificate.Subject}' does not match with host name '{uri.Host}'.");
 
@@ -55,7 +55,7 @@ internal sealed class CertificateTrustManager : TrustManager
 
         if (!CertHelper.CheckValidity(certificate, now))
         {
-            Logger.Error(
+            Neo4JLogger.Error(
                 null,
                 $"{nameof(CertificateTrustManager)}: Certificate '{certificate.Subject}' is not valid at the time of validity check '{now}'.");
 
@@ -72,7 +72,7 @@ internal sealed class CertificateTrustManager : TrustManager
 
     private X509Chain CreateChainAgainstStore(X509Certificate2 certificate)
     {
-        Logger.Info(
+        Neo4JLogger.Info(
             $"{nameof(CertificateTrustManager)}: Building chain against extra store certificate '{certificate.Subject}'.");
 
         // build chain against certificates passed, as some may not have been used when .net assessed trust.
@@ -88,7 +88,7 @@ internal sealed class CertificateTrustManager : TrustManager
     {
         if (chain.ChainStatus.Any(ShouldFailChain))
         {
-            Logger.Error(
+            Neo4JLogger.Error(
                 null,
                 $"{nameof(CertificateTrustManager)}: Unable to locate a certificate for {uri} in provided trusted certificates.");
 
@@ -99,14 +99,14 @@ internal sealed class CertificateTrustManager : TrustManager
         {
             if (CertHelper.FindCertificate(_trustedCertificates, chain.ChainElements[i].Certificate))
             {
-                Logger.Info(
+                Neo4JLogger.Info(
                     $"{nameof(CertificateTrustManager)}: Trusting {uri} with certificate '{certificate.Subject}'.");
 
                 return true;
             }
         }
 
-        Logger.Error(
+        Neo4JLogger.Error(
             null,
             $"{nameof(CertificateTrustManager)}: Unable to locate a certificate for {uri} in provided trusted certificates.");
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
@@ -51,7 +51,7 @@ internal class ChainTrustManager : TrustManager
         {
             if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))
             {
-                Logger.Error(
+                Neo4JLogger.Error(
                     null,
                     $"{GetType().Name}: Certificate '{certificate.Subject}' does not match with host name '{uri.Host}'.");
 
@@ -67,7 +67,7 @@ internal class ChainTrustManager : TrustManager
             result = BuildChain(certificate, chain.ChainPolicy.ExtraStore, out var newChain);
             if (!result)
             {
-                Logger.Error(
+                Neo4JLogger.Error(
                     null,
                     $"{GetType().Name}: Certificate '{certificate.Subject}' failed validation. Reason: {CertHelper.ChainStatusToText(newChain.ChainStatus)}");
             }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
@@ -38,7 +38,7 @@ internal sealed class InsecureTrustManager : TrustManager
         {
             if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))
             {
-                Logger.Error(
+                Neo4JLogger.Error(
                     null,
                     $"{GetType().Name}: Certificate '{certificate.Subject}' does not match with host name '{uri.Host}'.");
 
@@ -46,7 +46,7 @@ internal sealed class InsecureTrustManager : TrustManager
             }
         }
 
-        Logger.Info($"{GetType().Name}: Trusting {uri} with provided certificate '{certificate.Subject}'.");
+        Neo4JLogger.Info($"{GetType().Name}: Trusting {uri} with provided certificate '{certificate.Subject}'.");
         return true;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
@@ -43,7 +43,7 @@ internal sealed class PeerTrustManager : TrustManager
         {
             if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))
             {
-                Logger.Error(
+                Neo4JLogger.Error(
                     null,
                     $"{GetType().Name}: Certificate '{certificate.Subject}' does not match with host name '{uri.Host}'.");
 
@@ -53,7 +53,7 @@ internal sealed class PeerTrustManager : TrustManager
 
         if (!CertHelper.CheckValidity(certificate, now))
         {
-            Logger.Error(
+            Neo4JLogger.Error(
                 null,
                 $"{GetType().Name}: Certificate '{certificate.Subject}' is not valid at the time of validity check '{now}'.");
 
@@ -64,18 +64,18 @@ internal sealed class PeerTrustManager : TrustManager
         {
             if (CertHelper.FindCertificate(_location, StoreName.Disallowed, certificate))
             {
-                Logger.Error(
+                Neo4JLogger.Error(
                     null,
                     $"{GetType().Name}: Certificate '{certificate.Subject}' is found in '{_location}\\Disallowed` store.");
 
                 return false;
             }
 
-            Logger.Info($"{GetType().Name}: Trusting {uri} with certificate '{certificate.Subject}'.");
+            Neo4JLogger.Info($"{GetType().Name}: Trusting {uri} with certificate '{certificate.Subject}'.");
             return true;
         }
 
-        Logger.Error(
+        Neo4JLogger.Error(
             null,
             $"{GetType().Name}: Unable to locate a certificate for {uri} in '{_location}\\TrustedPeople` store.");
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -77,7 +77,7 @@ internal sealed class Driver : IInternalDriver
 
         var session = new AsyncSession(
             _connectionProvider,
-            Config.Logger,
+            Config.Neo4JLogger,
             _retryLogic,
             Config.FetchSize,
             sessionConfig,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DriverContext.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DriverContext.cs
@@ -40,7 +40,7 @@ internal sealed class DriverContext
             initialUri,
             config.NullableEncryptionLevel,
             config.TrustManager,
-            config.Logger);
+            config.Neo4JLogger);
 
         DriverBookmarkManager = new DefaultBookmarkManager(new BookmarkManagerConfig());
 
@@ -61,7 +61,7 @@ internal sealed class DriverContext
     public Config Config { get; }
 
     /// <summary>Shortcut to Config.Logger.</summary>
-    public ILogger Logger => Config.Logger;
+    public INeo4jLogger Neo4JLogger => Config.Neo4JLogger;
 
     public IAuthTokenManager AuthTokenManager { get; }
     public EncryptionManager EncryptionManager { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/EncryptionManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/EncryptionManager.cs
@@ -34,22 +34,22 @@ internal class EncryptionManager
         Uri uri,
         EncryptionLevel? level,
         TrustManager trustManager,
-        ILogger logger)
+        INeo4jLogger neo4JLogger)
     {
         var configured = level.HasValue || trustManager != null;
         if (configured)
         {
             AssertSimpleUriScheme(uri, level, trustManager);
-            return CreateFromConfig(level, trustManager, logger);
+            return CreateFromConfig(level, trustManager, neo4JLogger);
         }
 
-        return CreateFromUriScheme(uri, logger);
+        return CreateFromUriScheme(uri, neo4JLogger);
     }
 
-    private static EncryptionManager CreateFromUriScheme(Uri uri, ILogger logger)
+    private static EncryptionManager CreateFromUriScheme(Uri uri, INeo4jLogger neo4JLogger)
     {
         // let the uri scheme to decide
-        return Neo4jUri.ParseUriSchemeToEncryptionManager(uri, logger);
+        return Neo4jUri.ParseUriSchemeToEncryptionManager(uri, neo4JLogger);
     }
 
     private static void AssertSimpleUriScheme(Uri uri, EncryptionLevel? encryptionLevel, TrustManager trustManager)
@@ -65,18 +65,18 @@ internal class EncryptionManager
     public static EncryptionManager CreateFromConfig(
         EncryptionLevel? nullableLevel,
         TrustManager trustManager,
-        ILogger logger)
+        INeo4jLogger neo4JLogger)
     {
         var encrypted = ParseEncrypted(nullableLevel);
         if (encrypted && trustManager == null)
         {
-            return new EncryptionManager(true, CreateSecureTrustManager(logger));
+            return new EncryptionManager(true, CreateSecureTrustManager(neo4JLogger));
         }
 
-        if (trustManager != null && trustManager.Logger == null)
+        if (trustManager != null && trustManager.Neo4JLogger == null)
         {
             // likely to be true, as this is passed in by a user and logger is internal so we should set it.
-            trustManager.Logger = logger;
+            trustManager.Neo4JLogger = neo4JLogger;
         }
 
         return new EncryptionManager(encrypted, trustManager);
@@ -98,17 +98,17 @@ internal class EncryptionManager
         }
     }
 
-    public static TrustManager CreateSecureTrustManager(ILogger logger)
+    public static TrustManager CreateSecureTrustManager(INeo4jLogger neo4JLogger)
     {
         var trustManager = TrustManager.CreateChainTrust();
-        trustManager.Logger = logger;
+        trustManager.Neo4JLogger = neo4JLogger;
         return trustManager;
     }
 
-    public static TrustManager CreateInsecureTrustManager(ILogger logger)
+    public static TrustManager CreateInsecureTrustManager(INeo4jLogger neo4JLogger)
     {
         var trustManager = TrustManager.CreateInsecure();
-        trustManager.Logger = logger;
+        trustManager.Neo4JLogger = neo4JLogger;
         return trustManager;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/TaskExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/TaskExtensions.cs
@@ -48,7 +48,8 @@ internal static class TaskExtensions
         }
     }
 
-    public static async Task<T> Timeout<T>(this Task<T> task, TimeSpan timeout, CancellationToken cancellationToken)
+    public static async Task<T> Timeout<T>(this Task<T> task, TimeSpan timeout, CancellationToken cancellationToken,
+        Action onTimeout = null)
     {
         using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
@@ -64,6 +65,7 @@ internal static class TaskExtensions
 
             if (finished.IsCompleted && finished == delay)
             {
+                onTimeout?.Invoke();
                 throw new TimeoutException();
             }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkWriter.cs
@@ -37,7 +37,7 @@ internal sealed class ChunkWriter : Stream, IChunkWriter
     private readonly MemoryStream _chunkStream;
     private readonly int _defaultBufferSize;
     private readonly Stream _downStream;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly int _maxBufferSize;
     private long _dataPos = -1;
     private int _shrinkCounter;
@@ -45,7 +45,7 @@ internal sealed class ChunkWriter : Stream, IChunkWriter
     private long _startPos = -1;
 
     //TODO: ArrayPool avoid creating a new array for each chunk writer
-    public ChunkWriter(Stream downStream, DriverContext context, ILogger logger)
+    public ChunkWriter(Stream downStream, DriverContext context, INeo4jLogger neo4JLogger)
     {
         _downStream = downStream ?? throw new ArgumentNullException(nameof(downStream));
 
@@ -56,7 +56,7 @@ internal sealed class ChunkWriter : Stream, IChunkWriter
                 $"Property:{nameof(downStream.CanWrite)} is false but should be true");
         }
 
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _defaultBufferSize = context.Config.DefaultWriteBufferSize;
         _maxBufferSize = context.Config.MaxWriteBufferSize;
         _chunkStream = new MemoryStream(context.Config.DefaultWriteBufferSize);
@@ -154,7 +154,7 @@ internal sealed class ChunkWriter : Stream, IChunkWriter
         _chunkStream.SetLength(0);
         if (_chunkStream.Capacity > _maxBufferSize)
         {
-            _logger.Info(
+            _neo4JLogger.Info(
                 $@"Shrinking write buffers to the default write buffer size {
                     _defaultBufferSize
                 } since its size reached {
@@ -173,10 +173,10 @@ internal sealed class ChunkWriter : Stream, IChunkWriter
 
     private void LogStream(MemoryStream stream)
     {
-        if (_logger.IsTraceEnabled())
+        if (_neo4JLogger.IsTraceEnabled())
         {
             var buffer = stream.ToArray();
-            _logger.Trace("C: {0}", buffer.ToHexString(0, buffer.Length));
+            _neo4JLogger.Trace("C: {0}", buffer.ToHexString(0, buffer.Length));
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
@@ -26,17 +26,17 @@ internal sealed class MessageReader : IMessageReader
 {
     private readonly IChunkReader _chunkReader;
     private readonly int _defaultBufferSize;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly int _maxBufferSize;
     private readonly ByteBuffers _readerBuffers;
     private int _shrinkCounter;
 
-    public MessageReader(IChunkReader chunkReader, DriverContext driverContext, ILogger logger)
+    public MessageReader(IChunkReader chunkReader, DriverContext driverContext, INeo4jLogger neo4JLogger)
     {
         _chunkReader = chunkReader;
         _defaultBufferSize = driverContext.Config.DefaultReadBufferSize;
         _maxBufferSize = driverContext.Config.MaxReadBufferSize;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         BufferStream = new MemoryStream(driverContext.Config.MaxReadBufferSize);
         _readerBuffers = new ByteBuffers();
     }
@@ -84,7 +84,7 @@ internal sealed class MessageReader : IMessageReader
             return;
         }
 
-        _logger.Info(
+        _neo4JLogger.Info(
             $@"Shrinking read buffers to the default read buffer size {
                 _defaultBufferSize
             } since its size reached {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/DriverLoggerUtil.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/DriverLoggerUtil.cs
@@ -20,7 +20,7 @@ namespace Neo4j.Driver.Internal.Logging;
 
 internal static class DriverLoggerUtil
 {
-    public static async Task TryExecuteAsync(ILogger logger, Func<Task> func, string message = null)
+    public static async Task TryExecuteAsync(INeo4jLogger neo4JLogger, Func<Task> func, string message = null)
     {
         try
         {
@@ -28,12 +28,12 @@ internal static class DriverLoggerUtil
         }
         catch (Exception ex)
         {
-            logger.Error(ex, message);
+            neo4JLogger.Error(ex, message);
             throw;
         }
     }
 
-    public static async Task<T> TryExecuteAsync<T>(ILogger logger, Func<Task<T>> func, string message = null)
+    public static async Task<T> TryExecuteAsync<T>(INeo4jLogger neo4JLogger, Func<Task<T>> func, string message = null)
     {
         try
         {
@@ -41,7 +41,7 @@ internal static class DriverLoggerUtil
         }
         catch (Exception ex)
         {
-            logger.Error(ex, message);
+            neo4JLogger.Error(ex, message);
             throw;
         }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/NullNeo4JLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/NullNeo4JLogger.cs
@@ -17,55 +17,41 @@ using System;
 
 namespace Neo4j.Driver.Internal.Logging;
 
-internal abstract class ReformattedLogger : ILogger
+internal class NullNeo4JLogger : INeo4jLogger
 {
-    private readonly ILogger _delegate;
+    public static readonly NullNeo4JLogger Instance = new();
 
-    protected ReformattedLogger(ILogger logger)
+    private NullNeo4JLogger()
     {
-        _delegate = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public void Error(Exception cause, string message, params object[] args)
     {
-        _delegate.Error(cause, Reformat(message), args);
     }
 
     public void Warn(Exception cause, string message, params object[] args)
     {
-        _delegate.Warn(cause, Reformat(message), args);
     }
 
     public void Info(string message, params object[] args)
     {
-        _delegate.Info(Reformat(message), args);
     }
 
     public void Debug(string message, params object[] args)
     {
-        if (IsDebugEnabled())
-        {
-            _delegate.Debug(Reformat(message), args);
-        }
     }
 
     public void Trace(string message, params object[] args)
     {
-        if (IsTraceEnabled())
-        {
-            _delegate.Trace(Reformat(message), args);
-        }
     }
 
     public bool IsTraceEnabled()
     {
-        return _delegate.IsTraceEnabled();
+        return false;
     }
 
     public bool IsDebugEnabled()
     {
-        return _delegate != null && _delegate.IsDebugEnabled();
+        return false;
     }
-
-    protected abstract string Reformat(string message);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/PrefixNeo4JLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/PrefixNeo4JLogger.cs
@@ -15,9 +15,9 @@
 
 namespace Neo4j.Driver.Internal.Logging;
 
-internal class PrefixLogger : ReformattedLogger
+internal class PrefixNeo4JLogger : ReformattedNeo4JLogger
 {
-    public PrefixLogger(ILogger logger, string prefix = null) : base(logger)
+    public PrefixNeo4JLogger(INeo4jLogger neo4JLogger, string prefix = null) : base(neo4JLogger)
     {
         Prefix = prefix;
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Logging/ReformattedNeo4JLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Logging/ReformattedNeo4JLogger.cs
@@ -17,41 +17,55 @@ using System;
 
 namespace Neo4j.Driver.Internal.Logging;
 
-internal class NullLogger : ILogger
+internal abstract class ReformattedNeo4JLogger : INeo4jLogger
 {
-    public static readonly NullLogger Instance = new();
+    private readonly INeo4jLogger _delegate;
 
-    private NullLogger()
+    protected ReformattedNeo4JLogger(INeo4jLogger neo4JLogger)
     {
+        _delegate = neo4JLogger ?? throw new ArgumentNullException(nameof(neo4JLogger));
     }
 
     public void Error(Exception cause, string message, params object[] args)
     {
+        _delegate.Error(cause, Reformat(message), args);
     }
 
     public void Warn(Exception cause, string message, params object[] args)
     {
+        _delegate.Warn(cause, Reformat(message), args);
     }
 
     public void Info(string message, params object[] args)
     {
+        _delegate.Info(Reformat(message), args);
     }
 
     public void Debug(string message, params object[] args)
     {
+        if (IsDebugEnabled())
+        {
+            _delegate.Debug(Reformat(message), args);
+        }
     }
 
     public void Trace(string message, params object[] args)
     {
+        if (IsTraceEnabled())
+        {
+            _delegate.Trace(Reformat(message), args);
+        }
     }
 
     public bool IsTraceEnabled()
     {
-        return false;
+        return _delegate.IsTraceEnabled();
     }
 
     public bool IsDebugEnabled()
     {
-        return false;
+        return _delegate != null && _delegate.IsDebugEnabled();
     }
+
+    protected abstract string Reformat(string message);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/ResponsePipeline.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/ResponsePipeline.cs
@@ -25,14 +25,14 @@ internal sealed class ResponsePipeline : IResponsePipeline
     private const string MessagePattern = "S: {0}";
 
     private readonly ConcurrentQueue<IResponseHandler> _handlers;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
 
     private IResponsePipelineError _error;
 
-    public ResponsePipeline(ILogger logger)
+    public ResponsePipeline(INeo4jLogger neo4JLogger)
     {
         _handlers = new ConcurrentQueue<IResponseHandler>();
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _error = null;
     }
 
@@ -124,33 +124,33 @@ internal sealed class ResponsePipeline : IResponsePipeline
 
     private void LogSuccess(IDictionary<string, object> meta)
     {
-        if (_logger.IsDebugEnabled())
+        if (_neo4JLogger.IsDebugEnabled())
         {
-            _logger.Debug(MessagePattern, new SuccessMessage(meta));
+            _neo4JLogger.Debug(MessagePattern, new SuccessMessage(meta));
         }
     }
 
     private void LogRecord(object[] fields)
     {
-        if (_logger.IsDebugEnabled())
+        if (_neo4JLogger.IsDebugEnabled())
         {
-            _logger.Debug(MessagePattern, new RecordMessage(fields));
+            _neo4JLogger.Debug(MessagePattern, new RecordMessage(fields));
         }
     }
 
     private void LogFailure(string code, string message)
     {
-        if (_logger.IsDebugEnabled())
+        if (_neo4JLogger.IsDebugEnabled())
         {
-            _logger.Debug(MessagePattern, new FailureMessage(code, message));
+            _neo4JLogger.Debug(MessagePattern, new FailureMessage(code, message));
         }
     }
 
     private void LogIgnored()
     {
-        if (_logger.IsDebugEnabled())
+        if (_neo4JLogger.IsDebugEnabled())
         {
-            _logger.Debug(MessagePattern, IgnoredMessage.Instance);
+            _neo4JLogger.Debug(MessagePattern, IgnoredMessage.Instance);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/RouteResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/RouteResponseHandler.cs
@@ -48,7 +48,7 @@ internal sealed class RouteResponseHandler : MetadataCollectingResponseHandler
         if(_isDefaultRequest && metadata?["rt"] is IDictionary<string, object> rt && rt.TryGetValue("db", out var db))
         {
             var dbName = (string) db;
-            _sessionConfig?.DriverContext?.Logger?.Debug($"Caching database name '{dbName}' for key '{_cacheKey}'");
+            _sessionConfig?.DriverContext?.Neo4JLogger?.Debug($"Caching database name '{dbName}' for key '{_cacheKey}'");
             _homeDbCache.AddOrUpdate(_cacheKey, dbName);
             _sessionConfig?.PinDatabase(dbName);
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/BeginResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/BeginResponseHandler.cs
@@ -46,7 +46,7 @@ internal sealed class BeginResponseHandler : MetadataCollectingResponseHandler
         var dbInfo = GetMetadata<DatabaseInfoCollector, IDatabaseInfo>();
         if (_isDefaultDatabase && _homeDbCache != null && dbInfo?.Name != null)
         {
-            _sessionConfig.DriverContext.Logger?.Debug(
+            _sessionConfig.DriverContext.Neo4JLogger?.Debug(
                 $"Caching database name '{dbInfo.Name}' for key '{_cacheKey}'");
 
             _homeDbCache.AddOrUpdate(_cacheKey, dbInfo.Name);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/RunResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/V4/RunResponseHandler.cs
@@ -66,7 +66,7 @@ internal sealed class RunResponseHandler : MetadataCollectingResponseHandler
         var dbInfo = GetMetadata<DatabaseInfoCollector, IDatabaseInfo>();
         if (_isDefaultDatabase && _homeDbCache != null && dbInfo?.Name != null)
         {
-            _sessionConfig.DriverContext.Logger?.Debug($"Caching database name '{dbInfo.Name}' for key '{_cacheKey}'");
+            _sessionConfig.DriverContext.Neo4JLogger?.Debug($"Caching database name '{dbInfo.Name}' for key '{_cacheKey}'");
             _homeDbCache.AddOrUpdate(_cacheKey, dbInfo.Name);
             _sessionConfig?.PinDatabase(dbInfo.Name);
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LeastConnectedLoadBalancingStrategy.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LeastConnectedLoadBalancingStrategy.cs
@@ -21,14 +21,14 @@ namespace Neo4j.Driver.Internal.Routing;
 internal class LeastConnectedLoadBalancingStrategy : ILoadBalancingStrategy
 {
     private readonly IClusterConnectionPool _connectionPool;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly RoundRobinArrayIndex _readersIndex = new();
     private readonly RoundRobinArrayIndex _writersIndex = new();
 
-    public LeastConnectedLoadBalancingStrategy(IClusterConnectionPool connectionPool, ILogger logger)
+    public LeastConnectedLoadBalancingStrategy(IClusterConnectionPool connectionPool, INeo4jLogger neo4JLogger)
     {
         _connectionPool = connectionPool;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
     }
 
     public Uri SelectReader(IList<Uri> knownReaders, string forDatabase, string cachedDatabase = null)
@@ -99,9 +99,9 @@ internal class LeastConnectedLoadBalancingStrategy : ILoadBalancingStrategy
 
     private void LogDebug(string message)
     {
-        if (_logger.IsDebugEnabled())
+        if (_neo4JLogger.IsDebugEnabled())
         {
-            _logger.Debug(message);
+            _neo4JLogger.Debug(message);
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -318,7 +318,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
                 return conn;
             }
 
-            //else  connection already removed by clusterConnection onError method
+            break;
         }
 
         throw new SessionExpiredException($"Failed to connect to any {mode.ToString().ToLower()} server.");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -50,7 +50,12 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
 
         _neo4JLogger = driverContext.Neo4JLogger;
         _initialServerAddressProvider = new InitialServerAddressProvider(parsedUri, driverContext.Config.Resolver);
-        _routingTableManager = new RoutingTableManager(_initialServerAddressProvider, this, DriverContext, _neo4JLogger);
+        _routingTableManager = new RoutingTableManager(
+            _initialServerAddressProvider,
+            this,
+            DriverContext,
+            _neo4JLogger);
+
         _loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(
             _clusterConnectionPool,
             _neo4JLogger);
@@ -98,8 +103,9 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         Bookmarks bookmarks,
         bool forceAuth)
     {
-        return await AcquireConnectionInternalAsync(mode, database, sessionConfig, bookmarks, forceAuth)
-            .Timeout(DriverContext.Config.ConnectionAcquisitionTimeout, CancellationToken.None)
+        var cts = new CancellationTokenSource();
+        return await AcquireConnectionInternalAsync(mode, database, sessionConfig, bookmarks, forceAuth, cts.Token)
+            .Timeout(DriverContext.Config.ConnectionAcquisitionTimeout, cts.Token, () => cts.Cancel())
             .ConfigureAwait(false);
     }
 
@@ -108,7 +114,8 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         string database,
         SessionConfig sessionConfig,
         Bookmarks bookmarks,
-        bool forceAuth)
+        bool forceAuth,
+        CancellationToken cancellationToken = default)
     {
         if (IsClosed)
         {
@@ -118,15 +125,17 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         }
 
         _neo4JLogger.Debug($"LoadBalancer - Acquiring connection for '{database}'");
-        var conn = await AcquireConnectionAsync(mode, database, sessionConfig, bookmarks, forceAuth)
+        var conn = await AcquireConnectionAsync(mode, database, sessionConfig, bookmarks, forceAuth, cancellationToken)
             .ConfigureAwait(false);
 
         //If a non ssr connection is detected then the connection is not used and returned to the pool. Connection
         //acquisition is then repeated with the cache not being used.
         if (_clusterConnectionPool.ConnectionCausesCacheDisable(conn))
         {
-            _neo4JLogger.Debug($"LoadBalancer - Mixed cluster detected, some connections have no SSR. Re-acquiring " +
+            _neo4JLogger.Debug(
+                $"LoadBalancer - Mixed cluster detected, some connections have no SSR. Re-acquiring " +
                 $"connection without homeDB cache");
+
             await conn.CloseAsync().ConfigureAwait(false);
             conn = await AcquireConnectionAsync(mode, database, sessionConfig, bookmarks, forceAuth)
                 .ConfigureAwait(false);
@@ -250,7 +259,8 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         string database,
         SessionConfig sessionConfig,
         Bookmarks bookmarks,
-        bool forceAuth)
+        bool forceAuth,
+        CancellationToken cancellationToken = default)
     {
         var cachedDatabaseUsed = false;
         var databaseForRouting = sessionConfig?.Database ?? database;
@@ -318,7 +328,10 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
                 return conn;
             }
 
-            break;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
         }
 
         throw new SessionExpiredException($"Failed to connect to any {mode.ToString().ToLower()} server.");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -31,7 +31,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
     private readonly IClusterConnectionPool _clusterConnectionPool;
     private readonly IInitialServerAddressProvider _initialServerAddressProvider;
     private readonly ILoadBalancingStrategy _loadBalancingStrategy;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
     private readonly IRoutingTableManager _routingTableManager;
 
     private int _closedMarker;
@@ -48,12 +48,12 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
             connectionFactory,
             DriverContext);
 
-        _logger = driverContext.Logger;
+        _neo4JLogger = driverContext.Neo4JLogger;
         _initialServerAddressProvider = new InitialServerAddressProvider(parsedUri, driverContext.Config.Resolver);
-        _routingTableManager = new RoutingTableManager(_initialServerAddressProvider, this, DriverContext, _logger);
+        _routingTableManager = new RoutingTableManager(_initialServerAddressProvider, this, DriverContext, _neo4JLogger);
         _loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(
             _clusterConnectionPool,
-            _logger);
+            _neo4JLogger);
     }
 
     /// <summary>TEST ONLY.</summary>
@@ -66,12 +66,12 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         DriverContext driverContext = null)
     {
         DriverContext = driverContext;
-        _logger = NullLogger.Instance;
+        _neo4JLogger = NullNeo4JLogger.Instance;
         _clusterConnectionPool = clusterConnPool;
         _routingTableManager = routingTableManager;
         _loadBalancingStrategy = new LeastConnectedLoadBalancingStrategy(
             clusterConnPool,
-            _logger);
+            _neo4JLogger);
     }
 
     private bool IsClosed => _closedMarker > 0;
@@ -117,7 +117,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
                 "Failed to acquire a new connection as the driver has already been disposed.");
         }
 
-        _logger.Debug($"LoadBalancer - Acquiring connection for '{database}'");
+        _neo4JLogger.Debug($"LoadBalancer - Acquiring connection for '{database}'");
         var conn = await AcquireConnectionAsync(mode, database, sessionConfig, bookmarks, forceAuth)
             .ConfigureAwait(false);
 
@@ -125,7 +125,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         //acquisition is then repeated with the cache not being used.
         if (_clusterConnectionPool.ConnectionCausesCacheDisable(conn))
         {
-            _logger.Debug($"LoadBalancer - Mixed cluster detected, some connections have no SSR. Re-acquiring " +
+            _neo4JLogger.Debug($"LoadBalancer - Mixed cluster detected, some connections have no SSR. Re-acquiring " +
                 $"connection without homeDB cache");
             await conn.CloseAsync().ConfigureAwait(false);
             conn = await AcquireConnectionAsync(mode, database, sessionConfig, bookmarks, forceAuth)
@@ -199,7 +199,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
 
     public Task OnConnectionErrorAsync(Uri uri, string database, Exception e)
     {
-        _logger.Info($"Server at {uri} is no longer available due to error: {e.Message}.");
+        _neo4JLogger.Info($"Server at {uri} is no longer available due to error: {e.Message}.");
         _routingTableManager.ForgetServer(uri, database);
         return _clusterConnectionPool.DeactivateAsync(uri);
     }
@@ -258,16 +258,16 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
 
         if (string.IsNullOrWhiteSpace(databaseForRouting) && _clusterConnectionPool.CanUseHomeDbCache())
         {
-            _logger.Debug($"Checking cached home database for {cacheKey}");
+            _neo4JLogger.Debug($"Checking cached home database for {cacheKey}");
             cachedDatabaseUsed = DriverContext.HomeDbCache.TryGetCached(cacheKey, out databaseForRouting);
 
             if (cachedDatabaseUsed)
             {
-                _logger.Debug($"Using cached home database {databaseForRouting} for {cacheKey}");
+                _neo4JLogger.Debug($"Using cached home database {databaseForRouting} for {cacheKey}");
             }
             else
             {
-                _logger.Debug($"No cached home database found for {cacheKey}");
+                _neo4JLogger.Debug($"No cached home database found for {cacheKey}");
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/RoutingTableManager.cs
@@ -27,7 +27,7 @@ internal class RoutingTableManager : IRoutingTableManager
     private readonly IDiscovery _discovery;
     private readonly DriverContext _driverContext;
     private readonly IInitialServerAddressProvider _initialServerAddressProvider;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
 
     private readonly IClusterConnectionPoolManager _poolManager;
 
@@ -40,13 +40,13 @@ internal class RoutingTableManager : IRoutingTableManager
         IInitialServerAddressProvider initialServerAddressProvider,
         IClusterConnectionPoolManager poolManager,
         DriverContext driverContext,
-        ILogger logger)
+        INeo4jLogger neo4JLogger)
     {
         _initialServerAddressProvider = initialServerAddressProvider;
         _discovery = new ClusterDiscovery();
         _poolManager = poolManager;
         _driverContext = driverContext;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         // Default value.
         _routingTablePurgeDelay = TimeSpan.FromSeconds(30);
     }
@@ -56,14 +56,14 @@ internal class RoutingTableManager : IRoutingTableManager
         IInitialServerAddressProvider initialServerAddressProvider,
         IDiscovery discovery,
         IClusterConnectionPoolManager poolManager,
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         TimeSpan routingTablePurgeDelay,
         params IRoutingTable[] routingTables)
     {
         _initialServerAddressProvider = initialServerAddressProvider;
         _discovery = discovery;
         _poolManager = poolManager;
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _routingTablePurgeDelay = routingTablePurgeDelay;
 
         foreach (var routingTable in routingTables)
@@ -198,7 +198,7 @@ internal class RoutingTableManager : IRoutingTableManager
 
         PurgeAged();
 
-        _logger.Info("Routing table is updated => {0}", newRoutingTable);
+        _neo4JLogger.Info("Routing table is updated => {0}", newRoutingTable);
     }
 
     private void PurgeAged()
@@ -232,7 +232,7 @@ internal class RoutingTableManager : IRoutingTableManager
             throw new ArgumentNullException(nameof(database));
         }
 
-        _logger.Debug("Updating routing table for database '{0}'.", database);
+        _neo4JLogger.Debug("Updating routing table for database '{0}'.", database);
 
         var existingTable = RoutingTableFor(database);
         if (existingTable == null)
@@ -335,7 +335,7 @@ internal class RoutingTableManager : IRoutingTableManager
                             return newRoutingTable;
                         }
 
-                        _logger.Debug(
+                        _neo4JLogger.Debug(
                             "Skipping stale routing table received from server '{0}' for database '{1}'",
                             router,
                             database);
@@ -356,16 +356,16 @@ internal class RoutingTableManager : IRoutingTableManager
                     var code = ne.Code;
                     if (failfast)
                     {
-                        _logger.Error(ex, logMsg, router, database, code);
+                        _neo4JLogger.Error(ex, logMsg, router, database, code);
                     }
                     else
                     {
-                        _logger.Warn(ex, logMsg, router, database, code);
+                        _neo4JLogger.Warn(ex, logMsg, router, database, code);
                     }
                 }
                 else
                 {
-                    _logger.Warn(ex, logMsg, router, database);
+                    _neo4JLogger.Warn(ex, logMsg, router, database);
                 }
 
                 if (failfast)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/Neo4jUri.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/Neo4jUri.cs
@@ -62,7 +62,7 @@ internal static class Neo4jUri
         }
     }
 
-    public static EncryptionManager ParseUriSchemeToEncryptionManager(Uri uri, ILogger logger)
+    public static EncryptionManager ParseUriSchemeToEncryptionManager(Uri uri, INeo4jLogger neo4JLogger)
     {
         var scheme = uri.Scheme.ToLower();
         switch (scheme)
@@ -75,11 +75,11 @@ internal static class Neo4jUri
             case "bolt+s":
             case "neo4j+s":
                 // encryption with chain trust
-                return new EncryptionManager(true, EncryptionManager.CreateSecureTrustManager(logger));
+                return new EncryptionManager(true, EncryptionManager.CreateSecureTrustManager(neo4JLogger));
 
             case "bolt+ssc":
             case "neo4j+ssc":
-                return new EncryptionManager(true, EncryptionManager.CreateInsecureTrustManager(logger));
+                return new EncryptionManager(true, EncryptionManager.CreateInsecureTrustManager(neo4JLogger));
 
             default:
                 throw new NotSupportedException($"Unsupported URI scheme: {scheme}");

--- a/Neo4j.Driver/Neo4j.Driver/Public/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Config.cs
@@ -36,7 +36,7 @@ namespace Neo4j.Driver;
 ///     <item><see cref="ConnectionAcquisitionTimeout"/> : <c>1mins</c> </item>
 ///     <item><see cref="ConnectionIdleTimeout"/>: <see cref="InfiniteInterval"/></item>
 ///     <item><see cref="MaxConnectionLifetime"/>: <c>1h</c></item> <br></br>
-///     <item><see cref="Logger"/> : <c>logs nothing.</c></item>
+///     <item><see cref="Neo4JLogger"/> : <c>logs nothing.</c></item>
 ///     <item><see cref="MaxTransactionRetryTime"/>: <c>30s</c></item> <br></br>
 ///     <item><see cref="DefaultReadBufferSize"/> : <c>32K</c> </item>
 ///     <item><see cref="MaxReadBufferSize"/> : <c>128K</c> </item>
@@ -77,8 +77,8 @@ public class Config
     /// <summary>Specifies which <see cref="TrustManager"/> implementation should be used while establishing trust via TLS.</summary>
     public TrustManager TrustManager { get; internal set; }
 
-    /// <summary>The <see cref="ILogger"/> instance to be used to receive all logs produced by this driver.</summary>
-    public ILogger Logger { get; internal set; } = NullLogger.Instance;
+    /// <summary>The <see cref="INeo4jLogger"/> instance to be used to receive all logs produced by this driver.</summary>
+    public INeo4jLogger Neo4JLogger { get; internal set; } = NullNeo4JLogger.Instance;
 
     /// <summary>The maximum transaction retry timeout.</summary>
     public TimeSpan MaxTransactionRetryTime { get; internal set; } = TimeSpan.FromSeconds(30);

--- a/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
@@ -71,12 +71,12 @@ public sealed class ConfigBuilder
         return this;
     }
 
-    /// <summary>Sets the <see cref="Config"/> to use a given <see cref="ILogger"/> instance.</summary>
-    /// <param name="logger">The <see cref="ILogger"/> instance to use, if <c>null</c> no logging will occur.</param>
+    /// <summary>Sets the <see cref="Config"/> to use a given <see cref="INeo4jLogger"/> instance.</summary>
+    /// <param name="neo4JLogger">The <see cref="INeo4jLogger"/> instance to use, if <c>null</c> no logging will occur.</param>
     /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
-    public ConfigBuilder WithLogger(ILogger logger)
+    public ConfigBuilder WithLogger(INeo4jLogger neo4JLogger)
     {
-        _config.Logger = logger ?? NullLogger.Instance;
+        _config.Neo4JLogger = neo4JLogger ?? NullNeo4JLogger.Instance;
         return this;
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/GraphDatabase.cs
@@ -264,7 +264,7 @@ public static class GraphDatabase
                 connectionFactory,
                 context);
 
-        var retryLogic = new AsyncRetryLogic(context.Config.MaxTransactionRetryTime, context.Config.Logger);
+        var retryLogic = new AsyncRetryLogic(context.Config.MaxTransactionRetryTime, context.Config.Neo4JLogger);
         return new Internal.Driver(
             parsedUri,
             connectionProvider,

--- a/Neo4j.Driver/Neo4j.Driver/Public/INeo4jLogger.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/INeo4jLogger.cs
@@ -18,15 +18,16 @@ using System;
 namespace Neo4j.Driver;
 
 /// <summary>
-/// The new <see cref="ILogger"/> differs from the legacy one in the message format the logging methods are accepting. In
-/// <see cref="ILogger"/>, each logging method accepts a message which specifies how the message would be formatted and one
+/// The new <see cref="INeo4jLogger"/> differs from the legacy one in the message format the logging methods are accepting. In
+/// <see cref="INeo4jLogger"/>, each logging method accepts a message which specifies how the message would be formatted and one
 /// or many arguments that are used to replace placeholders in the message string. The following example shows a simplified
-/// version of how the <see cref="ILogger"/> is used in this driver:
+/// version of how the <see cref="INeo4jLogger"/> is used in this driver:
 /// <code>
 /// logger.Info("Hello {0}, {1}", "Alice", "Bob");
 /// </code>
 /// </summary>
-public interface ILogger
+// ReSharper disable once InconsistentNaming
+public interface INeo4jLogger
 {
     /// <summary>Logs an error.</summary>
     /// <param name="cause">The <see cref="Exception"/> that causes the error. This value could be null if not applied.</param>

--- a/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TransactionConfig.cs
@@ -113,13 +113,13 @@ public sealed class TransactionConfig
 public sealed class TransactionConfigBuilder
 {
     private readonly TransactionConfig _config;
-    private readonly ILogger _logger;
+    private readonly INeo4jLogger _neo4JLogger;
 
     internal TransactionConfigBuilder(
-        ILogger logger,
+        INeo4jLogger neo4JLogger,
         TransactionConfig config)
     {
-        _logger = logger;
+        _neo4JLogger = neo4JLogger;
         _config = config;
     }
 
@@ -163,7 +163,7 @@ public sealed class TransactionConfigBuilder
         {
             var timeSpan = TimeSpan.FromMilliseconds(Math.Ceiling(timeout.Value.TotalMilliseconds));
             _config.Timeout = timeSpan;
-            _logger.Info(
+            _neo4JLogger.Info(
                 $"Transaction timeout {timeout} contains sub-millisecond precision and will be rounded up to {timeSpan}.");
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
@@ -27,7 +27,7 @@ namespace Neo4j.Driver;
 /// </summary>
 public abstract class TrustManager
 {
-    internal ILogger Logger { get; set; }
+    internal INeo4jLogger Neo4JLogger { get; set; }
 
     /// <summary>Returns whether the endpoint should be trusted or not.</summary>
     /// <param name="uri">The uri towards which we're establishing connection</param>


### PR DESCRIPTION
Closes DRIVERS-93 This change renames the ILogger interface to INeo4jLogger so that when integration with Microsoft's standard logging framework is implemented, there will not be any ambiguity. I also renamed all the classes and variables so that they'll be clear too.

There is no change of functionality in this change, just the rename.