### PR TITLE
Move .NET-specific testkit skip decisions into the test backend

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/NativeToCypherTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/NativeToCypherTests.cs
@@ -1,0 +1,35 @@
+using System;
+using FluentAssertions;
+using Neo4j.Driver.Tests.TestBackend.Types;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.TestBackend.Tests;
+
+public class NativeToCypherTests
+{
+    [Fact]
+    public void Convert_Bytes_ProducesSpaceSeparatedHex()
+    {
+        var bytes = new byte[] { 0x00, 0x33, 0x66, 0x99, 0xcc, 0xff };
+
+        var result = (NativeToCypherObject)NativeToCypher.Convert(bytes);
+
+        result.name.Should().Be("CypherBytes");
+        ((NativeToCypherObject.DataType)result.data).value.Should().Be("00 33 66 99 cc ff");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, "NaN")]
+    [InlineData(double.PositiveInfinity, "+Infinity")]
+    [InlineData(double.NegativeInfinity, "-Infinity")]
+    public void Convert_SpecialDouble_ProducesStringValue(double input, string expectedValue)
+    {
+        var result = (NativeToCypherObject)NativeToCypher.Convert(input);
+
+        result.name.Should().Be("CypherFloat");
+        ((NativeToCypherObject.DataType)result.data).value.Should().Be(expectedValue);
+        Action serialize = () => JsonConvert.SerializeObject(result);
+        serialize.Should().NotThrow();
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Neo4j.Driver.Tests.TestBackend.Tests.csproj
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Neo4j.Driver.Tests.TestBackend.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\common.props" />
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <Configurations>Debug;Release;CI</Configurations>
+        <LangVersion>default</LangVersion>
+        <Platforms>AnyCPU</Platforms>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Neo4j.Driver.Tests.TestBackend\Neo4j.Driver.Tests.TestBackend.csproj" />
+    </ItemGroup>
+</Project>

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartSubTestTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartSubTestTests.cs
@@ -40,4 +40,49 @@ public class StartSubTestTests
         response["name"].Value<string>().Should().Be("SkipTest");
         response["data"]["reason"].Value<string>().Should().Contain("relationship");
     }
+
+    [Fact]
+    public void Respond_SkipsSubtest_ForOutOfRangeZonedTimeOffset()
+    {
+        var startSubTest = ZonedTimeSubTest(-86400);
+
+        var response = JObject.Parse(startSubTest.Respond());
+
+        response["name"].Value<string>().Should().Be("SkipTest");
+        response["data"]["reason"].Value<string>().Should().Contain("64800");
+    }
+
+    [Fact]
+    public void Respond_RunsSubtest_ForInRangeZonedTimeOffset()
+    {
+        var startSubTest = ZonedTimeSubTest(3661);
+
+        JObject.Parse(startSubTest.Respond())["name"].Value<string>().Should().Be("RunTest");
+    }
+
+    private static StartSubTest ZonedTimeSubTest(int utcOffsetSeconds)
+    {
+        return new StartSubTest
+        {
+            data = new StartSubTest.StartSubTestType
+            {
+                testName = "tests.stub.http_query.datatypes.test_temporal.TestTemporal.test_zoned_time",
+                subtestArguments = new Dictionary<string, JToken>
+                {
+                    ["x"] = new JObject
+                    {
+                        ["name"] = "CypherTime",
+                        ["data"] = new JObject
+                        {
+                            ["hour"] = 0,
+                            ["minute"] = 0,
+                            ["second"] = 0,
+                            ["nanosecond"] = 0,
+                            ["utc_offset_s"] = utcOffsetSeconds
+                        }
+                    }
+                }
+            }
+        };
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartSubTestTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartSubTestTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Handshake;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.TestBackend.Tests.Protocol.Handshake;
+
+public class StartSubTestTests
+{
+    [Fact]
+    public void Respond_RunsSubtest_ForUnlistedTest()
+    {
+        var startSubTest = new StartSubTest
+        {
+            data = new StartSubTest.StartSubTestType
+            {
+                testName = "some.unlisted.test_name",
+                subtestArguments = new Dictionary<string, JToken>()
+            }
+        };
+
+        JObject.Parse(startSubTest.Respond())["name"].Value<string>().Should().Be("RunTest");
+    }
+
+    [Fact]
+    public void Respond_SkipsSubtest_ForWholeTestSkip()
+    {
+        var startSubTest = new StartSubTest
+        {
+            data = new StartSubTest.StartSubTestType
+            {
+                testName = "x.test_should_echo_relationship",
+                subtestArguments = new Dictionary<string, JToken>()
+            }
+        };
+
+        var response = JObject.Parse(startSubTest.Respond());
+
+        response["name"].Value<string>().Should().Be("SkipTest");
+        response["data"]["reason"].Value<string>().Should().Contain("relationship");
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartTestTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartTestTests.cs
@@ -27,4 +27,18 @@ public class StartTestTests
 
         response["name"].Value<string>().Should().Be("RunTest");
     }
+
+    [Fact]
+    public void Respond_RequestsSubtests_ForZonedTime()
+    {
+        var startTest = new StartTest
+        {
+            data = new StartTest.StartTestType
+            {
+                testName = "tests.stub.http_query.datatypes.test_temporal.TestTemporal.test_zoned_time"
+            }
+        };
+
+        JObject.Parse(startTest.Respond())["name"].Value<string>().Should().Be("RunSubTests");
+    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartTestTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Handshake/StartTestTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Handshake;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.TestBackend.Tests.Protocol.Handshake;
+
+public class StartTestTests
+{
+    [Fact]
+    public void Respond_SkipsBlacklistedTest_WithReason()
+    {
+        var startTest = new StartTest { data = new StartTest.StartTestType { testName = "x.test_should_echo_relationship" } };
+
+        var response = JObject.Parse(startTest.Respond());
+
+        response["name"].Value<string>().Should().Be("SkipTest");
+        response["data"]["reason"].Value<string>().Should().Contain("relationship");
+    }
+
+    [Fact]
+    public void Respond_RunsUnlistedTest()
+    {
+        var startTest = new StartTest { data = new StartTest.StartTestType { testName = "some.unlisted.test_name" } };
+
+        var response = JObject.Parse(startTest.Respond());
+
+        response["name"].Value<string>().Should().Be("RunTest");
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Skip/TestSkipPolicyRegistryTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Skip/TestSkipPolicyRegistryTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.TestBackend.Tests.Protocol.Skip;
+
+public class TestSkipPolicyRegistryTests
+{
+    [Fact]
+    public void GetPolicy_ReturnsMatchingPolicy_WhenTestNameContainsFragment()
+    {
+        var policy = new SkipAllPolicy("blacklisted");
+        var registry = new TestSkipPolicyRegistry(new (string, ITestSkipPolicy)[]
+        {
+            ("module.TestThing.test_specific", policy)
+        });
+
+        registry.GetPolicy("fully.qualified.module.TestThing.test_specific")
+            .Should().BeSameAs(policy);
+    }
+
+    [Fact]
+    public void GetPolicy_ReturnsFirstMatch_WhenMultipleFragmentsMatch()
+    {
+        var first = new SkipAllPolicy("first");
+        var second = new SkipAllPolicy("second");
+        var registry = new TestSkipPolicyRegistry(new (string, ITestSkipPolicy)[]
+        {
+            ("test_a", first),
+            ("test_a", second)
+        });
+
+        registry.GetPolicy("module.test_a").Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void GetPolicy_ReturnsRunAll_WhenNoFragmentMatches()
+    {
+        var registry = new TestSkipPolicyRegistry(new (string, ITestSkipPolicy)[]
+        {
+            ("test_a", new SkipAllPolicy("nope"))
+        });
+
+        registry.GetPolicy("module.test_b").Overall.Should().BeOfType<TestDisposition.RunAll>();
+    }
+
+    [Fact]
+    public void DefaultRegistry_SkipsKnownBlacklistedTest()
+    {
+        TestSkipPolicies.Default.GetPolicy("anything.test_should_echo_relationship").Overall
+            .Should().BeOfType<TestDisposition.SkipAll>();
+    }
+
+    [Fact]
+    public void DefaultRegistry_RunsUnlistedTest()
+    {
+        TestSkipPolicies.Default.GetPolicy("some.totally.unlisted.test_name").Overall
+            .Should().BeOfType<TestDisposition.RunAll>();
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Skip/TestSkipPolicyTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Skip/TestSkipPolicyTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.TestBackend.Tests.Protocol.Skip;
+
+public class TestDispositionTests
+{
+    [Fact]
+    public void RunAll_IsSingletonRunAllCase()
+    {
+        TestDispositions.RunAll.Should().BeOfType<TestDisposition.RunAll>();
+        TestDispositions.RunAll.Should().BeSameAs(TestDispositions.RunAll);
+    }
+
+    [Fact]
+    public void RunSubtests_IsSingletonRunSubtestsCase()
+    {
+        TestDispositions.RunSubtests.Should().BeOfType<TestDisposition.RunSubtests>();
+        TestDispositions.RunSubtests.Should().BeSameAs(TestDispositions.RunSubtests);
+    }
+
+    [Fact]
+    public void SkipAll_CarriesReason()
+    {
+        var disposition = TestDispositions.SkipAll("because reasons");
+
+        disposition.Should().BeOfType<TestDisposition.SkipAll>()
+            .Which.Reason.Should().Be("because reasons");
+    }
+}
+
+public class RunAllPolicyTests
+{
+    [Fact]
+    public void Overall_IsRunAll()
+    {
+        new RunAllPolicy().Overall.Should().BeOfType<TestDisposition.RunAll>();
+    }
+
+    [Fact]
+    public void ShouldRunSubtest_ReturnsTrueWithNoReason()
+    {
+        var run = new RunAllPolicy().ShouldRunSubtest(NoParameters, out var reason);
+
+        run.Should().BeTrue();
+        reason.Should().BeEmpty();
+    }
+
+    private static IReadOnlyDictionary<string, JToken> NoParameters => new Dictionary<string, JToken>();
+}
+
+public class SkipAllPolicyTests
+{
+    [Fact]
+    public void Overall_IsSkipAllWithReason()
+    {
+        new SkipAllPolicy("blacklisted").Overall
+            .Should().BeOfType<TestDisposition.SkipAll>()
+            .Which.Reason.Should().Be("blacklisted");
+    }
+
+    [Fact]
+    public void ShouldRunSubtest_ReturnsFalseWithReason()
+    {
+        var run = new SkipAllPolicy("blacklisted").ShouldRunSubtest(NoParameters, out var reason);
+
+        run.Should().BeFalse();
+        reason.Should().Contain("blacklisted");
+    }
+
+    private static IReadOnlyDictionary<string, JToken> NoParameters => new Dictionary<string, JToken>();
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Skip/TryConstructPolicyTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend.Tests/Protocol/Skip/TryConstructPolicyTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.TestBackend.Tests.Protocol.Skip;
+
+public class TryConstructPolicyTests
+{
+    [Fact]
+    public void Overall_IsRunSubtests()
+    {
+        new TryConstructPolicy().Overall.Should().BeOfType<TestDisposition.RunSubtests>();
+    }
+
+    [Fact]
+    public void ShouldRunSubtest_RunsConstructibleValue()
+    {
+        var run = new TryConstructPolicy().ShouldRunSubtest(CypherTimeWithOffset(3661), out var reason);
+
+        run.Should().BeTrue();
+        reason.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ShouldRunSubtest_SkipsOutOfRangeOffset_WithRealReason()
+    {
+        var run = new TryConstructPolicy().ShouldRunSubtest(CypherTimeWithOffset(-86400), out var reason);
+
+        run.Should().BeFalse();
+        reason.Should().Contain("64800");
+    }
+
+    [Fact]
+    public void DefaultRegistry_UsesTryConstructForZonedTime()
+    {
+        TestSkipPolicies.Default.GetPolicy("tests.stub.http_query.datatypes.test_temporal.TestTemporal.test_zoned_time")
+            .Overall.Should().BeOfType<TestDisposition.RunSubtests>();
+    }
+
+    [Fact]
+    public void ShouldRunSubtest_SkipsUnconstructibleValue()
+    {
+        var parameters = new Dictionary<string, JToken>
+        {
+            ["x"] = JObject.Parse(@"{""name"":""CypherNotARealType"",""data"":{""value"":1}}")
+        };
+
+        var run = new TryConstructPolicy().ShouldRunSubtest(parameters, out var reason);
+
+        run.Should().BeFalse();
+        reason.Should().NotBeEmpty();
+    }
+
+    private static IReadOnlyDictionary<string, JToken> CypherTimeWithOffset(int utcOffsetSeconds)
+    {
+        return new Dictionary<string, JToken>
+        {
+            ["x"] = new JObject
+            {
+                ["name"] = "CypherTime",
+                ["data"] = new JObject
+                {
+                    ["hour"] = 0,
+                    ["minute"] = 0,
+                    ["second"] = 0,
+                    ["nanosecond"] = 0,
+                    ["utc_offset_s"] = utcOffsetSeconds
+                }
+            }
+        };
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/AssemblyAttributes.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Neo4j.Driver.Tests.TestBackend.Tests")]

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/StartSubTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/StartSubTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+using Newtonsoft.Json.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Handshake;
+
+internal class StartSubTest : ProtocolObject
+{
+    public StartSubTestType data { get; set; } = new();
+
+    public override async Task Process()
+    {
+        await Task.CompletedTask;
+    }
+
+    public override string Respond()
+    {
+        var policy = TestSkipPolicies.Default.GetPolicy(data.testName);
+
+        return policy.ShouldRunSubtest(data.subtestArguments, out var reason)
+            ? new ProtocolResponse("RunTest").Encode()
+            : new ProtocolResponse("SkipTest", new { reason }).Encode();
+    }
+
+    public class StartSubTestType
+    {
+        public string testName { get; set; }
+
+        public Dictionary<string, JToken> subtestArguments { get; set; } = new();
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/StartTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Handshake/StartTest.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
 
 namespace Neo4j.Driver.Tests.TestBackend.Protocol.Handshake;
 
@@ -28,13 +29,12 @@ internal class StartTest : ProtocolObject
 
     public override string Respond()
     {
-        var reason = string.Empty;
-        if (TestBlackList.FindTest(data.testName, out reason))
+        return TestSkipPolicies.Default.GetPolicy(data.testName).Overall switch
         {
-            return new ProtocolResponse("SkipTest", new { reason }).Encode();
-        }
-
-        return new ProtocolResponse("RunTest").Encode();
+            TestDisposition.SkipAll skip => new ProtocolResponse("SkipTest", new { reason = skip.Reason }).Encode(),
+            TestDisposition.RunSubtests => new ProtocolResponse("RunSubTests").Encode(),
+            _ => new ProtocolResponse("RunTest").Encode()
+        };
     }
 
     public class StartTestType

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/ITestSkipPolicy.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/ITestSkipPolicy.cs
@@ -1,0 +1,26 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal interface ITestSkipPolicy
+{
+    TestDisposition Overall { get; }
+
+    bool ShouldRunSubtest(IReadOnlyDictionary<string, JToken> parameters, out string skipReason);
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/RunAllPolicy.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/RunAllPolicy.cs
@@ -1,0 +1,30 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal sealed class RunAllPolicy : ITestSkipPolicy
+{
+    public TestDisposition Overall => TestDispositions.RunAll;
+
+    public bool ShouldRunSubtest(IReadOnlyDictionary<string, JToken> parameters, out string skipReason)
+    {
+        skipReason = string.Empty;
+        return true;
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/SkipAllPolicy.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/SkipAllPolicy.cs
@@ -1,0 +1,37 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal sealed class SkipAllPolicy : ITestSkipPolicy
+{
+    private readonly string _reason;
+
+    public SkipAllPolicy(string reason)
+    {
+        _reason = reason;
+    }
+
+    public TestDisposition Overall => TestDispositions.SkipAll(_reason);
+
+    public bool ShouldRunSubtest(IReadOnlyDictionary<string, JToken> parameters, out string skipReason)
+    {
+        skipReason = $"All subtests skipped: {_reason}";
+        return false;
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestDisposition.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestDisposition.cs
@@ -1,0 +1,34 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal abstract record TestDisposition
+{
+    public sealed record RunAll : TestDisposition;
+
+    public sealed record RunSubtests : TestDisposition;
+
+    public sealed record SkipAll(string Reason) : TestDisposition;
+}
+
+internal static class TestDispositions
+{
+    public static TestDisposition RunAll { get; } = new TestDisposition.RunAll();
+
+    public static TestDisposition RunSubtests { get; } = new TestDisposition.RunSubtests();
+
+    public static TestDisposition SkipAll(string reason) => new TestDisposition.SkipAll(reason);
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestSkipPolicies.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestSkipPolicies.cs
@@ -1,0 +1,35 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal static class TestSkipPolicies
+{
+    public static TestSkipPolicyRegistry Default { get; } = Build();
+
+    private static TestSkipPolicyRegistry Build()
+    {
+        var entries = new List<(string NameFragment, ITestSkipPolicy Policy)>();
+
+        entries.AddRange(
+            TestBlackList.Entries.Select(
+                blacklisted => (blacklisted.Name, (ITestSkipPolicy)new SkipAllPolicy(blacklisted.Reason))));
+
+        return new TestSkipPolicyRegistry(entries);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestSkipPolicies.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestSkipPolicies.cs
@@ -24,7 +24,10 @@ internal static class TestSkipPolicies
 
     private static TestSkipPolicyRegistry Build()
     {
-        var entries = new List<(string NameFragment, ITestSkipPolicy Policy)>();
+        var entries = new List<(string NameFragment, ITestSkipPolicy Policy)>
+        {
+            ("test_zoned_time", new TryConstructPolicy())
+        };
 
         entries.AddRange(
             TestBlackList.Entries.Select(

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestSkipPolicyRegistry.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TestSkipPolicyRegistry.cs
@@ -1,0 +1,43 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal sealed class TestSkipPolicyRegistry
+{
+    private static readonly ITestSkipPolicy RunAll = new RunAllPolicy();
+
+    private readonly IReadOnlyList<(string NameFragment, ITestSkipPolicy Policy)> _entries;
+
+    public TestSkipPolicyRegistry(IReadOnlyList<(string NameFragment, ITestSkipPolicy Policy)> entries)
+    {
+        _entries = entries;
+    }
+
+    public ITestSkipPolicy GetPolicy(string testName)
+    {
+        foreach (var (fragment, policy) in _entries)
+        {
+            if (testName.Contains(fragment))
+            {
+                return policy;
+            }
+        }
+
+        return RunAll;
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TryConstructPolicy.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Protocol/Skip/TryConstructPolicy.cs
@@ -1,0 +1,46 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Neo4j.Driver.Tests.TestBackend.Protocol.Session;
+using Neo4j.Driver.Tests.TestBackend.Types;
+using Newtonsoft.Json.Linq;
+
+namespace Neo4j.Driver.Tests.TestBackend.Protocol.Skip;
+
+internal sealed class TryConstructPolicy : ITestSkipPolicy
+{
+    public TestDisposition Overall => TestDispositions.RunSubtests;
+
+    public bool ShouldRunSubtest(IReadOnlyDictionary<string, JToken> parameters, out string skipReason)
+    {
+        foreach (var value in parameters.Values)
+        {
+            try
+            {
+                CypherToNative.Convert(JsonCypherParameterParser.ExtractParameterFromProperty(value as JObject));
+            }
+            catch (Exception ex)
+            {
+                skipReason = ex.Message;
+                return false;
+            }
+        }
+
+        skipReason = string.Empty;
+        return true;
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 
 namespace Neo4j.Driver.Tests.TestBackend;
@@ -136,17 +135,4 @@ internal static class TestBlackList
             "Re-enabling cache delayed until 6.0 release."),
     };
 
-    public static bool FindTest(string testName, out string reason)
-    {
-        var item = Array.Find(BlackListNames, x => testName.Contains(x.Name));
-
-        if (item != default)
-        {
-            reason = item.Reason;
-            return true;
-        }
-
-        reason = string.Empty;
-        return false;
-    }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/TestBlackList.cs
@@ -14,11 +14,14 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Neo4j.Driver.Tests.TestBackend;
 
 internal static class TestBlackList
 {
+    public static IReadOnlyList<(string Name, string Reason)> Entries => BlackListNames;
+
     private static readonly (string Name, string Reason)[] BlackListNames =
     {
         ("test_session_run.TestSessionRun.test_iteration_nested",

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/CypherToNative.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/CypherToNative.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Neo4j.Driver.Internal.Util;
 using Neo4j.Driver.Tests.TestBackend.Protocol.Session;
@@ -93,7 +92,7 @@ internal class CypherToNative
         { "CypherInt", typeof(long) },
         { "CypherFloat", typeof(double) },
         { "CypherString", typeof(string) },
-        { "CypherByteArray", typeof(byte[]) },
+        { "CypherBytes", typeof(byte[]) },
 
         { "CypherDate", typeof(LocalDate) },
         { "CypherTime", typeof(OffsetTime) },
@@ -118,9 +117,9 @@ internal class CypherToNative
 
         { typeof(bool), CypherSimple },
         { typeof(long), CypherSimple },
-        { typeof(double), CypherSimple },
+        { typeof(double), CypherDouble },
         { typeof(string), CypherSimple },
-        { typeof(byte[]), CypherSimple },
+        { typeof(byte[]), CypherBytesConvert },
 
         { typeof(LocalDate), CypherDateTime },
         { typeof(OffsetTime), CypherDateTime },
@@ -144,23 +143,53 @@ internal class CypherToNative
             return null;
         }
 
-        try
+        if (!TypeMap.TryGetValue(sourceObject.name, out var objectType))
         {
-            var objectType = TypeMap[sourceObject.name];
-            var function = FunctionMap[objectType];
+            throw new ArgumentException($"Unsupported Cypher type: {sourceObject.name}");
+        }
 
-            return function(objectType, sourceObject);
-        }
-        catch
+        if(!FunctionMap.TryGetValue(objectType, out var function))
         {
-            throw new IOException(
-                $"Attempting to convert an unsupported object type to a CypherType: {sourceObject.GetType()}");
+            throw new ArgumentException($"Missing conversion function for: {objectType}");
         }
+
+        return function(objectType, sourceObject);
     }
 
     public static object CypherSimple(Type objectType, CypherToNativeObject cypherObject)
     {
         return ((SimpleValue)cypherObject.data).value;
+    }
+
+    public static object CypherDouble(Type objectType, CypherToNativeObject cypherObject)
+    {
+        var raw = ((SimpleValue)cypherObject.data).value;
+        return raw switch
+        {
+            double d => d,
+            string s => s switch
+            {
+                "NaN" => double.NaN,
+                "Infinity" or "+Infinity" => double.PositiveInfinity,
+                "-Infinity" => double.NegativeInfinity,
+                _ => double.Parse(s, System.Globalization.CultureInfo.InvariantCulture)
+            },
+            _ => System.Convert.ToDouble(raw)
+        };
+    }
+
+    public static object CypherBytesConvert(Type objectType, CypherToNativeObject cypherObject)
+    {
+        var hex = (string)((SimpleValue)cypherObject.data).value;
+        if (string.IsNullOrEmpty(hex))
+            return Array.Empty<byte>();
+
+        var parts = hex.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        var bytes = new byte[parts.Length];
+        for (var i = 0; i < parts.Length; i++)
+            bytes[i] = System.Convert.ToByte(parts[i], 16);
+
+        return bytes;
     }
 
     public static object CypherTODO(Type objectType, CypherToNativeObject cypherObject)

--- a/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/NativeToCypher.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests.TestBackend/Types/NativeToCypher.cs
@@ -47,9 +47,9 @@ internal static class NativeToCypher
 
         { typeof(bool), CypherSimple },
         { typeof(long), CypherSimple },
-        { typeof(double), CypherSimple },
+        { typeof(double), CypherDouble },
         { typeof(string), CypherSimple },
-        { typeof(byte[]), CypherSimple },
+        { typeof(byte[]), CypherBytes },
 
         { typeof(LocalDate), CypherDateTime },
         { typeof(OffsetTime), CypherDateTime },
@@ -108,7 +108,7 @@ internal static class NativeToCypher
 
         if (sourceObject is double)
         {
-            return FunctionMap[typeof(double)]("CypherFloat", sourceObject);
+            return CypherDouble("CypherFloat", sourceObject);
         }
 
         if (sourceObject is string)
@@ -118,7 +118,7 @@ internal static class NativeToCypher
 
         if (sourceObject is byte[])
         {
-            return FunctionMap[typeof(byte[])]("CypherByteArray", sourceObject);
+            return CypherBytes("CypherBytes", sourceObject);
         }
 
         if (sourceObject as LocalDate != null)
@@ -178,6 +178,25 @@ internal static class NativeToCypher
     public static NativeToCypherObject CypherSimple(string cypherType, object obj)
     {
         return new NativeToCypherObject { name = cypherType, data = new NativeToCypherObject.DataType { value = obj } };
+    }
+
+    public static NativeToCypherObject CypherDouble(string cypherType, object obj)
+    {
+        var d = (double)obj;
+        object value = d switch
+        {
+            double.NaN => "NaN",
+            double.PositiveInfinity => "+Infinity",
+            double.NegativeInfinity => "-Infinity",
+            _ => d
+        };
+        return new NativeToCypherObject { name = cypherType, data = new NativeToCypherObject.DataType { value = value } };
+    }
+
+    public static NativeToCypherObject CypherBytes(string cypherType, object obj)
+    {
+        var hex = string.Join(" ", ((byte[])obj).Select(b => b.ToString("x2")));
+        return new NativeToCypherObject { name = cypherType, data = new NativeToCypherObject.DataType { value = hex } };
     }
 
     public static NativeToCypherObject CypherMap(string cypherType, object obj)

--- a/Neo4j.Driver/Neo4j.Driver.sln
+++ b/Neo4j.Driver/Neo4j.Driver.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neo4j.Driver.Tests.TestBack
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neo4j.Driver.Tests.BenchkitBackend", "Neo4j.Driver.Tests.BenchkitBackend\Neo4j.Driver.Tests.BenchkitBackend.csproj", "{EFFB6047-6BD4-4CEE-9D5B-09DFE8B8340E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Neo4j.Driver.Tests.TestBackend.Tests", "Neo4j.Driver.Tests.TestBackend.Tests\Neo4j.Driver.Tests.TestBackend.Tests.csproj", "{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -76,6 +78,12 @@ Global
 		{EFFB6047-6BD4-4CEE-9D5B-09DFE8B8340E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EFFB6047-6BD4-4CEE-9D5B-09DFE8B8340E}.CI|Any CPU.ActiveCfg = CI|Any CPU
 		{EFFB6047-6BD4-4CEE-9D5B-09DFE8B8340E}.CI|Any CPU.Build.0 = CI|Any CPU
+		{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}.CI|Any CPU.ActiveCfg = CI|Any CPU
+		{5B1611FB-06FF-4BF7-BE1C-B0D938702D2E}.CI|Any CPU.Build.0 = CI|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes DRIVERS-480

## Summary

Moves driver-specific test-skip decisions out of the shared testkit and into the .NET test backend, using testkit's existing `StartTest`/`StartSubTest` protocol. This keeps the shared testkit driver-agnostic and lets the interim `get_driver_name() not in ["dotnet"]` guards be removed (testkit side, separate change).

The motivating case: testkit's `test_zoned_time` includes UTC offsets of ±86400 (±24h) and ±64920 (±18h02m), which exceed .NET `OffsetTime`'s ±18:00 (±64800s) limit and can't be constructed. The backend now decides, per subtest, whether a value is representable.

## What's here

A small policy abstraction under `Protocol/Skip/`:

- `TestDisposition` (`RunAll` / `RunSubtests` / `SkipAll(reason)`) as a sealed-record union, plus a `TestDispositions` factory for enum-like values.
- `ITestSkipPolicy` (`Overall` + `ShouldRunSubtest(parameters, out reason)`), with `RunAllPolicy` (default), `SkipAllPolicy`, and `TryConstructPolicy`.
- `TestSkipPolicyRegistry` keyed by test name (substring match), with `TestSkipPolicies.Default` unifying the existing whole-test blacklist (`TestBlackList`, folded in as `SkipAll`) and per-subtest policies.
- `StartTest` now routes through the registry; a new `StartSubTest` handler maps `ShouldRunSubtest` to `RunTest`/`SkipTest`.
- `TryConstructPolicy` attempts to convert each subtest argument to its native value via the existing `CypherToNative` path; any construction failure means the value can't be represented, so it's skipped with the real exception message. Registered for `test_zoned_time`.

## Backend hardening (also fixes a latent cascade bug)

`CypherToNative.Convert` no longer wraps conversion failures in `IOException`. The controller treats `IOException` as a socket-level failure and tears down the connection, so a single unrepresentable value was killing the connection and cascading the remaining subtests into `BrokenPipe`. Conversion now runs outside any catch, so the real exception (an `ArgumentException`) reaches the controller's clean per-request handler; unknown/unmapped types throw `ArgumentException` rather than `IOException`.

The baseline commit also brings the DRIVERS-117 test-backend wire (de)serialization (hex bytes, NaN/±Infinity) and a new `TestBackend.Tests` xUnit project across.

## Tests

28 backend unit tests (xUnit + FluentAssertions), covering the dispositions/policies, the registry + blacklist fold-in, and the full `StartTest`/`StartSubTest` wiring end-to-end (out-of-range zoned-time offset → skip with the real reason; in-range → run).

## Notes for review

- The matching testkit changes (revert the interim skip, reshape `test_zoned_time` to use `should_run_subtest`) are a separate change on the testkit `feat/http-query-api` branch.
- The `Feature:HTTP:QueryAPI:1.0` flag is intentionally **not** added here (it isn't true on `6.x`), so the `http_query` suites skip on this branch; the mechanism is verified by the backend unit tests.