### PR TITLE
Document GQL cause chain on Neo4jException

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,10 +1,8 @@
-# Ignore everything
-/*
+:include .gitignore
 
-# except:
-!/Neo4j.Driver/
-!/Neo4j.Driver/**
-!/Neo4j.Driver/Neo4j.Driver/
-!/Neo4j.Driver/Neo4j.Driver/**
-!/Neo4j.Driver/Neo4j.Driver.Reactive/
-!/Neo4j.Driver/Neo4j.Driver.Reactive/**
+/testkit/
+/Neo4j.Driver/Neo4j.Driver.Tests/
+/Neo4j.Driver/Neo4j.Driver.Tests.BenchkitBackend/
+/Neo4j.Driver/Neo4j.Driver.Tests.Integration/
+/Neo4j.Driver/Neo4j.Driver.Tests.SimpleDriver/
+/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/

--- a/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
@@ -21,6 +21,14 @@ using Neo4j.Driver.Internal.Messaging;
 namespace Neo4j.Driver;
 
 /// <summary>The base class for all Neo4j exceptions.</summary>
+/// <remarks>
+/// <para>
+/// GQL errors may include a cause chain. When present, the GQL cause is exposed as
+/// <see cref="Exception.InnerException"/>, which may itself be a <see cref="Neo4jException"/>
+/// with its own cause. The full chain can be walked using the standard .NET
+/// <see cref="Exception.InnerException"/> property.
+/// </para>
+/// </remarks>
 [DataContract]
 public class Neo4jException : Exception
 {


### PR DESCRIPTION
CLOSES DRIVERS-241

Adds a `<remarks>` block to `Neo4jException` clarifying that GQL errors may include a cause chain, and that the GQL cause is exposed via the standard .NET `InnerException` property.