### PR TITLE
Enforce unused usings as build errors and clean up offenders

### DIFF
--- a/Neo4j.Driver/.editorconfig
+++ b/Neo4j.Driver/.editorconfig
@@ -61,6 +61,7 @@ csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_using_directive_placement = outside_namespace:silent
+dotnet_diagnostic.IDE0005.severity = warning
 dotnet_diagnostic.bc40000.severity = warning
 dotnet_diagnostic.bc400005.severity = warning
 dotnet_diagnostic.bc40008.severity = warning

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/DefaultHostResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Resolvers/DefaultHostResolver.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/GenericDictionaryExtensions.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Extensions/GenericDictionaryExtensions.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/PackStreamReader.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Reflection;
 using Neo4j.Driver.Internal.Connector;
 using Neo4j.Driver.Internal.Messaging;
 using Neo4j.Driver.Internal.Protocol;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IO/SpanPackStreamReader.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IO/SpanPackStreamReader.cs
@@ -17,7 +17,6 @@ using System;
 using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Neo4j.Driver.Internal.Messaging;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappableValueProvider.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Mapping/MappableValueProvider.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Neo4j.Driver.Internal.Mapping.TypeConversion;
 using Neo4j.Driver.Mapping;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/GqlStatusObjectsAndNotifications.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/MessageHandling/Metadata/GqlStatusObjectsAndNotifications.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Neo4j.Driver.Internal.Result;

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Result/Summary/Notification.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Result/Summary/Notification.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Neo4j.Driver.Internal.Result;
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ObjectToDictionary/ObjectToCypherParameterDictionaryConverter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ObjectToDictionary/ObjectToCypherParameterDictionaryConverter.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
+++ b/Neo4j.Driver/Neo4j.Driver/Neo4j.Driver.csproj
@@ -22,6 +22,8 @@
         <Configurations>Debug;Release;CI</Configurations>
         <LangVersion>latest</LangVersion>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Neo4j.Driver.xml</DocumentationFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <Version>6.2.1</Version>
         <LangVersion>latest</LangVersion>
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/CypherParameterMappingAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/CypherParameterMappingAttribute.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/IMappingBindingMutator.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/IMappingBindingMutator.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Neo4j.Driver.Internal.Mapping;
-
 namespace Neo4j.Driver.Mapping;
 
 /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/MappingDefaultValueAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/MappingDefaultValueAttribute.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/MappingSourceAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/Attributes/MappingSourceAttribute.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using Neo4j.Driver.Internal.Mapping;
 
 namespace Neo4j.Driver.Mapping;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ConventionTranslation/IIdentifierParser.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ConventionTranslation/IIdentifierParser.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
-
 namespace Neo4j.Driver.Mapping.ConventionTranslation;
 
 /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ConventionTranslation/StandardCaseFormatter.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Mapping/ConventionTranslation/StandardCaseFormatter.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Neo4j.Driver.Internal.Helpers;
 
 namespace Neo4j.Driver.Mapping.ConventionTranslation;
 

--- a/Neo4j.Driver/Neo4j.Driver/Public/Types/UnsupportedType.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Types/UnsupportedType.cs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Dynamic;
-using Neo4j.Driver.Internal.Protocol;
-
 namespace Neo4j.Driver;
 
 /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Types/Vector.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Types/Vector.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
Closes DRIVERS-482

Enables `IDE0005` (unnecessary `using` directives) as a build error on the main `Neo4j.Driver` project and cleans up the existing offenders.

## Changes
- `Neo4j.Driver.csproj`: add `EnforceCodeStyleInBuild=true` and `GenerateDocumentationFile=true`. The latter is required for `IDE0005` to be reported during command-line/CI builds.
- `.editorconfig`: set `dotnet_diagnostic.IDE0005.severity = warning`.

`TreatWarningsAsErrors` is already on for `Debug`/`Release`/`CI`, so a stray `using` now fails the build rather than just showing as a Rider squiggle.

- Removes the 17 unused `using` directives this surfaced across 16 files.

Verified with a clean rebuild across net8.0/net9.0/net10.0 in the `CI` configuration (0 errors, 0 `IDE0005`).