### PR TITLE
Fix API docs navbar hidden in docfx 2.78.5

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -56,7 +56,7 @@
       "_appTitle": "",
       "_disableContribution" : true,
       "_appFooter" : "Copyright (c) 2002-2023 Neo4j",
-      "_disableNavbar": true,
+      "_disableNavbar": false,
       "_appLogoPath": "images/neo4j-logo.png",
       "_appFaviconPath": "images/neo4j-logo.png"
     },


### PR DESCRIPTION
`_disableNavbar` went from being silently ignored in docfx 2.75.3 to being correctly enforced in 2.78.5, hiding the entire navbar including the brand/logo. The `neo4j-template` already hides nav links via CSS (`.navbar .navbar-nav { display: none }`), so `_disableNavbar` should be `false`.

This restores the version-stamped title (e.g. "Neo4j Bolt Driver 6.1 for .NET") in the navbar brand on the API docs site.