### PR TITLE
Fix concurrency error with MappingExtensions.AsType() - backport to 5.0 branch

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingConcurrencyTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/MappingConcurrencyTests.cs
@@ -13,9 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
 using System.Threading.Tasks;
+using Neo4j.Driver.Internal;
 using Neo4j.Driver.Internal.Mapping;
 using Xunit;
 using Xunit.Abstractions;
@@ -65,5 +70,66 @@ public class MappingConcurrencyTests(ITestOutputHelper testOutputHelper)
         await Task.WhenAll(threads.Select(t => t.Start()));
 
         testOutputHelper.WriteLine("All threads finished.");
+    }
+
+    [Fact]
+    public async Task MapMethods_ShouldBeThreadSafe()
+    {
+        var testObjects = CreateMultiTypedArray(100);
+
+        const int numberOfThreads = 4;
+        var tasks = new List<Task>(numberOfThreads);
+        var resetEvent = new ManualResetEventSlim(false);
+
+        for (var i = 0; i < numberOfThreads; i++)
+        {
+            tasks.Add(
+                Task.Run(() =>
+                {
+                    resetEvent.Wait(); // Wait for the signal to start
+                    for (var j = 0; j < 100; j++)
+                    {
+                        foreach (var obj in testObjects)
+                        {
+                            obj.AsType(obj.GetType());
+                        }
+
+                        MappingExtensions.ResetAsMethods();
+                    }
+                }));
+        }
+
+        resetEvent.Set(); // Signal all tasks to start
+        await Task.WhenAll(tasks);
+    }
+
+    private static object[] CreateMultiTypedArray(int numValues)
+    {
+        return Enumerable.Range(0, numValues)
+            .Select(_ => GetUniquelyTypedValue())
+            .ToArray();
+    }
+
+    private static object GetUniquelyTypedValue()
+    {
+        var typeName = $"Type_{Guid.NewGuid()}";
+
+        var asmName = new AssemblyName($"Asm_{Guid.NewGuid()}");
+        var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            asmName,
+            AssemblyBuilderAccess.Run);
+
+        var moduleBuilder = asmBuilder.DefineDynamicModule($"Module{Guid.NewGuid()}");
+
+        // Create a completely empty public class
+        var typeBuilder = moduleBuilder.DefineType(
+            typeName,
+            TypeAttributes.Public | TypeAttributes.Class);
+
+        Type emittedType = typeBuilder.CreateTypeInfo();
+
+        // Instantiate it
+        var instance = Activator.CreateInstance(emittedType);
+        return instance;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Neo4j.Driver.Tests.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0"/>
         <PackageReference Include="Moq" Version="4.20.69"/>
         <PackageReference Include="Moq.AutoMock" Version="3.5.0"/>
-        <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageReference Include="System.Linq.Async" Version="7.0.0" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0"/>
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23"/>
         <PackageReference Include="xunit" Version="$(XunitVersion)"/>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/MappingExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/MappingExtensions.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Reflection;
 using Neo4j.Driver.Mapping;
 
@@ -25,15 +25,16 @@ internal static class MappingExtensions
     private static readonly MethodInfo AsGenericMethod =
         typeof(ValueExtensions).GetMethod(nameof(ValueExtensions.As), [typeof(object)]);
 
-    private static readonly Dictionary<Type, MethodInfo> AsMethods = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo> AsMethods = new();
+    
+    internal static void ResetAsMethods()
+    {
+        AsMethods.Clear();
+    }
 
     public static object AsType(this object obj, Type type)
     {
-        if (!AsMethods.TryGetValue(type, out var asMethod))
-        {
-            asMethod = AsGenericMethod.MakeGenericMethod(type);
-            AsMethods[type] = asMethod;
-        }
+        var asMethod = AsMethods.GetOrAdd(type, t => AsGenericMethod.MakeGenericMethod(t));
 
         try
         {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -264,7 +264,7 @@ public class RecordObjectMapping : IRecordObjectMapping
 
     public MethodInfo GetMapMethodForType(Type type)
     {
-        return _mapMethods.AddOrUpdate(type, GetMapMethod, (_, m) => m);
+        return _mapMethods.GetOrAdd(type, GetMapMethod);
 
         MethodInfo GetMapMethod(Type t)
         {


### PR DESCRIPTION
Fixes issue mentioned lower down this thread: https://github.com/neo4j/neo4j-dotnet-driver/issues/846