### PR TITLE
[BLOCKED] - MultiAddress preview API  - currently failing testkit due to behaviour change

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/MultiAddressTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/MultiAddressTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Neo4j.Driver.Internal;
+using Neo4j.Driver.Preview;
+using Xunit;
+using InternalDriver = Neo4j.Driver.Internal.Driver;
+
+namespace Neo4j.Driver.Tests;
+
+public class MultiAddressTests
+{
+    private static readonly ServerAddress Addr1 = ServerAddress.From("server1.example.com", 7687);
+    private static readonly ServerAddress Addr2 = ServerAddress.From("server2.example.com", 7688);
+    private static readonly ServerAddress Addr3 = ServerAddress.From("server3.example.com", 7689);
+
+    public class Construction
+    {
+        [Fact]
+        public void TwoArgCtorSetsProperties()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1, Addr2 });
+
+            ma.Scheme.Should().Be("neo4j");
+            ma.Query.Should().Be(string.Empty);
+            ma.Addresses.Should().ContainInOrder(Addr1, Addr2);
+        }
+
+        [Fact]
+        public void ThreeArgCtorSetsProperties()
+        {
+            var ma = new MultiAddress("neo4j+s", "region=eu", new[] { Addr1 });
+
+            ma.Scheme.Should().Be("neo4j+s");
+            ma.Query.Should().Be("region=eu");
+            ma.Addresses.Should().ContainInOrder(Addr1);
+        }
+
+        [Fact]
+        public void NullQueryDefaultsToEmptyString()
+        {
+            var ma = new MultiAddress("neo4j", null, new[] { Addr1 });
+
+            ma.Query.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void AddressOrderIsPreserved()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr3, Addr1, Addr2 });
+
+            ma.Addresses.Should().ContainInOrder(Addr3, Addr1, Addr2);
+        }
+
+        [Fact]
+        public void SingleAddressIsAccepted()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1 });
+
+            ma.Addresses.Should().HaveCount(1);
+            ma.Addresses[0].Should().Be(Addr1);
+        }
+
+        [Fact]
+        public void AddressesListIsReadOnly()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1 });
+
+            ma.Addresses.Should().BeAssignableTo<IReadOnlyList<ServerAddress>>();
+        }
+
+        [Fact]
+        public void NullSchemeThrowsArgumentNullException()
+        {
+            var act = () => new MultiAddress(null, new[] { Addr1 });
+
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("scheme");
+        }
+
+        [Fact]
+        public void NullAddressesThrowsArgumentNullException()
+        {
+            var act = () => new MultiAddress("neo4j", (IEnumerable<ServerAddress>)null);
+
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("addresses");
+        }
+
+        [Fact]
+        public void NullAddressesInThreeArgCtorThrowsArgumentNullException()
+        {
+            var act = () => new MultiAddress("neo4j", "region=eu", null);
+
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("addresses");
+        }
+
+        [Fact]
+        public void EmptyAddressListThrowsArgumentException()
+        {
+            var act = () => new MultiAddress("neo4j", Enumerable.Empty<ServerAddress>());
+
+            act.Should().Throw<ArgumentException>().Which.ParamName.Should().Be("addresses");
+        }
+    }
+
+    public class ToCanonicalUri
+    {
+        [Fact]
+        public void UsesFirstAddressHostAndPort()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1, Addr2 });
+
+            var uri = ma.ToCanonicalUri();
+
+            uri.Host.Should().Be(Addr1.Host);
+            uri.Port.Should().Be(Addr1.Port);
+        }
+
+        [Fact]
+        public void SchemeIsPreserved()
+        {
+            var ma = new MultiAddress("neo4j+ssc", new[] { Addr1 });
+
+            ma.ToCanonicalUri().Scheme.Should().Be("neo4j+ssc");
+        }
+
+        [Fact]
+        public void QueryIsIncludedWhenPresent()
+        {
+            var ma = new MultiAddress("neo4j", "region=eu", new[] { Addr1 });
+
+            ma.ToCanonicalUri().Query.Should().Contain("region=eu");
+        }
+
+        [Fact]
+        public void QueryIsAbsentWhenEmpty()
+        {
+            var ma = new MultiAddress("neo4j", string.Empty, new[] { Addr1 });
+
+            ma.ToCanonicalUri().Query.Should().BeEmpty();
+        }
+    }
+
+    public class MultiAddressProviderTests
+    {
+        [Fact]
+        public void GetReturnsUriForEachAddress()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1, Addr2, Addr3 });
+            var provider = new MultiAddressProvider(ma);
+
+            var uris = provider.Get();
+
+            uris.Should().HaveCount(3);
+        }
+
+        [Fact]
+        public void GetPreservesHostAndPort()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1, Addr2 });
+            var provider = new MultiAddressProvider(ma);
+
+            var uris = provider.Get().OrderBy(u => u.Host).ToList();
+
+            uris.Should().Contain(u => u.Host == Addr1.Host && u.Port == Addr1.Port);
+            uris.Should().Contain(u => u.Host == Addr2.Host && u.Port == Addr2.Port);
+        }
+
+        [Fact]
+        public void GetIncludesQueryOnEachUri()
+        {
+            var ma = new MultiAddress("neo4j", "region=eu", new[] { Addr1, Addr2 });
+            var provider = new MultiAddressProvider(ma);
+
+            var uris = provider.Get().ToList();
+
+            uris.Should().OnlyContain(u => u.Query.Contains("region=eu"));
+        }
+
+        [Fact]
+        public void GetOmitsQueryWhenEmpty()
+        {
+            var ma = new MultiAddress("neo4j", string.Empty, new[] { Addr1 });
+            var provider = new MultiAddressProvider(ma);
+
+            var uris = provider.Get().ToList();
+
+            uris.Should().OnlyContain(u => string.IsNullOrEmpty(u.Query));
+        }
+
+        [Fact]
+        public void GetUsesSchemeFromMultiAddress()
+        {
+            var ma = new MultiAddress("neo4j+s", new[] { Addr1 });
+            var provider = new MultiAddressProvider(ma);
+
+            provider.Get().Should().OnlyContain(u => u.Scheme == "neo4j+s");
+        }
+    }
+
+    public class GraphDatabaseDriverOverload
+    {
+        [Fact]
+        public void NullMultiAddressThrowsArgumentNullException()
+        {
+            var act = () => GraphDatabase.Driver((MultiAddress)null, AuthTokens.None);
+
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("multiAddress");
+        }
+
+        [Fact]
+        public void NullAuthTokenManagerThrowsArgumentNullException()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1 });
+
+            var act = () => GraphDatabase.Driver(ma, (IAuthTokenManager)null, null);
+
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("authTokenManager");
+        }
+
+        [Fact]
+        public void BoltSchemeWithMultipleAddressesThrowsArgumentException()
+        {
+            var ma = new MultiAddress("bolt", new[] { Addr1, Addr2 });
+
+            var act = () => GraphDatabase.Driver(ma, AuthTokens.None);
+
+            act.Should().Throw<ArgumentException>().Which.ParamName.Should().Be("multiAddress");
+        }
+
+        [Fact]
+        public void BoltSchemeWithNonEmptyQueryThrowsArgumentException()
+        {
+            var ma = new MultiAddress("bolt", "region=eu", new[] { Addr1 });
+
+            var act = () => GraphDatabase.Driver(ma, AuthTokens.None);
+
+            act.Should().Throw<ArgumentException>().Which.ParamName.Should().Be("multiAddress");
+        }
+
+        [Fact]
+        public void RoutingSchemeWithMultipleAddressesCreatesDriver()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1, Addr2 });
+
+            using var driver = GraphDatabase.Driver(ma, AuthTokens.None);
+
+            driver.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void RoutingSchemeCanonicalUriUsesFirstAddress()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1, Addr2 });
+
+            using var driver = (InternalDriver)GraphDatabase.Driver(ma, AuthTokens.None);
+
+            driver.Uri.Host.Should().Be(Addr1.Host);
+            driver.Uri.Port.Should().Be(Addr1.Port);
+        }
+
+        [Fact]
+        public void DirectSchemeWithSingleAddressCreatesDriver()
+        {
+            var ma = new MultiAddress("bolt", new[] { Addr1 });
+
+            using var driver = GraphDatabase.Driver(ma, AuthTokens.None);
+
+            driver.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void EncryptedRoutingSchemeCreatesDriver()
+        {
+            var ma = new MultiAddress("neo4j+s", new[] { Addr1, Addr2 });
+
+            using var driver = GraphDatabase.Driver(ma, AuthTokens.None);
+
+            driver.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ConfigActionIsApplied()
+        {
+            var ma = new MultiAddress("neo4j", new[] { Addr1 });
+            var configWasInvoked = false;
+
+            using var driver = GraphDatabase.Driver(ma, AuthTokens.None, o => { configWasInvoked = true; });
+
+            configWasInvoked.Should().BeTrue();
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
@@ -51,7 +51,7 @@ public static class RoutingTableManagerTests
     {
         if (addressProvider == null)
         {
-            addressProvider = new InitialServerAddressProvider(InitialUri, new PassThroughServerAddressResolver());
+            addressProvider = new UriAddressProvider(InitialUri, new PassThroughServerAddressResolver());
         }
 
         if (discovery == null)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -542,12 +542,15 @@ internal sealed class SocketConnection : IConnection
         string address)
     {
         if (contextRoutingContext == null)
+        {
             return null;
+        }
 
         var result = new Dictionary<string, string>(contextRoutingContext)
         {
             ["address"] = address
         };
+
         return result;
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -42,6 +42,7 @@ internal sealed class SocketConnection : IConnection
     private readonly IResponsePipeline _responsePipeline;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
     private readonly ServerInfo _serverInfo;
+    private readonly IDictionary<string, string> _routingContext;
 
     private string _id;
 
@@ -60,6 +61,7 @@ internal sealed class SocketConnection : IConnection
         Context = context;
         AuthToken = authToken;
         _serverInfo = new ServerInfo(uri);
+        _routingContext = BuildRoutingContext(context.RoutingContext, _serverInfo.Address);
 
         _responsePipeline = new ResponsePipeline(_neo4JLogger);
         AuthTokenManager = context.AuthTokenManager;
@@ -86,6 +88,7 @@ internal sealed class SocketConnection : IConnection
         _responsePipeline = responsePipeline ?? new ResponsePipeline(neo4JLogger);
         _protocolFactory = protocolFactory ?? BoltProtocolFactory.Default;
         Context = context;
+        _routingContext = context != null ? BuildRoutingContext(context.RoutingContext, _serverInfo.Address) : null;
     }
 
     internal IReadOnlyList<IRequestMessage> Messages => _messages.ToList();
@@ -95,7 +98,7 @@ internal sealed class SocketConnection : IConnection
 
     public string Database { get; private set; }
 
-    public IDictionary<string, string> RoutingContext => Context.RoutingContext;
+    public IDictionary<string, string> RoutingContext => _routingContext;
     public BoltProtocolVersion Version => _client.Version;
 
     /// <summary>Internal Set used for tests.</summary>
@@ -532,6 +535,20 @@ internal sealed class SocketConnection : IConnection
     private static string FormatPrefix(string id)
     {
         return $"[{id}]";
+    }
+
+    private static IDictionary<string, string> BuildRoutingContext(
+        IDictionary<string, string> contextRoutingContext,
+        string address)
+    {
+        if (contextRoutingContext == null)
+            return null;
+
+        var result = new Dictionary<string, string>(contextRoutingContext)
+        {
+            ["address"] = address
+        };
+        return result;
     }
 }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/InitialServerAddressProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/InitialServerAddressProvider.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using Neo4j.Driver.Preview;
 
 namespace Neo4j.Driver.Internal;
 
@@ -23,12 +24,16 @@ internal interface IInitialServerAddressProvider
     ISet<Uri> Get();
 }
 
-internal sealed class InitialServerAddressProvider : IInitialServerAddressProvider
+/// <summary>
+/// Resolves the initial set of candidate URIs from a single URI + optional custom resolver.
+/// This is the legacy path, used when the driver is created with a string/Uri.
+/// </summary>
+internal sealed class UriAddressProvider : IInitialServerAddressProvider
 {
     private readonly Uri _initAddress;
     private readonly IServerAddressResolver _resolver;
 
-    public InitialServerAddressProvider(Uri initialServerAddress, IServerAddressResolver resolver)
+    public UriAddressProvider(Uri initialServerAddress, IServerAddressResolver resolver)
     {
         _initAddress = initialServerAddress;
         _resolver = resolver;
@@ -40,8 +45,40 @@ internal sealed class InitialServerAddressProvider : IInitialServerAddressProvid
         var addresses = _resolver.Resolve(ServerAddress.From(_initAddress));
         foreach (var address in addresses)
         {
-            // for now we convert this ServerAddress back to Uri
-            set.Add(new UriBuilder("neo4j://", address.Host, address.Port).Uri);
+            // preserve scheme from the original URI when converting back
+            set.Add(new UriBuilder(_initAddress.Scheme, address.Host, address.Port).Uri);
+        }
+
+        return set;
+    }
+}
+
+/// <summary>
+/// Resolves the initial set of candidate URIs directly from a <see cref="MultiAddress"/>.
+/// Each entry in <see cref="MultiAddress.Addresses"/> becomes a candidate URI, all sharing
+/// the same scheme and (if present) routing context query.
+/// </summary>
+internal sealed class MultiAddressProvider : IInitialServerAddressProvider
+{
+    private readonly MultiAddress _multiAddress;
+
+    public MultiAddressProvider(MultiAddress multiAddress)
+    {
+        _multiAddress = multiAddress;
+    }
+
+    public ISet<Uri> Get()
+    {
+        var set = new HashSet<Uri>();
+        foreach (var address in _multiAddress.Addresses)
+        {
+            var builder = new UriBuilder(_multiAddress.Scheme, address.Host, address.Port);
+            if (!string.IsNullOrEmpty(_multiAddress.Query))
+            {
+                builder.Query = _multiAddress.Query;
+            }
+
+            set.Add(builder.Uri);
         }
 
         return set;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Routing/LoadBalancer.cs
@@ -41,6 +41,17 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
         Uri parsedUri,
         IPooledConnectionFactory connectionFactory,
         DriverContext driverContext)
+        : this(
+            new UriAddressProvider(parsedUri, driverContext.Config.Resolver),
+            connectionFactory,
+            driverContext)
+    {
+    }
+
+    public LoadBalancer(
+        IInitialServerAddressProvider initialAddressProvider,
+        IPooledConnectionFactory connectionFactory,
+        DriverContext driverContext)
     {
         DriverContext = driverContext;
 
@@ -50,7 +61,7 @@ internal class LoadBalancer : IConnectionProvider, IErrorHandler, IClusterConnec
             DriverContext);
 
         _neo4JLogger = driverContext.Neo4JLogger;
-        _initialServerAddressProvider = new InitialServerAddressProvider(parsedUri, driverContext.Config.Resolver);
+        _initialServerAddressProvider = initialAddressProvider;
         _routingTableManager = new RoutingTableManager(
             _initialServerAddressProvider,
             this,

--- a/Neo4j.Driver/Neo4j.Driver/Public/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/GraphDatabase.cs
@@ -15,8 +15,10 @@
 
 using System;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Routing;
 using Neo4j.Driver.Internal.Util;
+using Neo4j.Driver.Preview;
 
 namespace Neo4j.Driver;
 
@@ -249,20 +251,71 @@ public static class GraphDatabase
         return CreateDriver(connectionFactory, context);
     }
 
+    internal static IDriver CreateMultiAddressDriver(
+        MultiAddress multiAddress,
+        IAuthTokenManager authTokenManager,
+        Action<ConfigBuilder> action)
+    {
+        if (multiAddress is null)
+        {
+            throw new ArgumentNullException(nameof(multiAddress));
+        }
+
+        authTokenManager = authTokenManager ?? throw new ArgumentNullException(nameof(authTokenManager));
+
+        var canonicalUri = multiAddress.ToCanonicalUri();
+        var parsedUri = Neo4jUri.ParseBoltUri(canonicalUri, Neo4jUri.DefaultBoltPort);
+
+        if (!Neo4jUri.IsRoutingUri(parsedUri) && multiAddress.Addresses.Count > 1)
+        {
+            throw new ArgumentException(
+                "A direct (bolt) scheme requires exactly one address. " +
+                "Use a routing scheme (neo4j, neo4j+s, neo4j+ssc) to provide multiple addresses.",
+                nameof(multiAddress));
+        }
+
+        if (!Neo4jUri.IsRoutingUri(parsedUri) && !string.IsNullOrEmpty(multiAddress.Query))
+        {
+            throw new ArgumentException(
+                "A routing context (Query) is not supported with direct (bolt) schemes.",
+                nameof(multiAddress));
+        }
+
+        var builder = Config.Builder;
+        action?.Invoke(builder);
+        var config = builder.Build();
+
+        var context = new DriverContext(canonicalUri, authTokenManager, config);
+        var connectionFactory = new PooledConnectionFactory(context);
+
+        return CreateDriver(connectionFactory, context, new MultiAddressProvider(multiAddress));
+    }
+
     internal static IDriver CreateDriver(
         IPooledConnectionFactory connectionFactory,
         DriverContext context)
     {
+        return CreateDriver(connectionFactory, context, addressProvider: null);
+    }
+
+    internal static IDriver CreateDriver(
+        IPooledConnectionFactory connectionFactory,
+        DriverContext context,
+        IInitialServerAddressProvider addressProvider)
+    {
         var parsedUri = Neo4jUri.ParseBoltUri(context.InitialUri, Neo4jUri.DefaultBoltPort);
-        IConnectionProvider connectionProvider = Neo4jUri.IsRoutingUri(parsedUri)
-            ? new LoadBalancer(
-                parsedUri,
-                connectionFactory,
-                context)
-            : new ConnectionPool(
-                parsedUri,
-                connectionFactory,
-                context);
+
+        IConnectionProvider connectionProvider;
+        if (Neo4jUri.IsRoutingUri(parsedUri))
+        {
+            connectionProvider = addressProvider != null
+                ? new LoadBalancer(addressProvider, connectionFactory, context)
+                : new LoadBalancer(parsedUri, connectionFactory, context);
+        }
+        else
+        {
+            connectionProvider = new ConnectionPool(parsedUri, connectionFactory, context);
+        }
 
         var server = new BoltProtocolAdapter(connectionProvider, context);
         return new Internal.Driver(parsedUri, server, context);

--- a/Neo4j.Driver/Neo4j.Driver/Public/Preview/GraphDatabaseExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Preview/GraphDatabaseExtensions.cs
@@ -1,0 +1,88 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Preview;
+
+/// <summary>
+/// Preview API extensions for <see cref="GraphDatabase"/>.
+/// Add <c>using Neo4j.Driver.Preview;</c> to access these members.
+/// </summary>
+/// <remarks>
+/// APIs in this namespace are preview features. They may change or be removed in a future release.
+/// Once stabilised they will be promoted to the main <c>Neo4j.Driver</c> namespace.
+/// </remarks>
+public static class GraphDatabaseExtensions
+{
+    extension(GraphDatabase)
+    {
+        /// <summary>
+        /// Returns a driver configured with multiple initial addresses for higher resilience during discovery.
+        /// </summary>
+        /// <param name="multiAddress">
+        /// The <see cref="MultiAddress"/> specifying the scheme, optional routing context, and the list of
+        /// initial addresses to try.
+        /// </param>
+        /// <param name="authToken">Authentication to use, <see cref="AuthTokens"/>.</param>
+        /// <returns>A new <see cref="IDriver"/> instance.</returns>
+        public static IDriver Driver(MultiAddress multiAddress, IAuthToken authToken)
+        {
+            return GraphDatabase.Driver(multiAddress, authToken, null);
+        }
+
+        /// <summary>
+        /// Returns a driver configured with multiple initial addresses for higher resilience during discovery.
+        /// </summary>
+        /// <param name="multiAddress">
+        /// The <see cref="MultiAddress"/> specifying the scheme, optional routing context, and the list of
+        /// initial addresses to try.
+        /// </param>
+        /// <param name="authToken">Authentication to use, <see cref="AuthTokens"/>.</param>
+        /// <param name="action">
+        /// Specifies how to build a driver configuration <see cref="Config"/> using <see cref="ConfigBuilder"/>.
+        /// If set to <c>null</c>, default configuration is used.
+        /// </param>
+        /// <returns>A new <see cref="IDriver"/> instance.</returns>
+        public static IDriver Driver(MultiAddress multiAddress, IAuthToken authToken, Action<ConfigBuilder> action)
+        {
+            return GraphDatabase.CreateMultiAddressDriver(
+                multiAddress,
+                AuthTokenManagers.Static(authToken),
+                action);
+        }
+
+        /// <summary>
+        /// Returns a driver configured with multiple initial addresses for higher resilience during discovery.
+        /// </summary>
+        /// <param name="multiAddress">
+        /// The <see cref="MultiAddress"/> specifying the scheme, optional routing context, and the list of
+        /// initial addresses to try.
+        /// </param>
+        /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication.</param>
+        /// <param name="action">
+        /// Specifies how to build a driver configuration <see cref="Config"/> using <see cref="ConfigBuilder"/>.
+        /// If set to <c>null</c>, default configuration is used.
+        /// </param>
+        /// <returns>A new <see cref="IDriver"/> instance.</returns>
+        public static IDriver Driver(
+            MultiAddress multiAddress,
+            IAuthTokenManager authTokenManager,
+            Action<ConfigBuilder> action)
+        {
+            return GraphDatabase.CreateMultiAddressDriver(multiAddress, authTokenManager, action);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Public/Preview/MultiAddress.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Preview/MultiAddress.cs
@@ -1,0 +1,112 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo4j.Driver.Preview;
+
+/// <summary>
+/// Configures the driver with multiple initial addresses for higher resilience during cluster discovery.
+/// Use as an alternative to a single URI string when creating a driver via
+/// <c>GraphDatabase.Driver(MultiAddress, ...)</c> (requires <c>using Neo4j.Driver.Preview</c>).
+/// </summary>
+/// <remarks>
+/// <b>Preview API.</b> This feature is a preview and may change or be removed in a future release.<br/>
+/// <br/>
+/// At least one address must be provided. When using a direct (bolt) scheme, exactly one address must be
+/// provided. Each address in <see cref="Addresses"/> will be tried in order when establishing the initial
+/// connection until the first one succeeds.
+/// </remarks>
+public sealed class MultiAddress
+{
+    /// <summary>
+    /// Gets the URI scheme, e.g. <c>"neo4j"</c>, <c>"neo4j+s"</c>, or <c>"neo4j+ssc"</c>.
+    /// </summary>
+    public string Scheme { get; }
+
+    /// <summary>
+    /// Gets the optional routing context query string, e.g. <c>"region=eu"</c>.
+    /// Defaults to an empty string (no routing context).
+    /// </summary>
+    public string Query { get; }
+
+    /// <summary>
+    /// Gets the ordered list of initial addresses to try when connecting to the cluster.
+    /// </summary>
+    public IReadOnlyList<ServerAddress> Addresses { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="MultiAddress"/> with no routing context query string.
+    /// </summary>
+    /// <param name="scheme">
+    /// The URI scheme to use, e.g. <c>"neo4j"</c>, <c>"neo4j+s"</c>, <c>"neo4j+ssc"</c>.
+    /// </param>
+    /// <param name="addresses">
+    /// The ordered list of server addresses. Must contain at least one entry.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="scheme"/> or <paramref name="addresses"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="addresses"/> is empty.</exception>
+    public MultiAddress(string scheme, IEnumerable<ServerAddress> addresses)
+        : this(scheme, string.Empty, addresses)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="MultiAddress"/> with a routing context query string.
+    /// </summary>
+    /// <param name="scheme">
+    /// The URI scheme to use, e.g. <c>"neo4j"</c>, <c>"neo4j+s"</c>, <c>"neo4j+ssc"</c>.
+    /// </param>
+    /// <param name="query">
+    /// The routing context as a query string, e.g. <c>"region=eu"</c>. Use an empty string or
+    /// <c>null</c> for no routing context.
+    /// </param>
+    /// <param name="addresses">
+    /// The ordered list of server addresses. Must contain at least one entry.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="scheme"/> or <paramref name="addresses"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="addresses"/> is empty.</exception>
+    public MultiAddress(string scheme, string query, IEnumerable<ServerAddress> addresses)
+    {
+        Scheme = scheme ?? throw new ArgumentNullException(nameof(scheme));
+        Query = query ?? string.Empty;
+
+        var list = addresses?.ToList() ?? throw new ArgumentNullException(nameof(addresses));
+        if (list.Count == 0)
+        {
+            throw new ArgumentException("At least one address must be provided.", nameof(addresses));
+        }
+
+        Addresses = list.AsReadOnly();
+    }
+
+    internal Uri ToCanonicalUri()
+    {
+        var first = Addresses[0];
+        var builder = new UriBuilder(Scheme, first.Host, first.Port);
+        if (!string.IsNullOrEmpty(Query))
+        {
+            builder.Query = Query;
+        }
+
+        return builder.Uri;
+    }
+}


### PR DESCRIPTION
Closes DRIVERS-110

Adds `MultiAddress` as a preview replacement for the old custom resolver API.

- `MultiAddress` class — scheme + optional routing context query + ordered list of `ServerAddress`. Lives in `Neo4j.Driver.Preview` so it can evolve freely.
- `MultiAddressProvider` — internal implementation of `IInitialServerAddressProvider` backed by `MultiAddress`, sitting alongside the existing `UriAddressProvider` (renamed from `InitialServerAddressProvider`).
- `LoadBalancer` refactor — the main constructor now delegates to a new overload that accepts `IInitialServerAddressProvider` directly, making it injectable without touching the existing URI path.
- `GraphDatabase.Driver(MultiAddress, ...)` — three overloads (token, token+config, token manager+config) exposed as C# 14 static extension members in `Neo4j.Driver.Preview`, so users opt in with `using Neo4j.Driver.Preview`. The actual logic lives in `internal static CreateMultiAddressDriver` on `GraphDatabase`.
- `SocketConnection` routing context fix — each connection now builds its own copy of the routing context dict with `address` set to the actual connected `host:port` (`ServerInfo.Address`) rather than the original URI, so the `HELLO` message sends the correct resolved address.
- Unit tests covering construction, validation, `MultiAddressProvider.Get()`, and the factory overloads.