### PR TITLE
Add configurable connection read timeout cap

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConfigTests.cs
@@ -40,6 +40,7 @@ public class ConfigTests
             config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(100);
             config.ConnectionTimeout.Should().Be(TimeSpan.FromSeconds(30));
+            config.ConnectionReadTimeoutCap.Should().BeNull();
             config.TlsVersion.Should().Be(SslProtocols.Tls12);
             config.TlsNegotiator.Should().BeNull();
         }
@@ -142,6 +143,25 @@ public class ConfigTests
             config.TrustManager.Should().BeNull();
             config.Neo4JLogger.Should().BeOfType<NullNeo4JLogger>();
             config.MaxIdleConnectionPoolSize.Should().Be(3);
+        }
+
+        [Fact]
+        public void WithConnectionReadTimeoutCapShouldModifyTheSingleValue()
+        {
+            var config = Config.Builder.WithConnectionReadTimeoutCap(TimeSpan.FromSeconds(10)).Build();
+            config.ConnectionReadTimeoutCap.Should().Be(TimeSpan.FromSeconds(10));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void WithConnectionReadTimeoutCapShouldRejectNonPositiveValues(int seconds)
+        {
+            var configBuilder = new ConfigBuilder(new Config());
+
+            var ex = Record.Exception(() => configBuilder.WithConnectionReadTimeoutCap(TimeSpan.FromSeconds(seconds)));
+
+            ex.Should().BeOfType<ArgumentOutOfRangeException>();
         }
 
         [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/HelloResponseHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/MessageHandling/HelloResponseHandlerTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Moq;
+using Neo4j.Driver.Internal.Connector;
+using Neo4j.Driver.Internal.MessageHandling;
+using Neo4j.Driver.Internal.MessageHandling.Metadata;
+using Neo4j.Driver.Internal.Protocol;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Internal.MessageHandling;
+
+public class HelloResponseHandlerTests
+{
+    private const string RecvTimeoutKey = "connection.recv_timeout_seconds";
+
+    [Fact]
+    public void ShouldApplyServerReadTimeoutWhenNoCapIsConfigured()
+    {
+        var connection = NewConnection();
+        var handler = new HelloResponseHandler(connection.Object);
+
+        handler.OnSuccess(NewSuccessMetadata(60));
+
+        connection.Verify(x => x.SetReadTimeoutInSeconds(60), Times.Once);
+    }
+
+    [Fact]
+    public void ShouldCapServerReadTimeoutWhenCapIsLower()
+    {
+        var connection = NewConnection(TimeSpan.FromSeconds(10));
+        var handler = new HelloResponseHandler(connection.Object);
+
+        handler.OnSuccess(NewSuccessMetadata(60));
+
+        connection.Verify(x => x.SetReadTimeoutInSeconds(10), Times.Once);
+    }
+
+    [Fact]
+    public void ShouldKeepServerReadTimeoutWhenCapIsHigher()
+    {
+        var connection = NewConnection(TimeSpan.FromSeconds(120));
+        var handler = new HelloResponseHandler(connection.Object);
+
+        handler.OnSuccess(NewSuccessMetadata(60));
+
+        connection.Verify(x => x.SetReadTimeoutInSeconds(60), Times.Once);
+    }
+
+    [Fact]
+    public void ShouldRoundFractionalCapUpToWholeSeconds()
+    {
+        var connection = NewConnection(TimeSpan.FromMilliseconds(1500));
+        var handler = new HelloResponseHandler(connection.Object);
+
+        handler.OnSuccess(NewSuccessMetadata(60));
+
+        connection.Verify(x => x.SetReadTimeoutInSeconds(2), Times.Once);
+    }
+
+    private static Mock<IConnection> NewConnection(TimeSpan? readTimeoutCap = null)
+    {
+        var connection = new Mock<IConnection>();
+        connection.SetupGet(x => x.Version).Returns(BoltProtocolVersion.V5_8);
+        connection.SetupGet(x => x.ConnectionReadTimeoutCap).Returns(readTimeoutCap);
+        return connection;
+    }
+
+    private static Dictionary<string, object> NewSuccessMetadata(long recvTimeoutSeconds)
+    {
+        return new Dictionary<string, object>
+        {
+            [ConfigurationHintsCollector.ConfigHintsKey] = new Dictionary<string, object>
+            {
+                [RecvTimeoutKey] = recvTimeoutSeconds
+            }
+        };
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/DelegatedConnection.cs
@@ -165,6 +165,7 @@ internal abstract class DelegatedConnection : IConnection
 
     public bool UtcEncodedDateTime => Delegate.UtcEncodedDateTime;
     public IAuthToken AuthToken => Delegate.AuthToken;
+    public TimeSpan? ConnectionReadTimeoutCap => Delegate.ConnectionReadTimeoutCap;
 
     public void UpdateId(string newConnId)
     {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/IConnection.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,6 +63,8 @@ internal interface IConnection : IConnectionDetails, IConnectionRunner
 
     public SessionConfig SessionConfig { get; set; }
     bool TelemetryEnabled { get; set; }
+
+    TimeSpan? ConnectionReadTimeoutCap { get; }
 
     bool SsrEnabled { get; set; }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/SocketConnection.cs
@@ -113,6 +113,8 @@ internal sealed class SocketConnection : IConnection
 
     public IDictionary<string, string> RoutingContext => _routingContext ?? Context.RoutingContext;
 
+    public TimeSpan? ConnectionReadTimeoutCap => Context.Config.ConnectionReadTimeoutCap;
+
     public BoltProtocolVersion Version => _client.Version;
 
     /// <summary>Internal Set used for tests.</summary>

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/HelloResponseHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/HelloResponseHandler.cs
@@ -77,7 +77,14 @@ internal sealed class HelloResponseHandler : MetadataCollectingResponseHandler
         var timeoutFound = configMetadata.TryGetValue("connection.recv_timeout_seconds", out var timeoutObject);
         if (timeoutFound && timeoutObject is long timeoutSec)
         {
-            _connection.SetReadTimeoutInSeconds((int)timeoutSec);
+            var timeout = TimeSpan.FromSeconds(timeoutSec);
+            var cap = _connection.ConnectionReadTimeoutCap;
+            if (cap.HasValue && cap.Value < timeout)
+            {
+                timeout = cap.Value;
+            }
+
+            _connection.SetReadTimeoutInSeconds((int)Math.Ceiling(timeout.TotalSeconds));
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Config.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Config.cs
@@ -31,7 +31,7 @@ namespace Neo4j.Driver;
 /// <list type="bullet">
 ///     <item><see cref="EncryptionLevel"/> : <c><see cref="EncryptionLevel"/> Encrypted</c> </item>
 ///     <item><see cref="TrustManager"/> : <c><see cref="TrustManager"/>CreateChainTrust()</c> </item>
-///     <item><see cref="ConnectionTimeout"/>: <c>30s</c> </item> <item><see cref="SocketKeepAlive"/>: <c>true</c></item>
+///     <item><see cref="ConnectionTimeout"/>: <c>30s</c> </item> <item><see cref="ConnectionReadTimeoutCap"/>: <c>null</c> </item> <item><see cref="SocketKeepAlive"/>: <c>true</c></item>
 ///     <item><see cref="MaxConnectionPoolSize"/> : <c>100</c> </item>
 ///     <item><see cref="ConnectionAcquisitionTimeout"/> : <c>1mins</c> </item>
 ///     <item><see cref="ConnectionIdleTimeout"/>: <see cref="InfiniteInterval"/></item>
@@ -141,6 +141,11 @@ public class Config
 
     /// <summary>The connection timeout when establishing a connection with a server.</summary>
     public TimeSpan ConnectionTimeout { get; internal set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Optional upper bound for the server-provided socket read timeout.
+    /// </summary>
+    public TimeSpan? ConnectionReadTimeoutCap { get; internal set; }
 
     /// <summary>The socket keep alive option.</summary>
     public bool SocketKeepAlive { get; internal set; } = true;

--- a/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/ConfigBuilder.cs
@@ -164,6 +164,25 @@ public sealed class ConfigBuilder
     }
 
     /// <summary>
+    /// Sets an optional upper bound for server-provided socket read timeout hints.
+    /// </summary>
+    /// <param name="timeSpan">The maximum socket read timeout to apply.</param>
+    /// <returns>A <see cref="ConfigBuilder"/> instance for further configuration options.</returns>
+    public ConfigBuilder WithConnectionReadTimeoutCap(TimeSpan timeSpan)
+    {
+        if (timeSpan <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeSpan),
+                timeSpan,
+                "must be > 0");
+        }
+
+        _config.ConnectionReadTimeoutCap = timeSpan;
+        return this;
+    }
+
+    /// <summary>
     /// Enable socket to send keep alive pings on TCP level to prevent pooled socket connections from getting killed
     /// after leaving client idle for a long time. The interval of keep alive pings are internal set via your OS system.
     /// </summary>


### PR DESCRIPTION
## Summary
- add an optional `Config.ConnectionReadTimeoutCap` setting
- add `ConfigBuilder.WithConnectionReadTimeoutCap(TimeSpan)`
- cap server-provided `connection.recv_timeout_seconds` hints when the configured cap is lower

## Motivation
Servers can advertise a socket read timeout that is higher than an application's desired failure/retry window. This adds an opt-in upper bound while preserving the existing default behavior when no cap is configured.

## Tests
- `dotnet test Neo4j.Driver\Neo4j.Driver.Tests\Neo4j.Driver.Tests.csproj --filter "FullyQualifiedName~ConfigTests|FullyQualifiedName~HelloResponseHandlerTests"`

Note: a full unfiltered `Neo4j.Driver.Tests` run was started locally but exceeded my 3-minute command timeout, so the focused tests above are the verified local check.