### PR TITLE
Add integration tests for native UUID type

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/ExternalBoltkitInstaller.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Internals/StandAlone/ExternalBoltkitInstaller.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Neo4j.Driver.Internal;
+using Neo4j.Driver.Internal.Util;
 using Org.BouncyCastle.Pkcs;
 using static Neo4j.Driver.IntegrationTests.Internals.DefaultInstallation;
 using static Neo4j.Driver.IntegrationTests.Internals.SettingsHelper;
@@ -73,7 +74,30 @@ public class ExternalBoltkitInstaller : IInstaller
             DefaultConfig[ListenAddr] = Ipv6EnabledAddr;
         }
 
+        // TODO: remove once UUID / Bolt 6.1 is GA (DRIVERS-476)
+        // [uuid-preview] search tag for removal of UUID preview workarounds
+        if (ServerSupportsUuidPreview())
+        {
+            DefaultConfig["internal.dbms.bolt.max_protocol_version"] = "6.1";
+            DefaultConfig["internal.cypher.uuid_type_enabled"] = "true";
+            DefaultConfig["internal.dbms.latest_runtime_version"] = "2147483647";
+            DefaultConfig["internal.dbms.latest_kernel_version"] = "254";
+        }
+
         UpdateSettings(DefaultConfig);
+    }
+
+    // [uuid-preview] search tag for removal of UUID preview workarounds
+    private static bool ServerSupportsUuidPreview()
+    {
+        try
+        {
+            return ServerVersion.From(BoltkitHelper.ServerVersion()) >= ServerVersion.From("2026.5.0");
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     public ISet<ISingleInstance> Start()

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/UuidIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/UuidIT.cs
@@ -51,7 +51,7 @@ public sealed class UuidIT : DirectDriverTestBase
         {
             Guid.Empty,
             new("ffffffff-ffff-ffff-ffff-ffffffffffff"),
-            Guid.NewGuid(),
+            new("01020304-0506-0708-090a-0b0c0d0e0f12"),
             Guid.NewGuid()
         };
 
@@ -125,6 +125,33 @@ public sealed class UuidIT : DirectDriverTestBase
 
             record[0].Should().BeOfType<Guid>();
             record[0].As<Guid>().Should().NotBe(Guid.Empty);
+        }
+        finally
+        {
+            await session.CloseAsync();
+        }
+    }
+
+    [RequireServerFact(MinUuidServerVersion, GreaterThanOrEqualTo)]
+    public async Task ShouldReceiveServerCreatedUuid()
+    {
+        // Construct UUIDs server-side from known strings so we verify the
+        // driver decodes the wire format (16 big-endian bytes) to the exact
+        // expected value, independent of the driver's own encoding.
+        await TestServerCreatedUuid("00000000-0000-0000-0000-000000000000");
+        await TestServerCreatedUuid("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        await TestServerCreatedUuid("01020304-0506-0708-090a-0b0c0d0e0f12");
+    }
+
+    private async Task TestServerCreatedUuid(string uuidString)
+    {
+        var session = Server.Driver.AsyncSession(o => o.WithDefaultAccessMode(AccessMode.Read));
+        try
+        {
+            var cursor = await session.RunAsync("RETURN uuid($s)", new { s = uuidString });
+            var record = await cursor.SingleAsync();
+
+            record[0].As<Guid>().Should().Be(new Guid(uuidString));
         }
         finally
         {

--- a/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/UuidIT.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.Integration/Types/UuidIT.cs
@@ -1,0 +1,150 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Neo4j.Driver.IntegrationTests.Direct;
+using Neo4j.Driver.IntegrationTests.Internals;
+using Xunit.Abstractions;
+using static Neo4j.Driver.IntegrationTests.Internals.VersionComparison;
+
+namespace Neo4j.Driver.IntegrationTests.Types;
+
+// Native UUID support requires Bolt 6.1, available from server 2026.5.0.
+// [uuid-preview] search tag for removal of UUID preview workarounds
+public sealed class UuidIT : DirectDriverTestBase
+{
+    private const string MinUuidServerVersion = "2026.5.0";
+
+    public UuidIT(ITestOutputHelper output, StandAloneIntegrationTestFixture fixture)
+        : base(output, fixture)
+    {
+    }
+
+    [RequireServerFact(MinUuidServerVersion, GreaterThanOrEqualTo)]
+    public async Task ShouldSendAndReceive()
+    {
+        await TestSendAndReceive(Guid.Empty);
+        await TestSendAndReceive(new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+        await TestSendAndReceive(new Guid("01020304-0506-0708-090a-0b0c0d0e0f12"));
+        await TestSendAndReceive(Guid.NewGuid());
+    }
+
+    [RequireServerFact(MinUuidServerVersion, GreaterThanOrEqualTo)]
+    public async Task ShouldSendAndReceiveInList()
+    {
+        var uuids = new List<Guid>
+        {
+            Guid.Empty,
+            new("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+            Guid.NewGuid(),
+            Guid.NewGuid()
+        };
+
+        var session = Server.Driver.AsyncSession(o => o.WithDefaultAccessMode(AccessMode.Read));
+        try
+        {
+            var cursor = await session.RunAsync("RETURN $uuids", new { uuids });
+            var record = await cursor.SingleAsync();
+
+            record[0].Should().BeEquivalentTo(uuids);
+        }
+        finally
+        {
+            await session.CloseAsync();
+        }
+    }
+
+    [RequireServerFact(MinUuidServerVersion, GreaterThanOrEqualTo)]
+    public async Task ShouldSendAndReceiveInMap()
+    {
+        var uuids = new Dictionary<string, Guid>
+        {
+            ["a"] = Guid.NewGuid(),
+            ["b"] = Guid.Empty
+        };
+
+        var session = Server.Driver.AsyncSession(o => o.WithDefaultAccessMode(AccessMode.Read));
+        try
+        {
+            var cursor = await session.RunAsync("RETURN $uuids", new { uuids });
+            var record = await cursor.SingleAsync();
+
+            record[0].Should().BeEquivalentTo(uuids);
+        }
+        finally
+        {
+            await session.CloseAsync();
+        }
+    }
+
+    [RequireServerFact(MinUuidServerVersion, GreaterThanOrEqualTo)]
+    public async Task ShouldStoreAndRetrieveUuidOnNode()
+    {
+        var uuid = Guid.NewGuid();
+
+        var session = Server.Driver.AsyncSession(o => o.WithDefaultAccessMode(AccessMode.Write));
+        try
+        {
+            var cursor = await session.RunAsync(
+                "CREATE (n:Node { id: $uuid }) RETURN n.id",
+                new { uuid });
+
+            var record = await cursor.SingleAsync();
+
+            record[0].As<Guid>().Should().Be(uuid);
+        }
+        finally
+        {
+            await session.CloseAsync();
+        }
+    }
+
+    [RequireServerFact(MinUuidServerVersion, GreaterThanOrEqualTo)]
+    public async Task ShouldReceiveServerGeneratedUuid()
+    {
+        var session = Server.Driver.AsyncSession(o => o.WithDefaultAccessMode(AccessMode.Read));
+        try
+        {
+            var cursor = await session.RunAsync("RETURN uuid()");
+            var record = await cursor.SingleAsync();
+
+            record[0].Should().BeOfType<Guid>();
+            record[0].As<Guid>().Should().NotBe(Guid.Empty);
+        }
+        finally
+        {
+            await session.CloseAsync();
+        }
+    }
+
+    private async Task TestSendAndReceive(Guid uuid)
+    {
+        var session = Server.Driver.AsyncSession(o => o.WithDefaultAccessMode(AccessMode.Read));
+        try
+        {
+            var cursor = await session.RunAsync("RETURN $uuid", new { uuid });
+            var record = await cursor.SingleAsync();
+
+            record[0].As<Guid>().Should().Be(uuid);
+        }
+        finally
+        {
+            await session.CloseAsync();
+        }
+    }
+}


### PR DESCRIPTION
Adds integration tests for the native UUID type (Bolt 6.1, mapped to `System.Guid`), the driver-side counterpart to the testkit ITs.

`UuidIT` covers scalar echo (nil / max / sequential / random), lists, maps, storage on a node, and server-generated `uuid()`. Tests are gated to server `2026.5.0+`.

Verified locally against a 6.1 server — all 5 tests pass.

Closes DRIVERS-448.

> [!NOTE]
> While UUID is in preview, the integration-test server is now started with the required internal preview flags (version-gated, tagged `[uuid-preview]`), so CI actually negotiates 6.1. These workarounds are tracked for removal at GA in DRIVERS-476.