### PR TITLE
Backport DRIVERS-26 and DRIVERS-200 to 4.4

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/ConfigBuilder.cs
@@ -44,10 +44,27 @@ namespace Neo4j.Driver
         }
 
         /// <summary>
-        /// Sets the <see cref="Config"/> to use TLS if <paramref name="level"/> is <c>true</c>.
+        /// Overrides the TLS encryption setting inferred from the URI scheme.
         /// </summary>
-        /// <param name="level"><see cref="EncryptionLevel.Encrypted"/> enables TLS for the connection, <see cref="EncryptionLevel.None"/> otherwise. See <see cref="EncryptionLevel"/> for more info</param>.
+        /// <param name="level">
+        /// <see cref="EncryptionLevel.Encrypted"/> requires TLS for all connections;
+        /// <see cref="EncryptionLevel.None"/> disables TLS.
+        /// </param>
         /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
+        /// <remarks>
+        /// <para>
+        /// There are three mutually exclusive ways to configure TLS behaviour:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>Use a <c>+s</c> URI suffix (e.g. <c>bolt+s://</c>, <c>neo4j+s://</c>) — TLS is required and the server certificate must be trusted by the system CA store.</description></item>
+        /// <item><description>Use a <c>+ssc</c> URI suffix (e.g. <c>bolt+ssc://</c>, <c>neo4j+ssc://</c>) — TLS is required and any certificate is accepted (including self-signed).</description></item>
+        /// <item><description>Use a plain <c>bolt://</c> or <c>neo4j://</c> URI and call <see cref="WithEncryptionLevel"/> to control TLS, optionally paired with <see cref="WithTrustManager"/> to configure certificate validation.</description></item>
+        /// </list>
+        /// <para>
+        /// These approaches are mutually exclusive. Calling this method has no effect when a <c>+s</c> or
+        /// <c>+ssc</c> URI scheme is used, as those schemes already imply a specific TLS and trust policy.
+        /// </para>
+        /// </remarks>
         public ConfigBuilder WithEncryptionLevel(EncryptionLevel level)
         {
             _config.NullableEncryptionLevel = level;
@@ -55,12 +72,21 @@ namespace Neo4j.Driver
         }
 
         /// <summary>
-        /// Sets the <see cref="TrustManager"/> to use while establishing trust via TLS.
-        /// The <paramref name="manager"/> will not take effect if <see cref="Config.EncryptionLevel"/> decides to use no TLS
-        /// encryption on the connections.
+        /// Sets a custom <see cref="TrustManager"/> for validating server TLS certificates.
+        /// Has no effect if TLS is not enabled (i.e. <see cref="Config.EncryptionLevel"/> is
+        /// <see cref="EncryptionLevel.None"/> and the URI scheme does not require encryption).
         /// </summary>
-        /// <param name="manager">A <see cref="TrustManager"/> instance.</param>
+        /// <param name="manager">
+        /// A <see cref="TrustManager"/> instance. Use the factory methods on <see cref="TrustManager"/>
+        /// (such as <see cref="TrustManager.CreateChainTrust()"/> or <see cref="TrustManager.CreateCertTrust(System.Collections.Generic.IEnumerable{System.Security.Cryptography.X509Certificates.X509Certificate2})"/>)
+        /// to create an appropriate instance, or subclass <see cref="TrustManager"/> for fully custom behaviour.
+        /// </param>
         /// <returns>An <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
+        /// <remarks>
+        /// This method only applies when using a plain <c>bolt://</c> or <c>neo4j://</c> URI with TLS enabled
+        /// via <see cref="WithEncryptionLevel"/>. When using a <c>+s</c> or <c>+ssc</c> URI scheme, the trust
+        /// policy is already determined by the scheme and this setting is ignored.
+        /// </remarks>
         public ConfigBuilder WithTrustManager(TrustManager manager)
         {
             _config.TrustManager = manager;

--- a/Neo4j.Driver/Neo4j.Driver/EncryptionLevel.cs
+++ b/Neo4j.Driver/Neo4j.Driver/EncryptionLevel.cs
@@ -18,17 +18,31 @@
 namespace Neo4j.Driver
 {
     /// <summary>
-    /// Control the level of encryption to require.
+    /// Controls whether the driver uses TLS encryption for connections.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For most use cases, encryption is configured through the URI scheme rather than this enum.
+    /// Use <c>bolt+s://</c> or <c>neo4j+s://</c> to require TLS, or <c>bolt+ssc://</c> /
+    /// <c>neo4j+ssc://</c> to require TLS while accepting self-signed server certificates.
+    /// </para>
+    /// <para>
+    /// Use <see cref="EncryptionLevel"/> with <see cref="ConfigBuilder.WithEncryptionLevel"/> only
+    /// when connecting via a plain <c>bolt://</c> or <c>neo4j://</c> URI and you need to override
+    /// the default (unencrypted) behaviour.
+    /// </para>
+    /// </remarks>
     public enum EncryptionLevel
     {
         /// <summary>
-        /// No encryption at all.
+        /// Connections are made without TLS. This is the default when using a plain
+        /// <c>bolt://</c> or <c>neo4j://</c> URI.
         /// </summary>
         None,
 
         /// <summary>
-        /// Always encrypted.
+        /// Connections must use TLS. Equivalent to using a <c>+s</c> URI scheme suffix
+        /// (e.g. <c>bolt+s://</c> or <c>neo4j+s://</c>).
         /// </summary>
         Encrypted
     }

--- a/Neo4j.Driver/Neo4j.Driver/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/IDriver.cs
@@ -26,9 +26,16 @@ namespace Neo4j.Driver
     ///     <see cref="IAsyncSession" /> method.
     /// </summary>
     /// <remarks>
-    /// The Driver maintains a connection pool buffering connections created by the user.
+    /// <para>The Driver maintains a connection pool buffering connections created by the user.
     /// The size of the buffer can be configured by the <see cref="Neo4j.Driver.Config.MaxConnectionPoolSize" />
-    /// property on the <see cref="Neo4j.Driver.Config" /> when creating the Driver.
+    /// property on the <see cref="Neo4j.Driver.Config" /> when creating the Driver.</para>
+    /// <para>The driver object is thread-safe and can be shared across threads.</para>
+    /// <para>
+    /// When the driver is disposed, all connections to the database are closed. Ensure that all sessions,
+    /// transactions, and other resources obtained from the driver have been closed <em>before</em> disposal.
+    /// Using the driver or any of its resources concurrently with disposal results in unspecified behavior,
+    /// which may include deadlocks, data races, or errors.
+    /// </para>
     /// </remarks>
     public interface IDriver : IDisposable
     {

--- a/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
@@ -25,9 +25,21 @@ namespace Neo4j.Driver
 {
 
     /// <summary>
-    /// This is the base class all built-in or custom trust manager implementations should be inheriting from. Trust managers
-    /// are the way that one could customise how TLS trust is established.
+    /// Base class for TLS trust managers. A trust manager decides whether to accept a server's TLS certificate
+    /// during connection establishment.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For most use cases, certificate trust is configured through the URI scheme rather than a
+    /// <see cref="TrustManager"/>. Use <c>bolt+s://</c> or <c>neo4j+s://</c> for standard CA-based
+    /// trust, or <c>bolt+ssc://</c> / <c>neo4j+ssc://</c> to accept self-signed server certificates.
+    /// </para>
+    /// <para>
+    /// Use a <see cref="TrustManager"/> (via <see cref="ConfigBuilder.WithTrustManager"/>) when you
+    /// need fine-grained control over certificate validation beyond what the URI scheme provides —
+    /// for example, to pin specific CA certificates or customise revocation checking.
+    /// </para>
+    /// </remarks>
     public abstract class TrustManager
     {
 
@@ -45,83 +57,104 @@ namespace Neo4j.Driver
             SslPolicyErrors sslPolicyErrors);
 
         /// <summary>
-        /// Creates an insecure trust manager that trusts any certificate it is presented, but does hostname verification.
+        /// Creates a trust manager that accepts any certificate without validation, with hostname verification enabled.
         /// </summary>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
+        /// <remarks>
+        /// <b>Warning:</b> this trust manager disables certificate validation and makes connections vulnerable to
+        /// man-in-the-middle attacks. It should not be used in production. Consider using
+        /// <see cref="CreateChainTrust()"/> or <see cref="CreateCertTrust(System.Collections.Generic.IEnumerable{System.Security.Cryptography.X509Certificates.X509Certificate2})"/> instead.
+        /// </remarks>
         public static TrustManager CreateInsecure() => CreateInsecure(false);
 
         /// <summary>
-        /// Creates an insecure trust manager that trusts any certificate it is presented with configurable hostname verification.
+        /// Creates a trust manager that accepts any certificate without validation.
         /// </summary>
-        /// <param name="verifyHostname">Whether to perform hostname verification</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
+        /// <remarks>
+        /// <b>Warning:</b> this trust manager disables certificate validation and makes connections vulnerable to
+        /// man-in-the-middle attacks. It should not be used in production. Consider using
+        /// <see cref="CreateChainTrust()"/> or <see cref="CreateCertTrust(System.Collections.Generic.IEnumerable{System.Security.Cryptography.X509Certificates.X509Certificate2})"/> instead.
+        /// </remarks>
         public static TrustManager CreateInsecure(bool verifyHostname) => new InsecureTrustManager(verifyHostname);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on system certificate stores.
+        /// Creates a trust manager that validates server certificates against the operating system's trusted CA stores,
+        /// with hostname verification enabled.
+        /// This is the recommended option for production environments where the server has a certificate issued by a
+        /// well-known CA.
         /// </summary>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreateChainTrust() => CreateChainTrust(true);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on system certificate stores with configurable hostname
-        /// verification.
+        /// Creates a trust manager that validates server certificates against the operating system's trusted CA stores.
+        /// This is the recommended option for production environments where the server has a certificate issued by a
+        /// well-known CA.
         /// </summary>
-        /// <param name="verifyHostname">Whether to perform hostname verification</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreateChainTrust(bool verifyHostname) => CreateChainTrust(verifyHostname,
             X509RevocationMode.NoCheck, X509RevocationFlag.ExcludeRoot, false);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on system certificate stores with configurable hostname
-        /// verification, revocation checks.
+        /// Creates a trust manager that validates server certificates against the operating system's trusted CA stores.
+        /// This is the recommended option for production environments where the server has a certificate issued by a
+        /// well-known CA.
         /// </summary>
-        /// <param name="verifyHostname">Whether to perform hostname verification</param>
-        /// <param name="revocationMode">The revocation check mode</param>
-        /// <param name="revocationFlag">How should the revocation check should behave</param>
-        /// <param name="useMachineContext">Whether to use machine context instead of user's for certificate stores</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+        /// <param name="revocationMode">Controls how certificate revocation is checked.</param>
+        /// <param name="revocationFlag">Controls which certificates in the chain are checked for revocation.</param>
+        /// <param name="useMachineContext">Whether to use the machine-level certificate store rather than the current user's store.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreateChainTrust(bool verifyHostname, X509RevocationMode revocationMode,
             X509RevocationFlag revocationFlag, bool useMachineContext) =>
             new ChainTrustManager(useMachineContext, verifyHostname, revocationMode, revocationFlag);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on TrustedPeople system certificate store.
+        /// Creates a trust manager that validates server certificates against the
+        /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename">TrustedPeople</see>
+        /// system certificate store, with hostname verification enabled.
         /// </summary>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreatePeerTrust() => CreatePeerTrust(true);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on TrustedPeople system certificate store with configurable
-        /// hostname verification.
+        /// Creates a trust manager that validates server certificates against the
+        /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename">TrustedPeople</see>
+        /// system certificate store.
         /// </summary>
-        /// <param name="verifyHostname">Whether to perform hostname verification</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreatePeerTrust(bool verifyHostname) => CreatePeerTrust(verifyHostname, false);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on TrustedPeople system certificate store with configurable
-        /// hostname verification.
+        /// Creates a trust manager that validates server certificates against the
+        /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename">TrustedPeople</see>
+        /// system certificate store.
         /// </summary>
-        /// <param name="verifyHostname">Whether to perform hostname verification</param>
-        /// <param name="useMachineContext">Whether to use machine context instead of user's for certificate stores</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+        /// <param name="useMachineContext">Whether to use the machine-level certificate store rather than the current user's store.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreatePeerTrust(bool verifyHostname, bool useMachineContext) => new PeerTrustManager(useMachineContext, verifyHostname);
 
         /// <summary>
-        /// Creates a trust manager that establishes trust based on provided list of trusted certificates.
+        /// Creates a trust manager that validates server certificates against a provided list of trusted CA certificates,
+        /// with hostname verification enabled.
+        /// Use this when connecting to a server whose certificate was issued by a private or self-managed CA.
         /// </summary>
-        /// <param name="trusted">List of trusted certificates</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="trusted">The list of trusted CA certificates to validate against.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreateCertTrust(IEnumerable<X509Certificate2> trusted) => CreateCertTrust(trusted, true);
-        
+
         /// <summary>
-        /// Creates a trust manager that establishes trust based on provided list of trusted certificates with configurable
-        /// hostname verification.
+        /// Creates a trust manager that validates server certificates against a provided list of trusted CA certificates.
+        /// Use this when connecting to a server whose certificate was issued by a private or self-managed CA.
         /// </summary>
-        /// <param name="trusted">List of trusted certificates</param>
-        /// <param name="verifyHostname">Whether to perform hostname verification</param>
-        /// <returns>An instance of <see cref="TrustManager"/></returns>
+        /// <param name="trusted">The list of trusted CA certificates to validate against.</param>
+        /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+        /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         public static TrustManager CreateCertTrust(IEnumerable<X509Certificate2> trusted, bool verifyHostname) => new CertificateTrustManager(verifyHostname, trusted);
 
     }

--- a/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
@@ -57,7 +57,7 @@ namespace Neo4j.Driver
             SslPolicyErrors sslPolicyErrors);
 
         /// <summary>
-        /// Creates a trust manager that accepts any certificate without validation, with hostname verification enabled.
+        /// Creates a trust manager that accepts any certificate without validation besides hostname verification.
         /// </summary>
         /// <returns>An instance of <see cref="TrustManager"/>.</returns>
         /// <remarks>

--- a/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/TrustManager.cs
@@ -95,6 +95,10 @@ namespace Neo4j.Driver
         /// </summary>
         /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
         /// <returns>An instance of <see cref="TrustManager"/>.</returns>
+        /// <remarks>
+        /// Certificate revocation checks are disabled by default. Use
+        /// <see cref="CreateChainTrust(bool, X509RevocationMode, X509RevocationFlag, bool)"/> to enable revocation checking.
+        /// </remarks>
         public static TrustManager CreateChainTrust(bool verifyHostname) => CreateChainTrust(verifyHostname,
             X509RevocationMode.NoCheck, X509RevocationFlag.ExcludeRoot, false);
 


### PR DESCRIPTION
Backport of two doc-only fixes to the 4.4 branch.

- **DRIVERS-26**: Improve encryption and TLS configuration API docs — clarifies URI scheme vs explicit API relationship, adds security warnings to insecure trust options.
- **DRIVERS-200**: Clarify disposal behaviour on `IDriver` — makes clear that sessions/transactions must be closed before disposal to avoid unspecified behaviour.