### PR TITLE
Interrupt stale liveness probe on acquisition timeout (DRIVERS-454)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -171,6 +171,62 @@ public class ConnectionPoolTests
         }
 
         [Fact]
+        public async Task ShouldNotLeakPoolSizeWhenLivenessProbeHangsDuringAcquisitionTimeout()
+        {
+            var connectionMock = new Mock<IPooledConnection>();
+            connectionMock
+                .Setup(x => x.InitAsync(It.IsAny<SessionConfig>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            connectionMock
+                .Setup(x => x.ResetAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // calling SyncAsync hangs indefinitely
+            connectionMock
+                .Setup(x => x.SyncAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(ct => Task.Delay(Timeout.Infinite, ct));
+
+            var connectionDestroyed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            
+            // this setup is called by the subject to destroy its connection
+            connectionMock
+                .Setup(x => x.DestroyAsync())
+                .Returns(() =>
+                {
+                    connectionDestroyed.TrySetResult(true);
+                    return Task.CompletedTask;
+                });
+
+            var factoryMock = new Mock<IPooledConnectionFactory>();
+            factoryMock
+                .Setup(x => x.Create(It.IsAny<Uri>(), It.IsAny<IConnectionReleaseManager>(), It.IsAny<IAuthToken>()))
+                .Returns(connectionMock.Object);
+
+            var pool = new ConnectionPool(
+                factoryMock.Object,
+                driverContext: TestDriverContext.With(
+                    config: x => x
+                        .WithMaxConnectionPoolSize(1)
+                        .WithConnectionAcquisitionTimeout(TimeSpan.FromMilliseconds(200))),
+                validator: new LivenessProbeValidator());
+
+            var act = () => pool.AcquireAsync(AccessMode.Read, null, null, Bookmarks.Empty);
+
+            // probe hangs, so acquisition times out with ClientException.
+            await act.Should().ThrowAsync<ClientException>();
+
+            // await the task marked completed in the mock's Destroy setup
+            // (i.e. the subject destroyed its connection)
+            // or 1-second timeout
+            var completed = await Task.WhenAny(connectionDestroyed.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+            completed.Should().BeSameAs(connectionDestroyed.Task);
+            
+            // pool slot was released
+            pool.PoolSize.Should().Be(0);
+        }
+
+        [Fact]
         public async Task ShouldNotExceedIdleLimit()
         {
             var pool = NewConnectionPool(
@@ -1724,6 +1780,12 @@ public class ConnectionPoolTests
             idleConnections.Count.Should().Be(0);
             VerifyDestroyAsyncCalledOnce(idleMocks);
         }
+    }
+
+    private sealed class LivenessProbeValidator : IConnectionValidator
+    {
+        public Task<bool> OnReleaseAsync(IPooledConnection connection) => Task.FromResult(true);
+        public AcquireStatus GetConnectionLifetimeStatus(IPooledConnection connection) => AcquireStatus.RequiresLivenessProbe;
     }
 
     private class TestConnectionValidator : IConnectionValidator

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -218,8 +218,8 @@ public class ConnectionPoolTests
 
             // await the task marked completed in the mock's Destroy setup
             // (i.e. the subject destroyed its connection)
-            // or 1-second timeout
-            var completed = await Task.WhenAny(connectionDestroyed.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+            // or 10-second timeout (can be slow in CI)
+            var completed = await Task.WhenAny(connectionDestroyed.Task, Task.Delay(TimeSpan.FromSeconds(10)));
             completed.Should().BeSameAs(connectionDestroyed.Task);
             
             // pool slot was released

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -507,8 +507,8 @@ internal sealed class ConnectionPool : IConnectionPool
             {
                 try
                 {
-                    await connection.ResetAsync().ConfigureAwait(false);
-                    await connection.SyncAsync().ConfigureAwait(false);
+                    await connection.ResetAsync(cancellationToken).ConfigureAwait(false);
+                    await connection.SyncAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
@@ -43,11 +43,11 @@ internal abstract class DelegatedConnection : IConnection
         return Delegate.NotifySecurityExceptionAsync(exception);
     }
 
-    public async Task SyncAsync()
+    public async Task SyncAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            await Delegate.SyncAsync().ConfigureAwait(false);
+            await Delegate.SyncAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -55,11 +55,11 @@ internal abstract class DelegatedConnection : IConnection
         }
     }
 
-    public async Task SendAsync()
+    public async Task SendAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            await Delegate.SendAsync().ConfigureAwait(false);
+            await Delegate.SendAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -67,11 +67,11 @@ internal abstract class DelegatedConnection : IConnection
         }
     }
 
-    public async Task ReceiveOneAsync()
+    public async Task ReceiveOneAsync(CancellationToken cancellationToken = default)
     {
         try
         {
-            await Delegate.ReceiveOneAsync().ConfigureAwait(false);
+            await Delegate.ReceiveOneAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -230,9 +230,9 @@ internal abstract class DelegatedConnection : IConnection
         return BoltProtocol.LogoutAsync(this);
     }
 
-    public Task ResetAsync()
+    public Task ResetAsync(CancellationToken cancellationToken = default)
     {
-        return BoltProtocol.ResetAsync(this);
+        return BoltProtocol.ResetAsync(this, cancellationToken);
     }
 
     public Task<IReadOnlyDictionary<string, object>> GetRoutingTableAsync(

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -77,13 +77,13 @@ internal interface IConnection : IConnectionDetails, IConnectionRunner
     ValueTask<bool> NotifySecurityExceptionAsync(SecurityException exception);
 
     // send all and receive all
-    Task SyncAsync();
+    Task SyncAsync(CancellationToken cancellationToken = default);
 
     // send all
-    Task SendAsync();
+    Task SendAsync(CancellationToken cancellationToken = default);
 
     // receive one
-    Task ReceiveOneAsync();
+    Task ReceiveOneAsync(CancellationToken cancellationToken = default);
 
     Task EnqueueAsync(IRequestMessage message, IResponseHandler handler);
 
@@ -95,7 +95,7 @@ internal interface IConnection : IConnectionDetails, IConnectionRunner
     );
 
     // Enqueue a reset message
-    Task ResetAsync();
+    Task ResetAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Close and release related resources</summary>
     Task DestroyAsync();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IMessageWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IMessageWriter.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.IO;
 using Neo4j.Driver.Internal.Messaging;
@@ -22,5 +23,5 @@ namespace Neo4j.Driver.Internal.Connector;
 internal interface IMessageWriter
 {
     void Write(IRequestMessage message, PackStreamWriter writer);
-    Task FlushAsync();
+    Task FlushAsync(CancellationToken cancellationToken = default);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/ISocketClient.cs
@@ -28,9 +28,9 @@ internal interface ISocketClient : IAsyncDisposable
     BoltProtocolVersion Version { get; }
     bool IsOpen { get; }
     Task ConnectAsync(CancellationToken token = default);
-    Task SendAsync(IEnumerable<IRequestMessage> messages);
-    Task ReceiveAsync(IResponsePipeline responsePipeline);
-    Task ReceiveOneAsync(IResponsePipeline responsePipeline);
+    Task SendAsync(IEnumerable<IRequestMessage> messages, CancellationToken cancellationToken = default);
+    Task ReceiveAsync(IResponsePipeline responsePipeline, CancellationToken cancellationToken = default);
+    Task ReceiveOneAsync(IResponsePipeline responsePipeline, CancellationToken cancellationToken = default);
     void SetReadTimeoutInSeconds(int seconds);
     void UseUtcEncoded();
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketClient.cs
@@ -85,7 +85,7 @@ internal sealed class SocketClient : ISocketClient
 
     public BoltProtocolVersion Version { get; private set; }
 
-    public async Task SendAsync(IEnumerable<IRequestMessage> messages)
+    public async Task SendAsync(IEnumerable<IRequestMessage> messages, CancellationToken cancellationToken = default)
     {
         var writer = _packstreamFactory.BuildWriter(_format, _chunkWriter);
         try
@@ -96,7 +96,7 @@ internal sealed class SocketClient : ISocketClient
                 _neo4JLogger.Debug(MessagePattern, message);
             }
 
-            await _chunkWriter.SendAsync().ConfigureAwait(false);
+            await _chunkWriter.SendAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -106,19 +106,19 @@ internal sealed class SocketClient : ISocketClient
         }
     }
 
-    public async Task ReceiveAsync(IResponsePipeline responsePipeline)
+    public async Task ReceiveAsync(IResponsePipeline responsePipeline, CancellationToken cancellationToken = default)
     {
         while (!responsePipeline.HasNoPendingMessages)
         {
-            await ReceiveOneAsync(responsePipeline).ConfigureAwait(false);
+            await ReceiveOneAsync(responsePipeline, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    public async Task ReceiveOneAsync(IResponsePipeline responsePipeline)
+    public async Task ReceiveOneAsync(IResponsePipeline responsePipeline, CancellationToken cancellationToken = default)
     {
         try
         {
-            await _messageReader.ReadAsync(responsePipeline, _format).ConfigureAwait(false);
+            await _messageReader.ReadAsync(responsePipeline, _format, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -219,13 +219,13 @@ internal sealed class SocketConnection : IConnection
         return AuthTokenManager.HandleSecurityExceptionAsync(AuthToken, exception);
     }
 
-    public async Task SyncAsync()
+    public async Task SyncAsync(CancellationToken cancellationToken = default)
     {
-        await SendAsync().ConfigureAwait(false);
-        await ReceiveAsync().ConfigureAwait(false);
+        await SendAsync(cancellationToken).ConfigureAwait(false);
+        await ReceiveAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task SendAsync()
+    public async Task SendAsync(CancellationToken cancellationToken = default)
     {
         if (_messages.Count == 0)
             // nothing to send
@@ -233,11 +233,11 @@ internal sealed class SocketConnection : IConnection
             return;
         }
 
-        await _sendLock.WaitAsync().ConfigureAwait(false);
+        await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             // send
-            await _client.SendAsync(_messages).ConfigureAwait(false);
+            await _client.SendAsync(_messages, cancellationToken).ConfigureAwait(false);
 
             _messages.Clear();
         }
@@ -247,9 +247,9 @@ internal sealed class SocketConnection : IConnection
         }
     }
 
-    public async Task ReceiveOneAsync()
+    public async Task ReceiveOneAsync(CancellationToken cancellationToken = default)
     {
-        await _recvLock.WaitAsync().ConfigureAwait(false);
+        await _recvLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             if (_responsePipeline.HasNoPendingMessages)
@@ -257,7 +257,7 @@ internal sealed class SocketConnection : IConnection
                 return;
             }
 
-            await _client.ReceiveOneAsync(_responsePipeline).ConfigureAwait(false);
+            await _client.ReceiveOneAsync(_responsePipeline, cancellationToken).ConfigureAwait(false);
 
             await HandleAuthErrorAsync(_responsePipeline).ConfigureAwait(false);
             _responsePipeline.AssertNoFailure();
@@ -289,9 +289,9 @@ internal sealed class SocketConnection : IConnection
         }
     }
 
-    public Task ResetAsync()
+    public Task ResetAsync(CancellationToken cancellationToken = default)
     {
-        return BoltProtocol.ResetAsync(this);
+        return BoltProtocol.ResetAsync(this, cancellationToken);
     }
 
     public bool IsOpen => _client.IsOpen;
@@ -530,9 +530,9 @@ internal sealed class SocketConnection : IConnection
         }
     }
 
-    private async Task ReceiveAsync()
+    private async Task ReceiveAsync(CancellationToken cancellationToken = default)
     {
-        await _recvLock.WaitAsync().ConfigureAwait(false);
+        await _recvLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -541,7 +541,7 @@ internal sealed class SocketConnection : IConnection
                 return;
             }
 
-            await _client.ReceiveAsync(_responsePipeline).ConfigureAwait(false);
+            await _client.ReceiveAsync(_responsePipeline, cancellationToken).ConfigureAwait(false);
 
             await HandleAuthErrorAsync(_responsePipeline).ConfigureAwait(false);
             _responsePipeline.AssertNoFailure();

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/StreamExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/StreamExtensions.cs
@@ -31,48 +31,61 @@ internal static class StreamExtensions
     /// <param name="offset">Offset from which to begin writing data from the stream</param>
     /// <param name="count">The maximum number of bytes to read</param>
     /// <param name="timeoutMs">The timeout in milliseconds that the stream will close after if there is no activity.</param>
+    /// <param name="cancellationToken">Token that can cancel the read independently of the timeout.</param>
     /// <returns>The number of bytes read</returns>
     public static async Task<int> ReadWithTimeoutAsync(
         this Stream stream,
         byte[] buffer,
         int offset,
         int count,
-        int timeoutMs)
+        int timeoutMs,
+        CancellationToken cancellationToken = default)
     {
         if (timeoutMs <= 0)
         {
             // no timeout and high traffic code, so avoid allocation Cancellation token source.
-            return await ReadWithoutTimeoutAsync(stream, buffer, offset, count).ConfigureAwait(false);
+            return await ReadWithoutTimeoutAsync(stream, buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        using var source = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs));
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs));
+
+        using var linked = cancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(timeoutSource.Token, cancellationToken)
+            : null;
+
+        var readToken = linked?.Token ?? timeoutSource.Token;
 
         try
         {
             // .netcore 3.0+ network streams support cancellation tokens.
-            return await stream.ReadAsync(buffer.AsMemory(offset, count), source.Token).ConfigureAwait(false);
+            return await stream.ReadAsync(buffer.AsMemory(offset, count), readToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (IsCancellationException(ex))
         {
-            //if the exception relates to cancellation we should throw a timeout.
-            if (source.IsCancellationRequested && IsCancellationException(ex))
-            {
-                // close the stream, the stream will be fully disposed later by SocketClient Dispose.
-                stream.Close();
+            // close the stream, the stream will be fully disposed later by SocketClient Dispose.
+            stream.Close();
 
+            if (timeoutSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
                 throw new ConnectionReadTimeoutException(
                     $"Socket/Stream timed out after {timeoutMs}ms, socket closed.",
                     ex);
             }
 
+            // External cancellation — rethrow as-is so callers can distinguish it from a timeout.
             throw;
         }
     }
 
-    private static Task<int> ReadWithoutTimeoutAsync(Stream stream, byte[] buffer, int offset, int count)
+    private static Task<int> ReadWithoutTimeoutAsync(
+        Stream stream,
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken = default)
     {
         // .netcore 3.0+ network streams support cancellation tokens.
-        return stream.ReadAsync(buffer.AsMemory(offset, count)).AsTask();
+        return stream.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
     }
 
     private static bool IsCancellationException(Exception ex)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkReader.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Helpers;
 
@@ -37,7 +38,9 @@ internal sealed class ChunkReader : IChunkReader
     private MemoryStream ChunkBuffer { get; set; }
     private long ChunkBufferRemaining => ChunkBuffer.Length - ChunkBuffer.Position;
 
-    public async Task<int> ReadMessageChunksToBufferStreamAsync(Stream bufferStream)
+    public async Task<int> ReadMessageChunksToBufferStreamAsync(
+        Stream bufferStream,
+        CancellationToken cancellationToken = default)
     {
         var messageCount = 0;
         //store output streams state, and ensure we add to the end of it.
@@ -52,7 +55,7 @@ internal sealed class ChunkReader : IChunkReader
             //We have not finished parsing the chunk buffer, so further messages to de-chunk
             while (chunkBufferPosition < ChunkBuffer.Length)
             {
-                if (await ConstructMessageAsync(bufferStream).ConfigureAwait(false))
+                if (await ConstructMessageAsync(bufferStream, cancellationToken).ConfigureAwait(false))
                 {
                     messageCount++;
                 }
@@ -80,7 +83,9 @@ internal sealed class ChunkReader : IChunkReader
         ChunkBuffer.Position = 0;
     }
 
-    private async Task PopulateChunkBufferAsync(int requiredSize = Constants.ChunkBufferSize)
+    private async Task PopulateChunkBufferAsync(
+        int requiredSize = Constants.ChunkBufferSize,
+        CancellationToken cancellationToken = default)
     {
         if (ChunkBufferRemaining >= requiredSize)
         {
@@ -99,7 +104,7 @@ internal sealed class ChunkReader : IChunkReader
         while (requiredSize > 0)
         {
             var numBytesRead = await NetworkStream
-                .ReadWithTimeoutAsync(data, 0, bufferSize, _readTimeoutMs)
+                .ReadWithTimeoutAsync(data, 0, bufferSize, _readTimeoutMs, cancellationToken)
                 .ConfigureAwait(false);
 
             if (numBytesRead <= 0)
@@ -121,9 +126,9 @@ internal sealed class ChunkReader : IChunkReader
         }
     }
 
-    private async Task<byte[]> ReadDataOfSizeAsync(int requiredSize)
+    private async Task<byte[]> ReadDataOfSizeAsync(int requiredSize, CancellationToken cancellationToken = default)
     {
-        await PopulateChunkBufferAsync(requiredSize).ConfigureAwait(false);
+        await PopulateChunkBufferAsync(requiredSize, cancellationToken).ConfigureAwait(false);
 
         var data = new byte[requiredSize];
         var readSize = ChunkBuffer.Read(data, 0, requiredSize);
@@ -136,13 +141,13 @@ internal sealed class ChunkReader : IChunkReader
         return data;
     }
 
-    private async Task<bool> ConstructMessageAsync(Stream outputMessageStream)
+    private async Task<bool> ConstructMessageAsync(Stream outputMessageStream, CancellationToken cancellationToken = default)
     {
         var dataRead = false;
 
         while (true)
         {
-            var chunkHeader = await ReadDataOfSizeAsync(ChunkHeaderSize).ConfigureAwait(false);
+            var chunkHeader = await ReadDataOfSizeAsync(ChunkHeaderSize, cancellationToken).ConfigureAwait(false);
             var chunkSize = PackStreamBitConverter.ToUInt16(chunkHeader);
 
             //NOOP or end of message
@@ -159,7 +164,7 @@ internal sealed class ChunkReader : IChunkReader
                 continue;
             }
 
-            var rawChunkData = await ReadDataOfSizeAsync(chunkSize).ConfigureAwait(false);
+            var rawChunkData = await ReadDataOfSizeAsync(chunkSize, cancellationToken).ConfigureAwait(false);
             dataRead = true;
             //Put the raw chunk data into the output stream
             outputMessageStream.Write(rawChunkData, 0, chunkSize);

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/ChunkWriter.cs
@@ -27,7 +27,7 @@ internal interface IChunkWriter
     void OpenChunk();
     void Write(byte[] buffer, int offset, int count);
     void CloseChunk();
-    Task SendAsync();
+    Task SendAsync(CancellationToken cancellationToken = default);
 }
 
 internal sealed class ChunkWriter : Stream, IChunkWriter
@@ -133,14 +133,14 @@ internal sealed class ChunkWriter : Stream, IChunkWriter
         }
     }
 
-    public async Task SendAsync()
+    public async Task SendAsync(CancellationToken cancellationToken = default)
     {
         LogStream(_chunkStream);
 
         _chunkStream.Position = 0;
         try
         {
-            await _chunkStream.CopyToAsync(_downStream).ConfigureAwait(false);
+            await _chunkStream.CopyToAsync(_downStream, cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IChunkReader.cs
@@ -14,12 +14,13 @@
 // limitations under the License.
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Neo4j.Driver.Internal.IO;
 
 internal interface IChunkReader
 {
-    Task<int> ReadMessageChunksToBufferStreamAsync(Stream bufferStream);
+    Task<int> ReadMessageChunksToBufferStreamAsync(Stream bufferStream, CancellationToken cancellationToken = default);
     void SetTimeoutInMs(int ms);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/IMessageReader.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.MessageHandling;
 using Neo4j.Driver.Internal.Protocol;
@@ -22,6 +23,6 @@ namespace Neo4j.Driver.Internal.IO;
 
 internal interface IMessageReader : IAsyncDisposable
 {
-    ValueTask ReadAsync(IResponsePipeline pipeline, MessageFormat format);
+    ValueTask ReadAsync(IResponsePipeline pipeline, MessageFormat format, CancellationToken cancellationToken = default);
     void SetReadTimeoutInMs(int ms);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageReader.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.MessageHandling;
@@ -43,9 +44,9 @@ internal sealed class MessageReader : IMessageReader
 
     public MemoryStream BufferStream { get; }
 
-    public async ValueTask ReadAsync(IResponsePipeline pipeline, MessageFormat format)
+    public async ValueTask ReadAsync(IResponsePipeline pipeline, MessageFormat format, CancellationToken cancellationToken = default)
     {
-        var messageCount = await _chunkReader.ReadMessageChunksToBufferStreamAsync(BufferStream).ConfigureAwait(false);
+        var messageCount = await _chunkReader.ReadMessageChunksToBufferStreamAsync(BufferStream, cancellationToken).ConfigureAwait(false);
         var psr = new PackStreamReader(format, BufferStream, _readerBuffers);
         ConsumeMessages(pipeline, messageCount, psr);
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageWriter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/MessageWriter.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;
@@ -39,8 +40,8 @@ internal sealed class MessageWriter : IMessageWriter
         _chunkWriter.CloseChunk();
     }
 
-    public Task FlushAsync()
+    public Task FlushAsync(CancellationToken cancellationToken = default)
     {
-        return _chunkWriter.SendAsync();
+        return _chunkWriter.SendAsync(cancellationToken);
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PipelinedMessageReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PipelinedMessageReader.cs
@@ -58,11 +58,11 @@ internal sealed class PipelinedMessageReader : IMessageReader
         return _pipeReader.CompleteAsync();
     }
 
-    public async ValueTask ReadAsync(IResponsePipeline pipeline, MessageFormat format)
+    public async ValueTask ReadAsync(IResponsePipeline pipeline, MessageFormat format, CancellationToken cancellationToken = default)
     {
         try
         {
-            var message = await ReadNextMessage(format, _pipeReader).ConfigureAwait(false);
+            var message = await ReadNextMessage(format, _pipeReader, cancellationToken).ConfigureAwait(false);
             message.Dispatch(pipeline);
         }
         catch (IOException)
@@ -70,9 +70,9 @@ internal sealed class PipelinedMessageReader : IMessageReader
             await _pipeReader.CompleteAsync().ConfigureAwait(false);
             throw;
         }
-        catch (OperationCanceledException canceledException)
+        catch (OperationCanceledException canceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            // A timeout has occurred, close the connection.
+            // A timeout has occurred (internal timeout source fired), close the connection.
             await _pipeReader.CompleteAsync(canceledException).ConfigureAwait(false);
             _stream.Close();
             throw new ConnectionReadTimeoutException(
@@ -106,15 +106,22 @@ internal sealed class PipelinedMessageReader : IMessageReader
         _source.CancelAfter(_timeoutInMs);
     }
 
-    private async ValueTask<IResponseMessage> ReadNextMessage(MessageFormat format, PipeReader pipeReader)
+    private async ValueTask<IResponseMessage> ReadNextMessage(
+        MessageFormat format,
+        PipeReader pipeReader,
+        CancellationToken cancellationToken = default)
     {
         ReadResult readResult;
         ushort size;
         do
         {
             ResetCancellation();
+            using var linked = cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(_source.Token, cancellationToken)
+                : null;
+            var readToken = linked?.Token ?? _source.Token;
             // Read Bolt protocol chunk header
-            readResult = await pipeReader.ReadAtLeastAsync(2, _source.Token).ConfigureAwait(false);
+            readResult = await pipeReader.ReadAtLeastAsync(2, readToken).ConfigureAwait(false);
             if (readResult is { IsCompleted: true, Buffer.Length: < 2 })
             {
                 throw new IOException(
@@ -161,7 +168,10 @@ internal sealed class PipelinedMessageReader : IMessageReader
             if (readResult.Buffer.Length < minimumRead)
             {
                 ResetCancellation();
-                readResult = await pipeReader.ReadAtLeastAsync(minimumRead, _source.Token).ConfigureAwait(false);
+                using var linkedInner = cancellationToken.CanBeCanceled
+                    ? CancellationTokenSource.CreateLinkedTokenSource(_source.Token, cancellationToken)
+                    : null;
+                readResult = await pipeReader.ReadAtLeastAsync(minimumRead, linkedInner?.Token ?? _source.Token).ConfigureAwait(false);
                 if (readResult.IsCompleted && readResult.Buffer.Length < minimumRead)
                 {
                     throw new IOException(

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocol.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocol.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.HomeDbCaching;
@@ -60,9 +61,9 @@ internal sealed class BoltProtocol : IBoltProtocol
         return _boltProtocolV3.LogoutAsync(connection);
     }
 
-    public Task ResetAsync(IConnection connection)
+    public Task ResetAsync(IConnection connection, CancellationToken cancellationToken = default)
     {
-        return _boltProtocolV3.ResetAsync(connection);
+        return _boltProtocolV3.ResetAsync(connection, cancellationToken);
     }
 
     public Task ReAuthAsync(IConnection connection, IAuthToken newAuthToken)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolHandlerFactory.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolHandlerFactory.cs
@@ -95,7 +95,7 @@ internal class BoltProtocolHandlerFactory : IBoltProtocolHandlerFactory
     {
         return new ResultCursorBuilder(
             summaryBuilder,
-            connection.ReceiveOneAsync,
+            () => connection.ReceiveOneAsync(),
             requestMore?.Invoke(connection, summaryBuilder, bookmarksTracker),
             cancelRequest?.Invoke(connection, summaryBuilder, bookmarksTracker),
             resultResourceHandler,

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/BoltProtocolV3.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.HomeDbCaching;
@@ -75,8 +76,10 @@ internal sealed class BoltProtocolV3 : IBoltProtocol
         await connection.SendAsync().ConfigureAwait(false);
     }
 
-    public Task ResetAsync(IConnection connection)
+    public Task ResetAsync(IConnection connection, CancellationToken cancellationToken = default)
     {
+        // cancellation token not used - enqueuing doesn't take any time in which to cancel it
+        // - the real cancellable work is in SyncAsync
         return connection.EnqueueAsync(ResetMessage.Instance, NoOpResponseHandler.Instance);
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/IBoltProtocol.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Protocol/IBoltProtocol.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.HomeDbCaching;
@@ -30,7 +31,7 @@ internal interface IBoltProtocol
         INotificationsConfig notificationsConfig);
 
     Task LogoutAsync(IConnection connection);
-    Task ResetAsync(IConnection connection);
+    Task ResetAsync(IConnection connection, CancellationToken cancellationToken = default);
     Task ReAuthAsync(IConnection connection, IAuthToken newAuthToken);
 
     Task<IReadOnlyDictionary<string, object>> GetRoutingTableAsync(


### PR DESCRIPTION
Fixes DRIVERS-454, issue #937.

When the pool acquires an idle connection that needs a liveness probe, it runs `ResetAsync` + `SyncAsync`. If the socket is dead and the server never responds, `SyncAsync` blocks until the OS socket read timeout (~60s). The cancellation token was not passed into that read, so the connection-acquisition timeout only cancelled the wrapper — the blocking read kept running and held the pool slot until the OS timeout. The pool only releases the slot (decrements its connection count) when the connection is destroyed, so a hung probe makes the pool behave as if it were at MaxConnectionPoolSize, refusing new connections until the 60s timeout.

By threading the cancellation token all the way down the IO stack, we can actually interrupt the socket read and let the pool free the slot immediately.

The test `ShouldNotLeakPoolSizeWhenLivenessProbeHangsDuringAcquisitionTimeout` was written to isolate the bug before fixing. It simulates a hanging probe and asserts the connection is destroyed and the pool slot is released.
