### PR TITLE
Fix OverflowException when passing record types as query parameters

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ObjectToCypherParameterDictionaryConverterTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ObjectToCypherParameterDictionaryConverterTests.cs
@@ -595,4 +595,67 @@ public class ObjectToCypherParameterDictionaryConverterTests : MappingTestWithGl
         public IEnumerator<T> GetEnumerator() => _values.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
+
+    [Fact]
+    public void ShouldHandleRecordTypes()
+    {
+        SetupDefaultMocks();
+        var result = GetSubject().Convert(new TestRecord { Id = "abc" });
+        result.Should().HaveCount(1);
+        result.Should().ContainKey("Id");
+        result["Id"].Should().Be("abc");
+    }
+
+    [Fact]
+    public void ShouldSkipWriteOnlyProperties()
+    {
+        SetupDefaultMocks();
+        var result = GetSubject().Convert(new WithWriteOnlyProperty { ReadableProperty = "readable" });
+        result.Should().HaveCount(1);
+        result.Should().ContainKey("ReadableProperty");
+        result.Should().NotContainKey("WriteOnly");
+    }
+
+    [Fact]
+    public void ShouldSkipIndexerProperties()
+    {
+        SetupDefaultMocks();
+        var result = GetSubject().Convert(new WithIndexer { Name = "test" });
+        result.Should().HaveCount(1);
+        result.Should().ContainKey("Name");
+    }
+
+    [Fact]
+    public void ShouldSkipStaticProperties()
+    {
+        SetupDefaultMocks();
+        var result = GetSubject().Convert(new WithStaticProperty { InstanceProperty = "instance" });
+        result.Should().HaveCount(1);
+        result.Should().ContainKey("InstanceProperty");
+        result.Should().NotContainKey("StaticProperty");
+    }
+
+    private record TestRecord
+    {
+        public string Id { get; init; }
+    }
+
+    private class WithWriteOnlyProperty
+    {
+        public string ReadableProperty { get; set; }
+        public string WriteOnly { set { } }
+    }
+
+    private class WithIndexer
+    {
+        private readonly Dictionary<string, string> _data = new();
+        public string Name { get; set; }
+        public string this[string key] { get => _data[key]; set => _data[key] = value; }
+    }
+
+    private class WithStaticProperty
+    {
+        public string InstanceProperty { get; set; }
+        public static string StaticProperty => "static";
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ObjectToDictionary/ObjectToCypherParameterDictionaryConverter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ObjectToDictionary/ObjectToCypherParameterDictionaryConverter.cs
@@ -71,7 +71,9 @@ internal class ObjectToCypherParameterDictionaryConverter(
 
     private IDictionary<string, object> FillDictionary(object o, IDictionary<string, object> dict)
     {
-        foreach (var propInfo in o.GetType().GetRuntimeProperties())
+        foreach (var propInfo in o.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0))
         {
             var mappingBinding = _mappingBindingProvider.GetMappingBinding(propInfo);
             var name = mappingBinding.CypherParameterName ??


### PR DESCRIPTION
Fixes DRIVERS-452. Bug report: #938.

Failing tests were written for the reported bug (record types) and three other property kinds that cause their own exceptions: write-only, indexers, and static properties.

The fix filters the properties used to build the parameter dictionary to only public, readable, non-indexed instance properties.