### PR TITLE
Fix TOC hidden in docfx 2.76+

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -55,6 +55,7 @@
       "_appName": "[app name not set]",
       "_appTitle": "",
       "_disableContribution" : true,
+      "_disableToc": false,
       "_appFooter" : "Copyright (c) 2002-2023 Neo4j",
       "_disableNavbar": false,
       "_appLogoPath": "images/neo4j-logo.png",


### PR DESCRIPTION
docfx 2.76.0 made the `modern` template start honouring `_disableToc`, and auto-sets it to `true` when `_navPath === _tocPath`. Our setup has both `navrel` and `tocrel` pointing to the same `toc.html`, which triggers the auto-disable on every page — the TOC silently disappeared from the 6.1 docs.

Adding `"_disableToc": false` to `globalMetadata` in `docfx.json` overrides this. Verified locally against docfx 2.76.0 and 2.78.5.