### PR TITLE
Support optional constructor and record parameters via default values

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/OptionalMappingTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/OptionalMappingTests.cs
@@ -69,6 +69,45 @@ public class OptionalMappingTests
     }
 
     [Fact]
+    public void ShouldUseParameterDefaultWhenRecordParameterIsAbsent()
+    {
+        var record = TestRecord.Create(["Value"], [69]);
+        var mapped = record.AsObject<RecordWithDefaultParameter>();
+
+        mapped.Value.Should().Be(69);
+        mapped.Extra.Should().Be("implicit");
+    }
+
+    [Fact]
+    public void ShouldUseParameterDefaultWhenConstructorParameterIsAbsent()
+    {
+        var record = TestRecord.Create(["value"], [69]);
+        var mapped = record.AsObject<ClassWithDefaultConstructorParameter>();
+
+        mapped.Value.Should().Be(69);
+        mapped.Extra.Should().Be("implicit");
+    }
+
+    [Fact]
+    public void ShouldUseAttributeDefaultWhenRecordParameterIsAbsent()
+    {
+        var record = TestRecord.Create(["Value"], [69]);
+        var mapped = record.AsObject<RecordWithAttributeDefaultParameter>();
+
+        mapped.Value.Should().Be(69);
+        mapped.Extra.Should().Be(7);
+    }
+
+    [Fact]
+    public void ShouldThrowWhenConstructorParameterWithoutDefaultIsAbsent()
+    {
+        var record = TestRecord.Create(["value"], [69]);
+        var act = () => { _ = record.AsObject<ClassWithRequiredConstructorParameter>(); };
+
+        act.Should().Throw<MappingFailedException>();
+    }
+
+    [Fact]
     public void ShouldFailToCreateObject()
     {
         var record = TestRecord.Create(["NotTheValue"], [69]);
@@ -117,5 +156,37 @@ public class OptionalMappingTests
     private class ClassWithPropertyWithoutDefaultValue
     {
         public int Value { get; set; }
+    }
+
+    private record RecordWithDefaultParameter(int Value, string Extra = "implicit");
+
+    private class ClassWithDefaultConstructorParameter
+    {
+        public ClassWithDefaultConstructorParameter(int value, string extra = "implicit")
+        {
+            Value = value;
+            Extra = extra;
+        }
+
+        public int Value { get; }
+
+        public string Extra { get; }
+    }
+
+    private record RecordWithAttributeDefaultParameter(
+        int Value,
+        [MappingDefaultValue(7)] int Extra);
+
+    private class ClassWithRequiredConstructorParameter
+    {
+        public ClassWithRequiredConstructorParameter(int value, string extra)
+        {
+            Value = value;
+            Extra = extra;
+        }
+
+        public int Value { get; }
+
+        public string Extra { get; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappingSourceDelegateBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappingSourceDelegateBuilder.cs
@@ -40,7 +40,7 @@ internal class MappingSourceDelegateBuilder : IMappingSourceDelegateBuilder
                 return mappingBinding.Optional;
             }
 
-            var (result, returnValue) = (EntityMappingSource: mappingBinding.EntityMappingSource, value) switch
+            var (result, returnValue) = (mappingBinding.EntityMappingSource, value) switch
             {
                 (EntityMappingSource.NodeLabel, INode node) => (true, node.Labels),
                 (EntityMappingSource.RelationshipType, IRelationship relationship) => (true, relationship.Type),

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/ParameterMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/ParameterMapper.cs
@@ -56,14 +56,21 @@ internal class ParameterMapper : IParameterMapper
                     p.parameter.ParameterType,
                     out var mappable);
 
-                if (!success)
+                if (success)
                 {
-                    throw new MappingFailedException(
-                        $"Cannot map record to type {typeof(T).Name} because the record does not " +
-                        $"contain a value for the parameter '{p.parameter.Name}'.");
+                    args.Add(mappable);
+                    continue;
                 }
 
-                args.Add(mappable);
+                if (p.parameter.HasDefaultValue)
+                {
+                    args.Add(p.parameter.DefaultValue);
+                    continue;
+                }
+
+                throw new MappingFailedException(
+                    $"Cannot map record to type {typeof(T).Name} because the record does not " +
+                    $"contain a value for the parameter '{p.parameter.Name}'.");
             }
 
             try

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/MappingOptionalAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/MappingOptionalAttribute.cs
@@ -14,12 +14,11 @@
 // limitations under the License.
 
 using System;
-using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 
 /// <summary>
-/// If a property or is decorated with this attribute, it will be considered optional. The mapper will not throw
+/// If a property is decorated with this attribute, it will be considered optional. The mapper will not throw
 /// an exception if it cannot find the named value in the record. This attribute will have no effect when using
 /// custom-defined mappers.
 /// </summary>


### PR DESCRIPTION
Depends on #943.

Fixes DRIVERS-462

Map absent record fields to constructor/record parameter defaults.

The object mapper previously threw whenever a record was missing a value for a constructor or record parameter, even when that parameter declared a default value. Parameters can now be made optional in the usual idiomatic way: 

```c#
record MyRecord(string Name, int? Age = null);

// or
class MyClass
{
    public MyClass(string key, int count = 0);
}
```


and the parameter mapper will honour the default value, with no need for attributes.

[MappingDefaultValue] continues to work as before, and [MappingOptional] stays property-only.

Resolves #854.