### PR TITLE
Add GQL status finder methods to Neo4jException

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Exceptions/Neo4jExceptionGqlStatusFinderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Exceptions/Neo4jExceptionGqlStatusFinderTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using Neo4j.Driver.Internal.Messaging;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Exceptions;
+
+public class Neo4jExceptionGqlStatusFinderTests
+{
+    private static Neo4jException ExceptionWithStatus(string gqlStatus, FailureMessage cause = null)
+    {
+        var msg = new FailureMessage { GqlStatus = gqlStatus, GqlCause = cause };
+        return Neo4jException.Create(msg);
+    }
+
+    public class FindByGqlStatus
+    {
+        [Fact]
+        public void ReturnsThisException_WhenItMatchesDirectly()
+        {
+            var ex = ExceptionWithStatus("42N04");
+
+            ex.FindByGqlStatus("42N04").Should().BeSameAs(ex);
+        }
+
+        [Fact]
+        public void ReturnsCause_WhenRootDoesNotMatch()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "42N04" };
+            var rootMsg = new FailureMessage { GqlStatus = "08N01", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+            var cause = (Neo4jException)root.InnerException;
+
+            root.FindByGqlStatus("42N04").Should().BeSameAs(cause);
+        }
+
+        [Fact]
+        public void ReturnsRoot_WhenRootMatchesBeforeCause()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "42N04" };
+            var rootMsg = new FailureMessage { GqlStatus = "42N04", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+
+            root.FindByGqlStatus("42N04").Should().BeSameAs(root);
+        }
+
+        [Fact]
+        public void ReturnsNull_WhenNoMatchInChain()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "08N01" };
+            var rootMsg = new FailureMessage { GqlStatus = "42N04", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+
+            root.FindByGqlStatus("99Z99").Should().BeNull();
+        }
+
+        [Fact]
+        public void ReturnsNull_WhenExceptionHasNoGqlStatus()
+        {
+            var ex = new Neo4jException("code", "message");
+
+            ex.FindByGqlStatus("42N04").Should().BeNull();
+        }
+    }
+
+    public class ContainsGqlStatus
+    {
+        [Fact]
+        public void ReturnsTrue_WhenThisExceptionMatches()
+        {
+            var ex = ExceptionWithStatus("42N04");
+
+            ex.ContainsGqlStatus("42N04").Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsTrue_WhenCauseMatches()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "42N04" };
+            var rootMsg = new FailureMessage { GqlStatus = "08N01", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+
+            root.ContainsGqlStatus("42N04").Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsFalse_WhenNoMatchInChain()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "08N01" };
+            var rootMsg = new FailureMessage { GqlStatus = "42N04", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+
+            root.ContainsGqlStatus("99Z99").Should().BeFalse();
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Exceptions/Neo4jExceptionGqlStatusFinderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Exceptions/Neo4jExceptionGqlStatusFinderTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Messaging;
 using Xunit;
@@ -59,21 +60,70 @@ public class Neo4jExceptionGqlStatusFinderTests
         }
 
         [Fact]
-        public void ReturnsNull_WhenNoMatchInChain()
+        public void Throws_WhenNoMatchInChain()
         {
             var causeMsg = new FailureMessage { GqlStatus = "08N01" };
             var rootMsg = new FailureMessage { GqlStatus = "42N04", GqlCause = causeMsg };
             var root = Neo4jException.Create(rootMsg);
 
-            root.FindByGqlStatus("99Z99").Should().BeNull();
+            var act = () => root.FindByGqlStatus("99Z99");
+
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*99Z99*");
         }
 
         [Fact]
-        public void ReturnsNull_WhenExceptionHasNoGqlStatus()
+        public void Throws_WhenExceptionHasNoGqlStatus()
         {
             var ex = new Neo4jException("code", "message");
 
-            ex.FindByGqlStatus("42N04").Should().BeNull();
+            var act = () => ex.FindByGqlStatus("42N04");
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+    }
+
+    public class TryFindByGqlStatus
+    {
+        [Fact]
+        public void ReturnsTrueAndSetsResult_WhenThisExceptionMatches()
+        {
+            var ex = ExceptionWithStatus("42N04");
+
+            ex.TryFindByGqlStatus("42N04", out var result).Should().BeTrue();
+            result.Should().BeSameAs(ex);
+        }
+
+        [Fact]
+        public void ReturnsTrueAndSetsCause_WhenRootDoesNotMatch()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "42N04" };
+            var rootMsg = new FailureMessage { GqlStatus = "08N01", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+            var cause = (Neo4jException)root.InnerException;
+
+            root.TryFindByGqlStatus("42N04", out var result).Should().BeTrue();
+            result.Should().BeSameAs(cause);
+        }
+
+        [Fact]
+        public void ReturnsFalseAndSetsNull_WhenNoMatchInChain()
+        {
+            var causeMsg = new FailureMessage { GqlStatus = "08N01" };
+            var rootMsg = new FailureMessage { GqlStatus = "42N04", GqlCause = causeMsg };
+            var root = Neo4jException.Create(rootMsg);
+
+            root.TryFindByGqlStatus("99Z99", out var result).Should().BeFalse();
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void ReturnsFalse_WhenExceptionHasNoGqlStatus()
+        {
+            var ex = new Neo4jException("code", "message");
+
+            ex.TryFindByGqlStatus("42N04", out var result).Should().BeFalse();
+            result.Should().BeNull();
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
@@ -118,6 +118,45 @@ public class Neo4jException : Exception
     /// </summary>
     public Dictionary<string, object> GqlDiagnosticRecord { get; }
 
+    /// <summary>
+    /// Returns whether this exception, or any <see cref="Neo4jException"/> in its GQL cause chain,
+    /// has the specified GQL status code.
+    /// </summary>
+    /// <param name="gqlStatus">The GQL status code to search for.</param>
+    /// <returns>
+    /// <c>true</c> if a matching <see cref="Neo4jException"/> is found in the cause chain;
+    /// otherwise <c>false</c>.
+    /// </returns>
+    public bool ContainsGqlStatus(string gqlStatus)
+    {
+        return FindByGqlStatus(gqlStatus) is not null;
+    }
+
+    /// <summary>
+    /// Returns the first <see cref="Neo4jException"/> in the GQL cause chain — starting with this
+    /// exception — whose <see cref="GqlStatus"/> matches the specified value, or <c>null</c> if
+    /// no match is found.
+    /// </summary>
+    /// <param name="gqlStatus">The GQL status code to search for.</param>
+    /// <returns>
+    /// The first matching <see cref="Neo4jException"/>, or <c>null</c> if none is found.
+    /// </returns>
+    public Neo4jException FindByGqlStatus(string gqlStatus)
+    {
+        var current = this;
+        while (current is not null)
+        {
+            if (current.GqlStatus == gqlStatus)
+            {
+                return current;
+            }
+
+            current = current.InnerException as Neo4jException;
+        }
+
+        return null;
+    }
+
     internal static Neo4jException Create(FailureMessage failureMessage)
     {
         Exception innerException = null;

--- a/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Exceptions/Neo4jException.cs
@@ -129,32 +129,58 @@ public class Neo4jException : Exception
     /// </returns>
     public bool ContainsGqlStatus(string gqlStatus)
     {
-        return FindByGqlStatus(gqlStatus) is not null;
+        return TryFindByGqlStatus(gqlStatus, out _);
     }
 
     /// <summary>
     /// Returns the first <see cref="Neo4jException"/> in the GQL cause chain — starting with this
-    /// exception — whose <see cref="GqlStatus"/> matches the specified value, or <c>null</c> if
-    /// no match is found.
+    /// exception — whose <see cref="GqlStatus"/> matches the specified value.
     /// </summary>
     /// <param name="gqlStatus">The GQL status code to search for.</param>
-    /// <returns>
-    /// The first matching <see cref="Neo4jException"/>, or <c>null</c> if none is found.
-    /// </returns>
+    /// <returns>The first matching <see cref="Neo4jException"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no exception in the cause chain has the specified GQL status code.
+    /// Use <see cref="TryFindByGqlStatus"/> to avoid the exception.
+    /// </exception>
     public Neo4jException FindByGqlStatus(string gqlStatus)
+    {
+        if (TryFindByGqlStatus(gqlStatus, out var result))
+        {
+            return result;
+        }
+
+        throw new InvalidOperationException(
+            $"No exception with GQL status '{gqlStatus}' was found in the cause chain.");
+    }
+
+    /// <summary>
+    /// Searches the GQL cause chain — starting with this exception — for a <see cref="Neo4jException"/>
+    /// whose <see cref="GqlStatus"/> matches the specified value.
+    /// </summary>
+    /// <param name="gqlStatus">The GQL status code to search for.</param>
+    /// <param name="result">
+    /// When this method returns <c>true</c>, contains the first matching <see cref="Neo4jException"/>;
+    /// otherwise <c>null</c>.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if a matching exception was found; otherwise <c>false</c>.
+    /// </returns>
+    public bool TryFindByGqlStatus(string gqlStatus, out Neo4jException result)
     {
         var current = this;
         while (current is not null)
         {
             if (current.GqlStatus == gqlStatus)
             {
-                return current;
+                result = current;
+                return true;
             }
 
             current = current.InnerException as Neo4jException;
         }
 
-        return null;
+        result = null;
+        return false;
     }
 
     internal static Neo4jException Create(FailureMessage failureMessage)


### PR DESCRIPTION
CLOSES DRIVERS-81

Adds `ContainsGqlStatus(string)` and `FindByGqlStatus(string)` to `Neo4jException`. Both methods walk the GQL cause chain via `InnerException`, same as as the Java driver (neo4j/neo4j-java-driver#1671).