### PR TITLE
Fix session.RunAsync with anonymous object parameters and transaction config

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
@@ -110,7 +110,7 @@ public class AsyncSessionTests
         {
             // https://github.com/neo4j/neo4j-dotnet-driver/issues/855
             var mockConn = new Mock<IConnection>();
-            var session = NewSession(mockConn.Object);
+            IAsyncSession session = NewSession(mockConn.Object);
 
             await session.RunAsync(
                 "CREATE (a:Person {name: $name})",

--- a/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AsyncSessionTests.cs
@@ -104,6 +104,30 @@ public class AsyncSessionTests
                     It.IsAny<IHomeDbCache>()),
                 Times.Once);
         }
+
+        [Fact]
+        public async Task ShouldAcceptAnonymousObjectParametersWithTransactionConfig()
+        {
+            // https://github.com/neo4j/neo4j-dotnet-driver/issues/855
+            var mockConn = new Mock<IConnection>();
+            var session = NewSession(mockConn.Object);
+
+            await session.RunAsync(
+                "CREATE (a:Person {name: $name})",
+                new { name = "John" },
+                conf => conf.WithTimeout(TimeSpan.FromSeconds(5)));
+
+            mockConn.Verify(
+                x => x.RunInAutoCommitTransactionAsync(
+                    It.Is<AutoCommitParams>(p =>
+                        p.Query.Text == "CREATE (a:Person {name: $name})" &&
+                        p.Query.Parameters.ContainsKey("name") &&
+                        (string)p.Query.Parameters["name"] == "John" &&
+                        p.Config.Timeout == TimeSpan.FromSeconds(5)),
+                    It.IsAny<INotificationsConfig>(),
+                    It.IsAny<IHomeDbCache>()),
+                Times.Once);
+        }
     }
 
     public class BeginTransactionAsyncMethod

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -127,6 +127,11 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
         return RunAsync(new Query(query), action);
     }
 
+    public Task<IResultCursor> RunAsync(string query, object parameters, Action<TransactionConfigBuilder> action)
+    {
+        return RunAsync(new Query(query, parameters), action);
+    }
+
     public Task<IResultCursor> RunAsync(
         string query,
         IDictionary<string, object> parameters,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/AsyncSession.cs
@@ -127,11 +127,6 @@ internal partial class AsyncSession : AsyncQueryRunner, IInternalAsyncSession
         return RunAsync(new Query(query), action);
     }
 
-    public Task<IResultCursor> RunAsync(string query, object parameters, Action<TransactionConfigBuilder> action)
-    {
-        return RunAsync(new Query(query, parameters), action);
-    }
-
     public Task<IResultCursor> RunAsync(
         string query,
         IDictionary<string, object> parameters,

--- a/Neo4j.Driver/Neo4j.Driver/Public/IAsyncQueryRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IAsyncQueryRunner.cs
@@ -30,7 +30,7 @@ public interface IAsyncQueryRunner : IAsyncDisposable, IDisposable
     /// </summary>
     /// <param name="query">A Cypher query.</param>
     /// <returns>A task of a stream of result values and associated metadata.</returns>
-    /// <exception cref="TransactionClosedException">>Thrown when used in a transaction that has previously been closed.</exception>
+    /// <exception cref="TransactionClosedException">Thrown when used in a transaction that has previously been closed.</exception>
     Task<IResultCursor> RunAsync(string query);
 
     /// <summary>Asynchronously execute a query and return a task of result stream.</summary>
@@ -42,7 +42,7 @@ public interface IAsyncQueryRunner : IAsyncDisposable, IDisposable
     /// <see cref="Mapping.CypherParameterMappingAttribute"/>, and global name translation.
     /// </param>
     /// <returns>A task of a stream of result values and associated metadata.</returns>
-    /// <exception cref="TransactionClosedException">>Thrown when used in a transaction that has previously been closed.</exception>
+    /// <exception cref="TransactionClosedException">Thrown when used in a transaction that has previously been closed.</exception>
     Task<IResultCursor> RunAsync(string query, object parameters);
 
     /// <summary>
@@ -53,12 +53,12 @@ public interface IAsyncQueryRunner : IAsyncDisposable, IDisposable
     /// <param name="query">A Cypher query.</param>
     /// <param name="parameters">Input parameters for the query.</param>
     /// <returns>A task of a stream of result values and associated metadata.</returns>
-    /// <exception cref="TransactionClosedException">>Thrown when used in a transaction that has previously been closed.</exception>
+    /// <exception cref="TransactionClosedException">Thrown when used in a transaction that has previously been closed.</exception>
     Task<IResultCursor> RunAsync(string query, IDictionary<string, object> parameters);
 
     /// <summary>Asynchronously execute a query and return a task of result stream.</summary>
     /// <param name="query">A Cypher query, <see cref="Query"/>.</param>
     /// <returns>A task of a stream of result values and associated metadata.</returns>
-    /// <exception cref="TransactionClosedException">>Thrown when used in a transaction that has previously been closed.</exception>
+    /// <exception cref="TransactionClosedException">Thrown when used in a transaction that has previously been closed.</exception>
     Task<IResultCursor> RunAsync(Query query);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/IAsyncQueryRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IAsyncQueryRunner.cs
@@ -35,7 +35,12 @@ public interface IAsyncQueryRunner : IAsyncDisposable, IDisposable
 
     /// <summary>Asynchronously execute a query and return a task of result stream.</summary>
     /// <param name="query">A Cypher query.</param>
-    /// <param name="parameters">A parameter dictionary which is made of prop.Name=prop.Value pairs would be created.</param>
+    /// <param name="parameters">
+    /// The query parameters. See <see cref="Query(string, object)"/> for a full description of how
+    /// objects are converted to Cypher parameter maps, including support for anonymous types, POCOs,
+    /// dictionaries, nested objects, property renaming with
+    /// <see cref="Mapping.CypherParameterMappingAttribute"/>, and global name translation.
+    /// </param>
     /// <returns>A task of a stream of result values and associated metadata.</returns>
     /// <exception cref="TransactionClosedException">>Thrown when used in a transaction that has previously been closed.</exception>
     Task<IResultCursor> RunAsync(string query, object parameters);

--- a/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
@@ -169,18 +169,24 @@ public interface IAsyncSession : IAsyncQueryRunner
     /// Asynchronously run a query within an AutoCommit transaction. Uses the specific <see cref="TransactionConfig"/>
     /// and returns a task of result stream. This method accepts a String representing a Cypher query which will be
     /// compiled into a query object that can be used to efficiently execute this query multiple times. This method
-    /// optionally accepts a set of parameters which will be injected into the query object query by Neo4j.
+    /// optionally accepts a set of parameters which will be injected into the query object by Neo4j.
     /// </summary>
     /// <param name="query">A Cypher query.</param>
     /// <param name="parameters">
-    /// A parameter object which is made of prop.Name=prop.Value pairs would be created from the object.
+    /// The query parameters. See <see cref="Query(string, object)"/> for a full description of how
+    /// objects are converted to Cypher parameter maps, including support for anonymous types, POCOs,
+    /// dictionaries, nested objects, property renaming with
+    /// <see cref="Mapping.CypherParameterMappingAttribute"/>, and global name translation.
     /// </param>
     /// <param name="action">
     /// Given a <see cref="TransactionConfigBuilder"/>, defines how to set the configurations for the new
     /// transaction.
     /// </param>
     /// <returns>A task of a stream of result values and associated metadata.</returns>
-    Task<IResultCursor> RunAsync(string query, object parameters, Action<TransactionConfigBuilder> action = null);
+    Task<IResultCursor> RunAsync(string query, object parameters, Action<TransactionConfigBuilder> action = null)
+    {
+        return RunAsync(new Query(query, parameters), action);
+    }
 
     /// <summary>
     /// Asynchronously run a query within an AutoCommit transaction. Uses the specific <see cref="TransactionConfig"/>

--- a/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IAsyncSession.cs
@@ -172,6 +172,23 @@ public interface IAsyncSession : IAsyncQueryRunner
     /// optionally accepts a set of parameters which will be injected into the query object query by Neo4j.
     /// </summary>
     /// <param name="query">A Cypher query.</param>
+    /// <param name="parameters">
+    /// A parameter object which is made of prop.Name=prop.Value pairs would be created from the object.
+    /// </param>
+    /// <param name="action">
+    /// Given a <see cref="TransactionConfigBuilder"/>, defines how to set the configurations for the new
+    /// transaction.
+    /// </param>
+    /// <returns>A task of a stream of result values and associated metadata.</returns>
+    Task<IResultCursor> RunAsync(string query, object parameters, Action<TransactionConfigBuilder> action = null);
+
+    /// <summary>
+    /// Asynchronously run a query within an AutoCommit transaction. Uses the specific <see cref="TransactionConfig"/>
+    /// and returns a task of result stream. This method accepts a String representing a Cypher query which will be
+    /// compiled into a query object that can be used to efficiently execute this query multiple times. This method
+    /// optionally accepts a set of parameters which will be injected into the query object query by Neo4j.
+    /// </summary>
+    /// <param name="query">A Cypher query.</param>
     /// <param name="parameters">Input parameters for the query.</param>
     /// <param name="action">
     /// Given a <see cref="TransactionConfigBuilder"/>, defines how to set the configurations for the new

--- a/Neo4j.Driver/Neo4j.Driver/Public/Query.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Query.cs
@@ -27,9 +27,37 @@ public class Query
     {
     }
 
-    /// <summary>Create a query with parameters specified as anonymous objects</summary>
-    /// <param name="text">The query's text</param>
-    /// <param name="parameters">The query parameters, specified as an object which is then converted into key-value pairs.</param>
+    /// <summary>Create a query with parameters as an object.</summary>
+    /// <param name="text">The query's text.</param>
+    /// <param name="parameters">
+    /// The query parameters. The driver converts this object to a Cypher parameter map as follows:
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <b>Anonymous types and POCOs:</b> each public property becomes a Cypher parameter, with
+    ///     the property name used as the key. Nested objects become Cypher maps; collections and
+    ///     arrays become Cypher lists.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Dictionary types</b> (<see cref="IDictionary{TKey,TValue}"/> with string keys,
+    ///     <see cref="IReadOnlyDictionary{TKey,TValue}"/>, or <see cref="IEnumerable{T}"/> of
+    ///     <see cref="KeyValuePair{TKey,TValue}"/>): treated as the parameter map.
+    ///   </description></item>
+    /// </list>
+    /// <para>
+    ///   <b>Renaming parameters:</b> decorate a property with
+    ///   <see cref="Mapping.CypherParameterMappingAttribute"/> to override the key used in the
+    ///   Cypher parameter map. For full control, implement
+    ///   <see cref="Mapping.IMappingBindingMutator"/> on a custom attribute.
+    /// </para>
+    /// <para>
+    ///   <b>Global name translation:</b> if
+    ///   <see cref="Mapping.RecordObjectMapping"/><c>.TranslateIdentifiers</c> has been called with
+    ///   <c>translateCypherParameters: true</c>, the configured
+    ///   <see cref="Mapping.ConventionTranslation.IConventionTranslator"/> is applied to top-level
+    ///   property names that do not carry an explicit
+    ///   <see cref="Mapping.CypherParameterMappingAttribute"/>.
+    /// </para>
+    /// </param>
     public Query(string text, object parameters)
         : this(text, parameters.ToCypherParameterDictionary())
     {


### PR DESCRIPTION
Fixes #855.

`IAsyncSession.RunAsync` was missing the `(string, object, Action<TransactionConfigBuilder>)` overload. The two-argument form `RunAsync(string, object)` accepted anonymous types fine, but combining it with a transaction config action required `IDictionary<string, object>` and rejected anonymous types with `CS1503`.

- Added `RunAsync(string query, object parameters, Action<TransactionConfigBuilder> action = null)` to `IAsyncSession` and `AsyncSession` 
- Improved XML documentation to describe the object-to-parameter-map conversion, including anonymous types, POCOs, dictionaries, `[CypherParameterMapping]`, `IMappingBindingMutator`, and global convention translation

Closes DRIVERS-327