### PR TITLE
Fix preview references in xml documentation

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Messaging/FailureMessage.cs
@@ -57,8 +57,7 @@ internal sealed class FailureMessage : IResponseMessage
     public string GqlRawClassification { get; set; }
 
     /// <summary>
-    /// GqlDiagnosticRecord returns further information about the status for diagnostic purposes. GqlDiagnosticRecord
-    /// is part of the GQL compliant errors preview feature.
+    /// GqlDiagnosticRecord returns further information about the status for diagnostic purposes. 
     /// </summary>
     public Dictionary<string, object> GqlDiagnosticRecord { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/IGqlStatusObject.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/IGqlStatusObject.cs
@@ -18,8 +18,7 @@ using System.Collections.Generic;
 namespace Neo4j.Driver;
 
 /// <summary>
-/// This is a preview API, This API may change between minor revisions.<br/> The GQL-status object as defined by
-/// the GQL standard. Returned by <see cref="IResultSummary.GqlStatusObjects"/>
+/// The GQL-status object as defined by the GQL standard. Returned by <see cref="IResultSummary.GqlStatusObjects"/>
 /// </summary>
 /// <seealso cref="IResultSummary.GqlStatusObjects"/>
 /// <since>5.23.0</since>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/IResultSummary.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/IResultSummary.cs
@@ -74,8 +74,7 @@ public interface IResultSummary
     IList<INotification> Notifications { get; }
 
     /// <summary>
-    /// This is a preview API, This API may change between minor revisions.<br/> Gets the GQL statuses produced by the
-    /// server when executing a statement or query.
+    /// Gets the GQL statuses produced by the server when executing a statement or query.
     /// </summary>
     /// <seealso cref="IGqlStatusObject">For more information about GQL Statuses</seealso>
     /// <since>5.23.0</since>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Summary/NotificationClassification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Summary/NotificationClassification.cs
@@ -16,9 +16,8 @@
 namespace Neo4j.Driver;
 
 /// <summary>
-/// This is a preview API, This API may change between minor revisions.<br/> Represents the classification of
-/// server notifications surfaced by <see cref="IGqlStatusObject"/>.<br/> Used in conjunction with
-/// <see cref="NotificationSeverity"/>.
+/// Represents the classification of server notifications surfaced by <see cref="IGqlStatusObject"/>. Used in
+/// conjunction with <see cref="NotificationSeverity"/>.
 /// </summary>
 /// <since>5.23.0</since>
 public enum NotificationClassification

--- a/Neo4j.Driver/Neo4j.Driver/Public/Types/UnsupportedType.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Types/UnsupportedType.cs
@@ -20,7 +20,7 @@ namespace Neo4j.Driver;
 
 /// <summary>
 /// Represents a type unknown to the driver, received from the server.
-/// This type is used for instance when a newer DBMS produces a result containing a type that the current version of the
+/// This type is used, for instance, when a newer DBMS produces a result containing a type that the current version of the
 /// driver does not yet understand.
 ///
 /// Note that this type may only be received from the server, but cannot be sent to the server (e.g., as a query parameter).

--- a/Neo4j.Driver/common.props
+++ b/Neo4j.Driver/common.props
@@ -6,24 +6,18 @@
         <AssemblyFileVersion>6.0.0.0</AssemblyFileVersion>
         <FileVersion>6.0.0.0</FileVersion>
     </PropertyGroup>
+
     <PropertyGroup>
         <XunitVersion>2.4.1</XunitVersion>
         <MSTestVersion>16.1.1</MSTestVersion>
     </PropertyGroup>
+
     <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <SignAssembly>true</SignAssembly>
         <DelaySign>false</DelaySign>
         <AssemblyOriginatorKeyFile>..\neo4j.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
 
-    <!--
-      <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='ReleaseSigned'">
-        <GetFrameworkSdkPath>
-          <Output TaskParameter="Path" PropertyName="WindowsSdkPath" />
-        </GetFrameworkSdkPath>
-        <Exec Command="&quot;$(SDK40ToolsPath)sn.exe&quot; -R &quot;$(TargetPath)&quot; &quot;$(SignatureFile)&quot;" />
-      </Target>
-    -->
     <PropertyGroup>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Some of the XML documentation around GQL statuses and notifications still said it was in preview; this has been rectified.