### PR TITLE
Add user to benchkit backend dockerfile

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.BenchkitBackend/Dockerfile
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.BenchkitBackend/Dockerfile
@@ -23,4 +23,9 @@ WORKDIR /app
 # Copy from build stage
 COPY --from=build /app .
 
+# Add non-root user and set it as the user to run the container
+RUN useradd -m appuser
+RUN chown -R appuser /app
+USER appuser
+
 ENTRYPOINT ["dotnet", "Neo4j.Driver.Tests.BenchkitBackend.dll"]


### PR DESCRIPTION
This pull request updates the Dockerfile for `Neo4j.Driver.Tests.BenchkitBackend` to improve container security by ensuring the application does not run as root.

**Container security improvements:**

* Added a non-root user (`appuser`) and changed file ownership to this user, then set the container to run as `appuser` instead of root.