### PR TITLE
Deprecate notifications in favor of GQL statuses 

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Messages/FailureMessageTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/Messages/FailureMessageTests.cs
@@ -34,8 +34,12 @@ public class FailureMessageTests
     [Fact]
     public void ShouldIncludeValuesInToString()
     {
-        var message = new FailureMessage("e.g.Code", "e.g.Message");
-        message.ToString().Should().Be("FAILURE code=e.g.Code, message=e.g.Message");
+        var message = new FailureMessage("e.g.Code", "e.g.Message")
+        {
+            GqlStatus = "e.g.Gql Status"
+        };
+
+        message.ToString().Should().Be("FAILURE gqlStatus=e.g.Gql Status, message=e.g.Message");
     }
 
     [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.sln.DotSettings
+++ b/Neo4j.Driver/Neo4j.Driver.sln.DotSettings
@@ -234,6 +234,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=accessmode/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gqlstatus/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	</wpf:ResourceDictionary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/GqlCompliance/GqlErrors.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/GqlCompliance/GqlErrors.cs
@@ -48,13 +48,10 @@ internal static class GqlErrors
         {
             message.GqlRawClassification = classification.ToString();
             message.GqlClassification = UnknownError;
-            foreach (var c in new[] { ClientError, DatabaseError, TransientError })
+            
+            if(classification is string and (ClientError or TransientError or DatabaseError))
             {
-                if (classification is string cl && cl == c)
-                {
-                    message.GqlClassification = c;
-                    break;
-                }
+                message.GqlClassification = classification.ToString();
             }
         }
         else

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/GqlStatusObjectsAndNotifications.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/GqlStatusObjectsAndNotifications.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.IO.MessageSerializers;
@@ -32,7 +33,8 @@ internal sealed class FailureMessage : IResponseMessage
         Message = message;
     }
 
-    /// <summary>Code is the Neo4j-specific error code, to be deprecated in favor of GqlStatus.</summary>
+    /// <summary>Code is the Neo4j-specific error code, now deprecated in favor of <see cref="GqlStatus"/>.</summary>
+    [Obsolete("This property is deprecated and will be removed in future versions. Use GqlStatus instead.")]
     public string Code { get; set; }
 
     /// <summary>The specific error message describing the failure.</summary>
@@ -71,6 +73,6 @@ internal sealed class FailureMessage : IResponseMessage
 
     public override string ToString()
     {
-        return $"FAILURE code={Code}, message={Message}";
+        return $"FAILURE gqlStatus={GqlStatus}, message={Message}";
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/Summary/SummaryBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/Summary/SummaryBuilder.cs
@@ -68,6 +68,8 @@ internal sealed class SummaryBuilder
         public bool HasProfile => Profile != null;
         public IPlan Plan { get; }
         public IProfiledPlan Profile { get; }
+        
+        [Obsolete("This API is deprecated and will be removed in a future release. Use GqlStatusObjects instead.")]
         public IList<INotification> Notifications { get; }
         public IList<IGqlStatusObject> GqlStatusObjects { get; }
         public TimeSpan ResultAvailableAfter { get; }

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/INotification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/INotification.cs
@@ -21,6 +21,7 @@ namespace Neo4j.Driver;
 /// Representation for notifications found when executing a query. A notification can be visualized in a client
 /// pinpointing problems or other information about the query.
 /// </summary>
+[Obsolete("This API is deprecated and will be removed in a future release. Use IGqlStatusObject for status information.")]
 public interface INotification
 {
     /// <summary>Gets the notification code of the <see cref="INotification"/> instance.</summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/IResultSummary.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/IResultSummary.cs
@@ -68,6 +68,9 @@ public interface IResultSummary
     /// problematic queries or other valuable information that can be presented in a client. Unlike failures or errors,
     /// notifications do not affect the execution of a query.
     /// </remarks>
+    [Obsolete(
+        "Notifications are being replaced by GQL Statuses. Please use GqlStatusObjects property instead. "+ 
+        "This property will be removed in a future release.")]
     IList<INotification> Notifications { get; }
 
     /// <summary>


### PR DESCRIPTION
* Marked the `INotification` interface and the `Notifications` property in both `IResultSummary` and `ResultSummary` as obsolete.

* Deprecated the `Code` property in `FailureMessage`

* Updated the string representation of `FailureMessage` to show `gqlStatus` instead of the legacy `code` field.

* Amended test for said ToString method.

Closes DRIVERS-86.
