### PR TITLE
Backport DRIVERS-26 and DRIVERS-200 to 5.x

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver/Public/CertificateTrustRule.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/CertificateTrustRule.cs
@@ -15,15 +15,33 @@
 
 namespace Neo4j.Driver;
 
-/// <summary>Rules for how to validate a server certificate.</summary>
+/// <summary>
+/// Controls which server certificates the driver will accept when establishing a TLS connection.
+/// Used with <see cref="ConfigBuilder.WithCertificateTrustRule(CertificateTrustRule, System.Collections.Generic.IReadOnlyList{System.Security.Cryptography.X509Certificates.X509Certificate2})"/>.
+/// </summary>
 public enum CertificateTrustRule
 {
-    /// <summary>Trust only certificates that can build a chain against system's CA stores</summary>
+    /// <summary>
+    /// Accept only certificates that can be verified against the operating system's trusted CA stores.
+    /// This is the recommended option for production environments where the server has a certificate
+    /// issued by a well-known CA.
+    /// </summary>
     TrustSystem = 0,
 
-    /// <summary>Trust certificates that can build an x509Chain against list of specified certificates.</summary>
+    /// <summary>
+    /// Accept only certificates that chain to one of a provided list of trusted CA certificates.
+    /// Use this when connecting to a server with a certificate issued by a private or self-managed CA.
+    /// The list of trusted certificates must be supplied via
+    /// <see cref="ConfigBuilder.WithCertificateTrustRule(CertificateTrustRule, System.Collections.Generic.IReadOnlyList{System.Security.Cryptography.X509Certificates.X509Certificate2})"/>.
+    /// </summary>
     TrustList = 1,
 
-    /// <summary>Trust any certificate</summary>
+    /// <summary>
+    /// Accept any certificate without validation.
+    /// <para>
+    /// <b>Warning:</b> this disables all certificate trust checks and makes the connection vulnerable
+    /// to man-in-the-middle attacks. Do not use in production.
+    /// </para>
+    /// </summary>
     TrustAny = 2
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
@@ -45,13 +45,28 @@ public sealed class ConfigBuilder
         return _config;
     }
 
-    /// <summary>Sets the <see cref="Config"/> to use TLS if <paramref name="level"/> is <c>Encrypted</c>.</summary>
+    /// <summary>
+    /// Overrides the TLS encryption setting inferred from the URI scheme.
+    /// </summary>
     /// <param name="level">
-    /// <see cref="EncryptionLevel.Encrypted"/> enables TLS for the connection,
-    /// <see cref="EncryptionLevel.None"/> otherwise. See <see cref="EncryptionLevel"/> for more info
+    /// <see cref="EncryptionLevel.Encrypted"/> requires TLS for all connections;
+    /// <see cref="EncryptionLevel.None"/> disables TLS.
     /// </param>
-    /// .
     /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
+    /// <remarks>
+    /// <para>
+    /// There are three mutually exclusive ways to configure TLS behaviour:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Use a <c>+s</c> URI suffix (e.g. <c>bolt+s://</c>, <c>neo4j+s://</c>) — TLS is required and the server certificate must be trusted by the system CA store.</description></item>
+    /// <item><description>Use a <c>+ssc</c> URI suffix (e.g. <c>bolt+ssc://</c>, <c>neo4j+ssc://</c>) — TLS is required and any certificate is accepted (including self-signed).</description></item>
+    /// <item><description>Use a plain <c>bolt://</c> or <c>neo4j://</c> URI and call <see cref="WithEncryptionLevel"/> to control TLS, optionally paired with <see cref="WithTrustManager"/> or <see cref="WithCertificateTrustRule(CertificateTrustRule, System.Collections.Generic.IReadOnlyList{System.Security.Cryptography.X509Certificates.X509Certificate2})"/> to configure certificate validation.</description></item>
+    /// </list>
+    /// <para>
+    /// These approaches are mutually exclusive. Calling this method has no effect when a <c>+s</c> or
+    /// <c>+ssc</c> URI scheme is used, as those schemes already imply a specific TLS and trust policy.
+    /// </para>
+    /// </remarks>
     public ConfigBuilder WithEncryptionLevel(EncryptionLevel level)
     {
         _config.NullableEncryptionLevel = level;
@@ -59,12 +74,27 @@ public sealed class ConfigBuilder
     }
 
     /// <summary>
-    /// Sets the <see cref="TrustManager"/> to use while establishing trust via TLS. The <paramref name="manager"/>
-    /// will not take effect if <see cref="Config.EncryptionLevel"/> decides to use no TLS encryption on the connections.
+    /// Sets a custom <see cref="TrustManager"/> for validating server TLS certificates.
+    /// Has no effect if TLS is not enabled (i.e. <see cref="Config.EncryptionLevel"/> is
+    /// <see cref="EncryptionLevel.None"/> and the URI scheme does not require encryption).
     /// </summary>
-    /// <param name="manager">A <see cref="TrustManager"/> instance.</param>
+    /// <param name="manager">
+    /// A <see cref="TrustManager"/> instance. Use the factory methods on <see cref="TrustManager"/>
+    /// (such as <see cref="TrustManager.CreateChainTrust"/> or <see cref="TrustManager.CreateCertTrust"/>)
+    /// to create an appropriate instance, or subclass <see cref="TrustManager"/> for fully custom behaviour.
+    /// </param>
     /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
-    /// <remarks>We recommend using WithCertificateTrustPaths or WithCertificates</remarks>
+    /// <remarks>
+    /// <para>
+    /// For most use cases, prefer <see cref="WithCertificateTrustRule(CertificateTrustRule, System.Collections.Generic.IReadOnlyList{System.Security.Cryptography.X509Certificates.X509Certificate2})"/>,
+    /// which provides a simpler API for the common trust scenarios.
+    /// </para>
+    /// <para>
+    /// This method only applies when using a plain <c>bolt://</c> or <c>neo4j://</c> URI with TLS enabled
+    /// via <see cref="WithEncryptionLevel"/>. When using a <c>+s</c> or <c>+ssc</c> URI scheme, the trust
+    /// policy is already determined by the scheme and this setting is ignored.
+    /// </para>
+    /// </remarks>
     public ConfigBuilder WithTrustManager(TrustManager manager)
     {
         _config.TrustManager = manager;
@@ -321,21 +351,29 @@ public sealed class ConfigBuilder
     }
 
     /// <summary>
-    /// Sets the rule for which Certificate Authority(CA) certificates to use when building trust with a server
-    /// certificate.
+    /// Sets the rule used to validate the server's TLS certificate.
     /// </summary>
-    /// <param name="certificateTrustRule">The rule for validating server certificates when using encryption.</param>
+    /// <param name="certificateTrustRule">The validation rule. See <see cref="CertificateTrustRule"/> for options.</param>
     /// <param name="trustedCaCertificates">
-    /// Optional list of certificates to use to validate a server certificate. should only
-    /// be set when <paramref name="certificateTrustRule"/> is <c>CertificateTrustRule.TrustList</c>
+    /// The CA certificates to trust. Required when <paramref name="certificateTrustRule"/> is
+    /// <see cref="CertificateTrustRule.TrustList"/>; must be <c>null</c> for all other rules.
     /// </param>
     /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     /// <remarks>
-    /// Used in conjunction with <see cref="WithEncryptionLevel"/>. Not to be used when using a non-basic Uri
-    /// Scheme(+s, +ssc) on <see cref="GraphDatabase"/>
+    /// <para>
+    /// There are three mutually exclusive ways to configure TLS behaviour — see
+    /// <see cref="WithEncryptionLevel"/> for a full description. This method configures how the driver
+    /// validates the server certificate and is only meaningful when using the third option: a plain
+    /// <c>bolt://</c> or <c>neo4j://</c> URI with TLS enabled via <see cref="WithEncryptionLevel"/>.
+    /// </para>
+    /// <para>
+    /// When using a <c>+s</c> URI scheme, the driver always validates against the system CA store.
+    /// When using a <c>+ssc</c> URI scheme, the driver accepts any certificate. In both cases this
+    /// setting is ignored.
+    /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentException">Thrown when mismatch between certificateTrustRule and trustedCaCertificates.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when certificateTrustRule is not an expected enum.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="trustedCaCertificates"/> is inconsistent with <paramref name="certificateTrustRule"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="certificateTrustRule"/> is not a recognised value.</exception>
     public ConfigBuilder WithCertificateTrustRule(
         CertificateTrustRule certificateTrustRule,
         IReadOnlyList<X509Certificate2> trustedCaCertificates = null)
@@ -362,24 +400,23 @@ public sealed class ConfigBuilder
     }
 
     /// <summary>
-    /// Sets the rule for which Certificate Authority(CA) certificates to use when building trust with a server
-    /// certificate.
+    /// Sets the rule used to validate the server's TLS certificate, with trusted CA certificates loaded from files.
     /// </summary>
-    /// <param name="certificateTrustRule">The rule for validating server certificates when using encryption.</param>
+    /// <param name="certificateTrustRule">The validation rule. See <see cref="CertificateTrustRule"/> for options.</param>
     /// <param name="trustedCaCertificateFileNames">
-    /// Optional list of paths to certificates to use to validate a server
-    /// certificate. should only be set when using <code>CertificateTrustRule.TrustList</code>
+    /// Paths to PEM or DER-encoded CA certificate files to trust. Required when
+    /// <paramref name="certificateTrustRule"/> is <see cref="CertificateTrustRule.TrustList"/>; must be
+    /// <c>null</c> for all other rules.
     /// </param>
     /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
     /// <remarks>
-    /// Used in conjunction with <see cref="WithEncryptionLevel"/>. Not to be used when using a non-basic Uri
-    /// Scheme(+s, +ssc) on <see cref="GraphDatabase"/>
+    /// Convenience wrapper around
+    /// <see cref="WithCertificateTrustRule(CertificateTrustRule, System.Collections.Generic.IReadOnlyList{System.Security.Cryptography.X509Certificates.X509Certificate2})"/>
+    /// that loads certificates from disk. See that overload for full remarks, including the mutually
+    /// exclusive relationship with <c>+s</c> and <c>+ssc</c> URI schemes.
     /// </remarks>
-    /// <exception cref="ArgumentException">
-    /// Thrown when mismatch between certificateTrustRule and
-    /// trustedCaCertificateFileNames.
-    /// </exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when certificateTrustRule is not an expected enum.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="trustedCaCertificateFileNames"/> is inconsistent with <paramref name="certificateTrustRule"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="certificateTrustRule"/> is not a recognised value.</exception>
     public ConfigBuilder WithCertificateTrustRule(
         CertificateTrustRule certificateTrustRule,
         IReadOnlyList<string> trustedCaCertificateFileNames = null)

--- a/Neo4j.Driver/Neo4j.Driver/Public/EncryptionLevel.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/EncryptionLevel.cs
@@ -15,12 +15,32 @@
 
 namespace Neo4j.Driver;
 
-/// <summary>Control the level of encryption to require.</summary>
+/// <summary>
+/// Controls whether the driver uses TLS encryption for connections.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For most use cases, encryption is configured through the URI scheme rather than this enum.
+/// Use <c>bolt+s://</c> or <c>neo4j+s://</c> to require TLS, or <c>bolt+ssc://</c> /
+/// <c>neo4j+ssc://</c> to require TLS while accepting self-signed server certificates.
+/// </para>
+/// <para>
+/// Use <see cref="EncryptionLevel"/> with <see cref="ConfigBuilder.WithEncryptionLevel"/> only
+/// when connecting via a plain <c>bolt://</c> or <c>neo4j://</c> URI and you need to override
+/// the default (unencrypted) behaviour.
+/// </para>
+/// </remarks>
 public enum EncryptionLevel
 {
-    /// <summary>No encryption at all.</summary>
+    /// <summary>
+    /// Connections are made without TLS. This is the default when using a plain
+    /// <c>bolt://</c> or <c>neo4j://</c> URI.
+    /// </summary>
     None,
 
-    /// <summary>Always encrypted.</summary>
+    /// <summary>
+    /// Connections must use TLS. Equivalent to using a <c>+s</c> URI scheme suffix
+    /// (e.g. <c>bolt+s://</c> or <c>neo4j+s://</c>).
+    /// </summary>
     Encrypted
 }

--- a/Neo4j.Driver/Neo4j.Driver/Public/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/IDriver.cs
@@ -23,9 +23,17 @@ namespace Neo4j.Driver;
 /// via the <see cref="IAsyncSession"/> method.
 /// </summary>
 /// <remarks>
-/// The Driver maintains a connection pool buffering connections created by the user. The size of the buffer can
+/// <para>The Driver maintains a connection pool buffering connections created by the user. The size of the buffer can
 /// be configured by the <see cref="Neo4j.Driver.Config.MaxConnectionPoolSize"/> property on the
-/// <see cref="Neo4j.Driver.Config"/> when creating the Driver.
+/// <see cref="Neo4j.Driver.Config"/> when creating the Driver.</para>
+/// <para>The driver object is thread-safe and can be shared across threads.</para>
+/// <para>
+/// When the driver is disposed — for example at the end of a <c>using</c> block — all connections
+/// to the database are closed. Ensure that all sessions, transactions, and other resources obtained
+/// from the driver have been closed <em>before</em> disposal. Using the driver or any of its
+/// resources concurrently with disposal results in unspecified behavior, which may include
+/// deadlocks, data races, or errors.
+/// </para>
 /// </remarks>
 public interface IDriver : IDisposable, IAsyncDisposable
 {

--- a/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
@@ -22,9 +22,21 @@ using Neo4j.Driver.Internal.Connector.Trust;
 namespace Neo4j.Driver;
 
 /// <summary>
-/// This is the base class all built-in or custom trust manager implementations should be inheriting from. Trust
-/// managers are the way that one could customise how TLS trust is established.
+/// Base class for TLS trust managers. A trust manager decides whether to accept a server's TLS certificate
+/// during connection establishment.
 /// </summary>
+/// <remarks>
+/// <para>
+/// For most use cases, certificate trust is configured through the URI scheme rather than a
+/// <see cref="TrustManager"/>. Use <c>bolt+s://</c> or <c>neo4j+s://</c> for standard CA-based
+/// trust, or <c>bolt+ssc://</c> / <c>neo4j+ssc://</c> to accept self-signed server certificates.
+/// </para>
+/// <para>
+/// Use a <see cref="TrustManager"/> (via <see cref="ConfigBuilder.WithTrustManager"/>) when you
+/// need fine-grained control over certificate validation beyond what the URI scheme provides —
+/// for example, to pin specific CA certificates or customise revocation checking.
+/// </para>
+/// </remarks>
 public abstract class TrustManager
 {
     internal ILogger Logger { get; set; }
@@ -47,25 +59,30 @@ public abstract class TrustManager
         SslPolicyErrors sslPolicyErrors);
 
     /// <summary>
-    /// Creates an insecure trust manager that trusts any certificate it is presented with configurable hostname
-    /// verification.
+    /// Creates a trust manager that accepts any certificate without validation.
     /// </summary>
-    /// <param name="verifyHostname">Whether to perform hostname verification</param>
-    /// <returns>An instance of <see cref="TrustManager"/></returns>
+    /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
+    /// <returns>An instance of <see cref="TrustManager"/>.</returns>
+    /// <remarks>
+    /// <b>Warning:</b> this trust manager disables certificate validation and makes connections vulnerable to
+    /// man-in-the-middle attacks. It should not be used in production. Consider using
+    /// <see cref="CreateChainTrust"/> or <see cref="CreateCertTrust"/> instead.
+    /// </remarks>
     public static TrustManager CreateInsecure(bool verifyHostname = false)
     {
         return new InsecureTrustManager(verifyHostname);
     }
 
     /// <summary>
-    /// Creates a trust manager that establishes trust based on system certificate stores with configurable hostname
-    /// verification, revocation checks.
+    /// Creates a trust manager that validates server certificates against the operating system's trusted CA stores.
+    /// This is the recommended option for production environments where the server has a certificate issued by a
+    /// well-known CA.
     /// </summary>
-    /// <param name="verifyHostname">Whether to perform hostname verification</param>
-    /// <param name="revocationMode">The revocation check mode</param>
-    /// <param name="revocationFlag">How should the revocation check should behave</param>
-    /// <param name="useMachineContext">Whether to use machine context instead of user's for certificate stores</param>
-    /// <returns>An instance of <see cref="TrustManager"/></returns>
+    /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject. Defaults to <c>true</c>.</param>
+    /// <param name="revocationMode">Controls how certificate revocation is checked. Defaults to <see cref="X509RevocationMode.NoCheck"/>.</param>
+    /// <param name="revocationFlag">Controls which certificates in the chain are checked for revocation. Defaults to <see cref="X509RevocationFlag.ExcludeRoot"/>.</param>
+    /// <param name="useMachineContext">Whether to use the machine-level certificate store rather than the current user's store. Defaults to <c>false</c>.</param>
+    /// <returns>An instance of <see cref="TrustManager"/>.</returns>
     public static TrustManager CreateChainTrust(
         bool verifyHostname = true,
         X509RevocationMode revocationMode = X509RevocationMode.NoCheck,
@@ -76,24 +93,25 @@ public abstract class TrustManager
     }
 
     /// <summary>
-    /// Creates a trust manager that establishes trust based on TrustedPeople system certificate store with
-    /// configurable hostname verification.
+    /// Creates a trust manager that validates server certificates against the
+    /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename">TrustedPeople</see>
+    /// system certificate store.
     /// </summary>
-    /// <param name="verifyHostname">Whether to perform hostname verification</param>
-    /// <param name="useMachineContext">Whether to use machine context instead of user's for certificate stores</param>
-    /// <returns>An instance of <see cref="TrustManager"/></returns>
+    /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject. Defaults to <c>true</c>.</param>
+    /// <param name="useMachineContext">Whether to use the machine-level certificate store rather than the current user's store. Defaults to <c>false</c>.</param>
+    /// <returns>An instance of <see cref="TrustManager"/>.</returns>
     public static TrustManager CreatePeerTrust(bool verifyHostname = true, bool useMachineContext = false)
     {
         return new PeerTrustManager(useMachineContext, verifyHostname);
     }
 
     /// <summary>
-    /// Creates a trust manager that establishes trust based on provided list of trusted certificates with
-    /// configurable hostname verification.
+    /// Creates a trust manager that validates server certificates against a provided list of trusted CA certificates.
+    /// Use this when connecting to a server whose certificate was issued by a private or self-managed CA.
     /// </summary>
-    /// <param name="trusted">List of trusted certificates</param>
-    /// <param name="verifyHostname">Whether to perform hostname verification</param>
-    /// <returns>An instance of <see cref="TrustManager"/></returns>
+    /// <param name="trusted">The list of trusted CA certificates to validate against.</param>
+    /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject. Defaults to <c>true</c>.</param>
+    /// <returns>An instance of <see cref="TrustManager"/>.</returns>
     public static TrustManager CreateCertTrust(IEnumerable<X509Certificate2> trusted, bool verifyHostname = true)
     {
         return new CertificateTrustManager(verifyHostname, trusted);


### PR DESCRIPTION
Backport of two doc-only fixes to the 5.x branch.

- **DRIVERS-26**: Improve encryption and TLS configuration API docs — clarifies URI scheme vs explicit API relationship, adds security warnings to insecure trust options.
- **DRIVERS-200**: Clarify disposal behaviour on `IDriver` — makes clear that sessions/transactions must be closed before disposal to avoid unspecified behaviour.