### PR TITLE
Bump version to 6.1.0

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Reactive/Neo4j.Driver.Reactive.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Reactive/Neo4j.Driver.Reactive.csproj
@@ -22,7 +22,7 @@
         <Configurations>Debug;Release;CI</Configurations>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Neo4j.Driver.Reactive.xml</DocumentationFile>
         <RootNamespace>Neo4j.Driver</RootNamespace>
-        <Version>6.0.0</Version>
+        <Version>6.1.0</Version>
         <LangVersion>default</LangVersion>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>

--- a/Neo4j.Driver/Neo4j.Driver.Tests.SimpleDriver/Neo4j.Driver.Tests.SimpleDriver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.SimpleDriver/Neo4j.Driver.Tests.SimpleDriver.csproj
@@ -18,7 +18,7 @@
         <Configurations>Debug;Release;CI</Configurations>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Neo4j.Driver.Simple.xml</DocumentationFile>
         <RootNamespace>Neo4j.Driver</RootNamespace>
-        <Version>6.0.0</Version>
+        <Version>6.1.0</Version>
         <LangVersion>default</LangVersion>
         <Platforms>AnyCPU</Platforms>
         <IsPackable>false</IsPackable>

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -22,7 +22,7 @@
         <Configurations>Debug;Release;CI</Configurations>
         <LangVersion>latest</LangVersion>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Neo4j.Driver.xml</DocumentationFile>
-        <Version>6.0.0</Version>
+        <Version>6.1.0</Version>
         <LangVersion>latest</LangVersion>
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Platforms>AnyCPU</Platforms>

--- a/Neo4j.Driver/common.props
+++ b/Neo4j.Driver/common.props
@@ -1,10 +1,10 @@
 <Project>
     <PropertyGroup>
         <Copyright>Copyright 2002-2023</Copyright>
-        <Version>6.0.0</Version>
-        <AssemblyVersion>6.0.0.0</AssemblyVersion>
-        <AssemblyFileVersion>6.0.0.0</AssemblyFileVersion>
-        <FileVersion>6.0.0.0</FileVersion>
+        <Version>6.1.0</Version>
+        <AssemblyVersion>6.1.0.0</AssemblyVersion>
+        <AssemblyFileVersion>6.1.0.0</AssemblyFileVersion>
+        <FileVersion>6.1.0.0</FileVersion>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Bumps version numbers to 6.1.0 ahead of release.

Files updated:
- `Neo4j.Driver/common.props` — `Version`, `AssemblyVersion`, `AssemblyFileVersion`, `FileVersion`
- `Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj` — `Version`
- `Neo4j.Driver/Neo4j.Driver.Reactive/Neo4j.Driver.Reactive.csproj` — `Version`
- `Neo4j.Driver/Neo4j.Driver.Tests.SimpleDriver/Neo4j.Driver.Tests.SimpleDriver.csproj` — `Version`