### PR TITLE
FIX: Make stale liveness probe cancellation on acquisition timeout deterministic

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -182,19 +182,16 @@ public class ConnectionPoolTests
                 .Setup(x => x.ResetAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            // calling SyncAsync hangs indefinitely
             connectionMock
                 .Setup(x => x.SyncAsync(It.IsAny<CancellationToken>()))
                 .Returns<CancellationToken>(ct => Task.Delay(Timeout.Infinite, ct));
 
-            var connectionDestroyed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            
-            // this setup is called by the subject to destroy its connection
+            var connectionDestroyed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             connectionMock
                 .Setup(x => x.DestroyAsync())
                 .Returns(() =>
                 {
-                    connectionDestroyed.TrySetResult(true);
+                    connectionDestroyed.TrySetResult();
                     return Task.CompletedTask;
                 });
 
@@ -203,26 +200,23 @@ public class ConnectionPoolTests
                 .Setup(x => x.Create(It.IsAny<Uri>(), It.IsAny<IConnectionReleaseManager>(), It.IsAny<IAuthToken>()))
                 .Returns(connectionMock.Object);
 
+            CancellationTokenSource acquisitionTimeoutSource = null;
             var pool = new ConnectionPool(
                 factoryMock.Object,
                 driverContext: TestDriverContext.With(
                     config: x => x
                         .WithMaxConnectionPoolSize(1)
                         .WithConnectionAcquisitionTimeout(TimeSpan.FromMilliseconds(200))),
-                validator: new LivenessProbeValidator());
+                validator: new LivenessProbeValidator(),
+                acquisitionTimeoutSourceFactory: _ => acquisitionTimeoutSource = new CancellationTokenSource());
 
             var act = () => pool.AcquireAsync(AccessMode.Read, null, null, Bookmarks.Empty);
 
-            // probe hangs, so acquisition times out with ClientException.
             await act.Should().ThrowAsync<ClientException>();
 
-            // await the task marked completed in the mock's Destroy setup
-            // (i.e. the subject destroyed its connection)
-            // or 10-second timeout (can be slow in CI)
-            var completed = await Task.WhenAny(connectionDestroyed.Task, Task.Delay(TimeSpan.FromSeconds(10)));
-            completed.Should().BeSameAs(connectionDestroyed.Task);
-            
-            // pool slot was released
+            acquisitionTimeoutSource.IsCancellationRequested.Should().BeTrue();
+
+            await connectionDestroyed.Task.WaitAsync(TimeSpan.FromSeconds(3));
             pool.PoolSize.Should().Be(0);
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -37,6 +37,8 @@ internal sealed class ConnectionPool : IConnectionPool
 
     private readonly IConnectionValidator _connectionValidator;
 
+    private readonly Func<TimeSpan, CancellationTokenSource> _acquisitionTimeoutSourceFactory;
+
     private readonly string _id;
 
     private readonly BlockingCollection<IPooledConnection> _idleConnections = new();
@@ -67,6 +69,7 @@ internal sealed class ConnectionPool : IConnectionPool
         _neo4JLogger = new PrefixNeo4JLogger(driverContext.Neo4JLogger, $"[{_id}]");
 
         _connectionFactory = connectionFactory;
+        _acquisitionTimeoutSourceFactory = timeout => new CancellationTokenSource(timeout);
         DriverContext = driverContext;
         _connectionValidator = new ConnectionValidator(
             driverContext.Config.ConnectionIdleTimeout,
@@ -82,7 +85,8 @@ internal sealed class ConnectionPool : IConnectionPool
         BlockingCollection<IPooledConnection> idleConnections = null,
         ConcurrentHashSet<IPooledConnection> inUseConnections = null,
         DriverContext driverContext = null,
-        IConnectionValidator validator = null)
+        IConnectionValidator validator = null,
+        Func<TimeSpan, CancellationTokenSource> acquisitionTimeoutSourceFactory = null)
         : this(
             new Uri("bolt://localhost:7687"),
             connectionFactory,
@@ -93,6 +97,11 @@ internal sealed class ConnectionPool : IConnectionPool
         if (validator != null)
         {
             _connectionValidator = validator;
+        }
+
+        if (acquisitionTimeoutSourceFactory != null)
+        {
+            _acquisitionTimeoutSourceFactory = acquisitionTimeoutSourceFactory;
         }
     }
 
@@ -450,24 +459,19 @@ internal sealed class ConnectionPool : IConnectionPool
         AccessMode mode,
         TimeSpan timeout)
     {
-        using var cts = new CancellationTokenSource(timeout);
+        using var cts = _acquisitionTimeoutSourceFactory(timeout);
 
         try
         {
             return await AcquireAsync(mode, database, sessionConfig, cts.Token)
-                .Timeout(timeout, cts.Token)
+                .Timeout(timeout, cts.Token, () => cts.Cancel())
                 .ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
         {
             _poolMetricsListener?.PoolTimedOutToAcquire();
-            if (cts.Token.IsCancellationRequested)
-            {
-                throw new ClientException(
-                    $"Failed to obtain a connection from pool within {ConnectionAcquisitionTimeout}");
-            }
-
-            throw new ClientException("Failed to obtain a connection from pool");
+            throw new ClientException(
+                $"Failed to obtain a connection from pool within {ConnectionAcquisitionTimeout}");
         }
     }
 


### PR DESCRIPTION
Fixes DRIVERS-468.

The fix for #940 (DRIVERS-454) exposed a race condition further up the stack, which would result in the bug intermittently reoccurring. Unit tests passed until a build of a later change failed. To be able to test deterministically, a mockable cancellation token factory was added to the internal ConnectionProvider constructor, allowing a token to be provided and then checked for cancellation. 

The fix was to ensure the cancellation token was explicitly cancelled on acquisition timeout at the time of setting up the timeout.