### PR TITLE
Object mapper re-attempts setter mapping for optional constructor parameters, failing when the value is absent from the record

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/ConventionTranslation/TranslationEndToEndTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/ConventionTranslation/TranslationEndToEndTests.cs
@@ -128,4 +128,22 @@ public class TranslationEndToEndTests : MappingTestWithGlobalState
         crewMember.PersonName.Should().Be("Bob");
         crewMember.YearsOfService.Should().Be(10);
     }
+
+    public class NestedDottedMember
+    {
+        [MappingBindings(Path = "mainPerson.fullName")]
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public void ShouldTranslateEachSegmentOfDotSeparatedNonExplicitPath()
+    {
+        var personNode = new Node(0, [], new Dictionary<string, object> { ["full_name"] = "Bob" });
+        var record = TestRecord.Create(("main_person", personNode));
+        RecordObjectMapping.TranslateIdentifiers(FieldCaseConvention.SnakeCase);
+
+        var result = record.AsObject<NestedDottedMember>();
+
+        result.Name.Should().Be("Bob");
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/ConventionTranslation/TranslationEndToEndTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/ConventionTranslation/TranslationEndToEndTests.cs
@@ -146,4 +146,31 @@ public class TranslationEndToEndTests : MappingTestWithGlobalState
 
         result.Name.Should().Be("Bob");
     }
+
+    public class ExplicitParamMember
+    {
+        [MappingConstructor]
+        public ExplicitParamMember([MappingSource("title_field")] string titleField = "from-ctor")
+        {
+            TitleField = titleField;
+        }
+
+        public string TitleField { get; set; }
+    }
+
+    [Fact]
+    public void ShouldRebuildDefaultMapperWhenTranslationConfigChanges()
+    {
+        RecordObjectMapping.TranslateIdentifiers(FieldCaseConvention.SnakeCase);
+        var underSnake = TestRecord.Create(("title_field", "snake"), ("title-field", "kebab"))
+        .AsObject<ExplicitParamMember>();
+
+        underSnake.TitleField.Should().Be("snake");
+
+        RecordObjectMapping.TranslateIdentifiers(FieldCaseConvention.KebabCase);
+        var underKebab = TestRecord.Create(("title_field", "snake"), ("title-field", "kebab"))
+            .AsObject<ExplicitParamMember>();
+            
+        underKebab.TitleField.Should().Be("kebab");
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/ConventionTranslation/TranslationEndToEndTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/ConventionTranslation/TranslationEndToEndTests.cs
@@ -107,4 +107,25 @@ public class TranslationEndToEndTests : MappingTestWithGlobalState
         flightCrew.CoPilot.NumberOfMiddleNames.Should().Be(2);
         flightCrew.CoPilot.FavouriteColor.Should().Be("blue");
     }
+
+    public class CrewMember(string personName, int yearsOfService = 10)
+    {
+        public string PersonName { get; set; } = personName;
+        public int YearsOfService { get; set; } = yearsOfService;
+    }
+
+    [Fact]
+    public void ShouldNotReMapOptionalConstructorParametersWhenTranslating()
+    {
+        // "years_of_service" is absent, so the optional constructor parameter falls back to its default.
+        // under identifier translation the public property resolves to the same record field as the parameter,
+        // so it must not be re-mapped via its setter (which would fail because the field is absent).
+        var record = TestRecord.Create(["person_name"], ["Bob"]);
+        RecordObjectMapping.TranslateIdentifiers(FieldCaseConvention.SnakeCase);
+
+        var crewMember = record.AsObject<CrewMember>();
+
+        crewMember.PersonName.Should().Be("Bob");
+        crewMember.YearsOfService.Should().Be(10);
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Mapping/DefaultMapperTests.cs
@@ -222,6 +222,35 @@ public class DefaultMapperTests
         act.Should().Throw<InvalidOperationException>();
     }
 
+    [Fact]
+    public void ShouldNotPopulatePropertiesWithNonPublicSetters()
+    {
+        // a property with a non-public setter must be left at its default: the mapper should not
+        // reflectively invoke private setters, even when the record contains a matching field.
+        var record = TestRecord.Create(new[] { "Name", "Secret" }, new object[] { "Foo", "shh" });
+
+        var mapper = DefaultMapper.Get<ClassWithPrivateSetter>();
+        var result = mapper.Map(record);
+
+        result.Name.Should().Be("Foo");
+        result.Secret.Should().BeNull();
+    }
+
+    [Fact]
+    public void ShouldNotReMapOptionalConstructorParametersWithPrivateSetters()
+    {
+        // the record omits "age", so the optional constructor parameter falls back to its default.
+        // the corresponding property has a private setter, so it must not be re-mapped via the setter
+        // (which would fail because the value is absent from the record).
+        var record = TestRecord.Create(["name"], ["Foo"]);
+
+        var mapper = DefaultMapper.Get<OptionalConstructorParamWithPrivateSetters>();
+        var result = mapper.Map(record);
+
+        result.Name.Should().Be("Foo");
+        result.Age.Should().Be(99);
+    }
+
     private class SimpleClass
     {
         public int Id { get; set; }
@@ -358,5 +387,24 @@ public class DefaultMapperTests
         private NoConstructors()
         {
         }
+    }
+
+    private class ClassWithPrivateSetter
+    {
+        public string Name { get; set; }
+        public string Secret { get; private set; }
+    }
+
+    private class OptionalConstructorParamWithPrivateSetters
+    {
+        [MappingConstructor]
+        public OptionalConstructorParamWithPrivateSetters(string name, int age = 99)
+        {
+            Name = name;
+            Age = age;
+        }
+
+        public string Name { get; private set; }
+        public int Age { get; private set; }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
@@ -67,7 +67,7 @@ internal static class DefaultMapper
             var mappingBinding = MappingBindingProvider.GetMappingBinding(property);
 
             // don't re-map any fields that were already mapped by the constructor
-            if (!usedEntitySources.Contains(mappingBinding.Path))
+            if (!usedEntitySources.Contains(ResolveRecordField(mappingBinding.Path, mappingBinding.Explicit)))
             {
                 mappingBuilder.Map(setter, mappingBinding);
             }
@@ -84,16 +84,26 @@ internal static class DefaultMapper
         foreach (var parameter in constructor.GetParameters())
         {
             var mappingBinding = MappingBindingProvider.GetMappingBinding(parameter);
-            var key = mappingBinding?.Path;
-            if (key == null || isRecordType)
-            {
-                key = parameter.Name;
-            }
 
-            usedEntitySources.Add(key);
+            // for record types the positional parameter and its generated property share a name, and the property
+            // is mapped by that name rather than by any [MappingSource] on the parameter, so key on the name.
+            var (path, isExplicit) = isRecordType
+                ? (parameter.Name, false)
+                : (mappingBinding.Path, mappingBinding.Explicit);
+
+            usedEntitySources.Add(ResolveRecordField(path, isExplicit));
         }
 
         return usedEntitySources;
+    }
+
+    // resolves a binding's path to the record field it actually reads, so that the used-source comparison matches
+    // on the database field rather than the raw C# name. Non-explicit members are subject to identifier
+    // translation (e.g. a ctor param 'yearsOfService' and a property 'YearsOfService' both resolve to the same
+    // field), while members with [MappingSource] use their path verbatim.
+    private static string ResolveRecordField(string path, bool isExplicit)
+    {
+        return isExplicit ? path : RecordObjectMapping.Instance.GetTranslatedRecordIdentifier(path);
     }
 
     private static bool IsRecord(Type type)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
@@ -103,7 +103,7 @@ internal static class DefaultMapper
     // field), while members with [MappingSource] use their path verbatim.
     private static string ResolveRecordField(string path, bool isExplicit)
     {
-        return isExplicit ? path : RecordObjectMapping.Instance.GetTranslatedRecordIdentifier(path);
+        return isExplicit ? path : RecordObjectMapping.Instance.GetTranslatedRecordPath(path);
     }
 
     private static bool IsRecord(Type type)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/DefaultMapper.cs
@@ -54,11 +54,12 @@ internal static class DefaultMapper
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         foreach (var property in properties)
         {
-            // ignore properties without a setter or with MappingIgnoredAttribute, or compiler generated,
-            // or if the setter has already been mapped elsewhere (e.g. custom mapping config)
-            if (property.SetMethod is null ||
+            // only public setters are mapped. Also ignore properties with MappingIgnoredAttribute
+            // or whose setter has already been mapped elsewhere (e.g. custom mapping config).
+            var setter = property.GetSetMethod();
+            if (setter is null ||
                 property.GetCustomAttribute<MappingIgnoredAttribute>() is not null ||
-                mappedSetters.Contains(property.SetMethod))
+                mappedSetters.Contains(setter))
             {
                 continue;
             }
@@ -68,7 +69,7 @@ internal static class DefaultMapper
             // don't re-map any fields that were already mapped by the constructor
             if (!usedEntitySources.Contains(mappingBinding.Path))
             {
-                mappingBuilder.Map(property.SetMethod, mappingBinding);
+                mappingBuilder.Map(setter, mappingBinding);
             }
         }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/RecordPathFinder.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/RecordPathFinder.cs
@@ -35,11 +35,15 @@ internal class RecordPathFinder : IRecordPathFinder
             return false;
         }
 
+        if (translate)
+        {
+            path = RecordObjectMapping.Instance.GetTranslatedRecordPath(path);
+        }
+
         var dotIndex = path.IndexOf('.');
         if (dotIndex == -1)
         {
             // if the path matches a field name, we can return the value directly
-            path = translate ? RecordObjectMapping.Instance.GetTranslatedRecordIdentifier(path) : path;
             if (record.TryGet(path, out value))
             {
                 return true;
@@ -50,10 +54,7 @@ internal class RecordPathFinder : IRecordPathFinder
             // if there's a dot in the path, we can try to split it and check if the first part
             // matches a field name and the second part matches a property name
             var field = path.Substring(0, dotIndex);
-            field = translate ? RecordObjectMapping.Instance.GetTranslatedRecordIdentifier(field) : field;
-            
             var property = path.Substring(dotIndex + 1);
-            property = translate ? RecordObjectMapping.Instance.GetTranslatedRecordIdentifier(property) : property;
 
             if (!record.TryGetCaseInsensitive(field, out object fieldValue))
             {

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -169,6 +169,22 @@ public class RecordObjectMapping : IRecordObjectMapping
         return _conventionTranslator.Translate(objectIdentifier);
     }
 
+    internal string GetTranslatedRecordPath(string path)
+    {
+        if (path is null || path.IndexOf('.') < 0)
+        {
+            return GetTranslatedRecordIdentifier(path);
+        }
+
+        var segments = path.Split('.');
+        for (var i = 0; i < segments.Length; i++)
+        {
+            segments[i] = GetTranslatedRecordIdentifier(segments[i]);
+        }
+
+        return string.Join(".", segments);
+    }
+
     internal string GetTranslatedCypherParameterName(string propertyName)
     {
         return _translateCypherParameterNames 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/RecordObjectMapping.cs
@@ -207,6 +207,10 @@ public class RecordObjectMapping : IRecordObjectMapping
     {
         _conventionTranslator = conventionTranslator;
         _translateCypherParameterNames = translateCypherParameters;
+
+        // default mappers bake the translation config into their used-source dedup keys at build time and are
+        // cached per type, so if translation config changes the whole cache is invalidated.
+        DefaultMapper.Reset();
     }
 
     private static void TranslateIdentifiers(IConventionTranslator conventionTranslator, bool translateCypherParameters)


### PR DESCRIPTION
Fixes DRIVERS-472

Two related fixes in the default object mapper:

- Stop mapping non-public property setters. The mapper was using
  `PropertyInfo.SetMethod` (any accessibility), so `{ get; private set; }`
  properties were written via reflection — an accidental regression from #751.
  It now maps public setters only, via `GetSetMethod()`.

- Dedup constructor-mapped fields by their resolved record field rather than the
  raw C# name. A constructor parameter and its property could resolve to the same
  record field (under identifier translation) yet differ by name, so the property
  was re-mapped via its setter and threw when the field was absent (optional
  parameter falling back to its default). The dedup now compares the resolved
  field, applying the same translation the lookups use.