### PR TITLE
Add scoped dependency injection container

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/DependencyInjection/ScopedContainerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/DependencyInjection/ScopedContainerTests.cs
@@ -1,0 +1,749 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Neo4j.Driver.Internal.DependencyInjection;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Internal.DependencyInjection;
+
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Local")]
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+[SuppressMessage("ReSharper", "UnusedParameter.Local")]
+[SuppressMessage("ReSharper", "UnusedMember.Local")]
+public class ScopedContainerTests
+{
+    public interface ITestService
+    {
+    } 
+
+    public interface IDependency
+    {
+    }
+
+    public interface IMultiImplementer 
+    {
+    }
+
+    private class TestService(IDependency dependency) : ITestService
+    {
+        public IDependency Dependency { get; } = dependency;
+    }
+
+    private class ServiceWithNoDependencies : ITestService
+    {
+    }
+
+    private class MultiImplementer1 : IMultiImplementer
+    {
+    }
+
+    private class MultiImplementer2 : IMultiImplementer
+    {
+    }
+
+    private class ServiceWithMultipleConstructors
+    {
+        public int ConstructorCalled { get; }
+        public ServiceWithMultipleConstructors() => ConstructorCalled = 0;
+        public ServiceWithMultipleConstructors(IDependency dependency) => ConstructorCalled = 1;
+        public ServiceWithMultipleConstructors(IDependency dep1, ITestService dep2) => ConstructorCalled = 2;
+    }
+
+    public class CircularA
+    {
+        public CircularA(CircularB b)
+        {
+        }
+    }
+
+    public class CircularB
+    {
+        public CircularB(CircularA a)
+        {
+        }
+    }
+
+    public class SiblingA(ITestService testService)
+    {
+        public ITestService InnerTestService { get; } = testService;
+    }
+
+    public class SiblingB(ITestService testService)
+    {
+        public ITestService InnerTestService { get; } = testService;
+    }
+
+    public class SiblingParent(SiblingA a, SiblingB b)
+    {
+        public SiblingA A { get; } = a;
+        public SiblingB B { get; } = b;
+    }
+
+    private class DisposableService : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private class AsyncDisposableService : IAsyncDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        public ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private class OrderedDisposable(List<string> order, string name) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            order.Add(name);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void RegisterInstance_ResolvesRegisteredInstance()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var instance = mocker.Get<ITestService>();
+
+        container.RegisterInstance(instance);
+        var resolved = container.Resolve<ITestService>();
+
+        resolved.Should().BeSameAs(instance);
+    }
+
+    [Fact]
+    public void RegisterType_CreatesNewInstanceWithConstructorResolution()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var dependency = mocker.Get<IDependency>();
+
+        container.RegisterInstance(dependency);
+        container.RegisterType<ITestService, TestService>();
+
+        var resolved = container.Resolve<ITestService>();
+
+        resolved.Should().BeOfType<TestService>();
+        ((TestService)resolved).Dependency.Should().BeSameAs(dependency);
+    }
+
+    [Fact]
+    public void RegisterType_WithNoConstructorDependencies_CreatesInstance()
+    {
+        var container = new ScopedContainer();
+
+        container.RegisterType<ITestService, ServiceWithNoDependencies>();
+        var resolved = container.Resolve<ITestService>();
+
+        resolved.Should().BeOfType<ServiceWithNoDependencies>();
+    }
+
+    [Fact]
+    public void RegisterType_SelectsConstructorWithMostParameters()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+
+        container.RegisterInstance(mocker.Get<IDependency>());
+        container.RegisterInstance(mocker.Get<ITestService>());
+        container.RegisterType<ServiceWithMultipleConstructors>();
+
+        var resolved = container.Resolve<ServiceWithMultipleConstructors>();
+
+        resolved.ConstructorCalled.Should().Be(2);
+    }
+
+    [Fact]
+    public void Resolve_ThrowsForUnregisteredService()
+    {
+        var container = new ScopedContainer();
+
+        var act = () => container.Resolve<ITestService>();
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*not registered*");
+    }
+
+    [Fact]
+    public void Resolve_ThrowsForCircularDependency()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<CircularA>();
+        container.RegisterType<CircularB>();
+
+        var act = () => container.Resolve<CircularA>();
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*Circular dependency*");
+    }
+
+    [Fact]
+    public void Resolve_SucceedsForMultipleDependentsOnSameService()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+
+        var testService = mocker.Get<ITestService>();
+
+        container.RegisterInstance(testService);
+        container.RegisterType<SiblingA>();
+        container.RegisterType<SiblingB>();
+        container.RegisterType<SiblingParent>();
+
+        var parent = container.Resolve<SiblingParent>();
+        parent.Should().NotBeNull();
+        parent.A.InnerTestService.Should().BeSameAs(testService);
+        parent.B.InnerTestService.Should().BeSameAs(testService);
+    }
+
+    [Fact]
+    public void ResolveEnumerable_ResolvesAllImplementers()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<IMultiImplementer, MultiImplementer1>();
+        container.RegisterType<IMultiImplementer, MultiImplementer2>();
+
+        var resolved = container.Resolve<IEnumerable<IMultiImplementer>>().ToArray();
+
+        resolved.Should().HaveCount(2);
+        resolved.Should().ContainSingle(x => x is MultiImplementer1);
+        resolved.Should().ContainSingle(x => x is MultiImplementer2);
+    }
+
+    [Fact]
+    public void ResolveEnumerable_ReturnsEmptyForNoImplementers()
+    {
+        var container = new ScopedContainer();
+
+        var resolved = container.Resolve<IEnumerable<IMultiImplementer>>();
+
+        resolved.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RegisterInterceptor_CallsInterceptorDuringResolution()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var mockInterceptor = mocker.GetMock<IResolutionInterceptor>();
+        var overrideInstance = mocker.Get<ITestService>();
+
+        mockInterceptor
+            .Setup(x => x.TryResolve(
+                typeof(ITestService),
+                It.IsAny<Type>(),
+                It.IsAny<IServiceResolver>(),
+                out It.Ref<object>.IsAny))
+            .Returns(
+                new TryResolveDelegate((_, _, _, out service) =>
+                {
+                    service = overrideInstance;
+                    return true;
+                }));
+
+        container.RegisterInterceptor(mockInterceptor.Object);
+        var resolved = container.Resolve<ITestService>();
+
+        resolved.Should().BeSameAs(overrideInstance);
+    }
+
+    private delegate bool TryResolveDelegate(
+        Type serviceType,
+        Type requestingType,
+        IServiceResolver resolver,
+        out object service);
+
+    [Fact]
+    public void RegisterInterceptor_FallsBackToNormalResolutionWhenInterceptorReturnsFalse()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var mockInterceptor = mocker.GetMock<IResolutionInterceptor>();
+        var instance = mocker.Get<ITestService>();
+
+        mockInterceptor
+            .Setup(x => x.TryResolve(
+                It.IsAny<Type>(),
+                It.IsAny<Type>(),
+                It.IsAny<IServiceResolver>(),
+                out It.Ref<object>.IsAny))
+            .Returns(false);
+
+        container.RegisterInterceptor(mockInterceptor.Object);
+        container.RegisterInstance(instance);
+        var resolved = container.Resolve<ITestService>();
+
+        resolved.Should().BeSameAs(instance);
+    }
+
+    [Fact]
+    public void CreateScope_CreatesChildContainerWithParentDelegation()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var parentInstance = mocker.Get<ITestService>();
+
+        container.RegisterInstance(parentInstance);
+        var scope = container.CreateChildScope(_ => {});
+
+        var resolved = scope.Resolve<ITestService>();
+
+        resolved.Should().BeSameAs(parentInstance);
+    }
+
+    [Fact]
+    public void CreateScope_ChildRegistrationsDoNotAffectParent()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var childInstance = mocker.Get<ITestService>();
+
+        var scope = container.CreateChildScope(x => x.RegisterInstance(childInstance));
+
+        var act = () => container.Resolve<ITestService>();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void CreateScope_ChildOverridesParentRegistration()
+    {
+        var container = new ScopedContainer();
+        var mocker = new AutoMocker();
+        var parentInstance = mocker.Get<ITestService>();
+        var childInstance = new Mock<ITestService>().Object;
+
+        container.RegisterInstance(parentInstance);
+        var scope = (ScopedContainer)container.CreateChildScope(x => x.RegisterInstance(childInstance));
+
+        var resolved = scope.Resolve<ITestService>();
+
+        resolved.Should().BeSameAs(childInstance);
+    }
+
+    [Fact]
+    public void ResolveEnumerable_IncludesParentAndChildImplementers()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<IMultiImplementer, MultiImplementer1>();
+
+        var scope = (ScopedContainer)container.CreateChildScope(x =>
+            x.RegisterType<IMultiImplementer, MultiImplementer2>());
+
+        var resolved = scope.Resolve<IEnumerable<IMultiImplementer>>().ToArray();
+
+        resolved.Should().HaveCount(2);
+        resolved.Should().ContainSingle(x => x is MultiImplementer1);
+        resolved.Should().ContainSingle(x => x is MultiImplementer2);
+    }
+
+    [Fact]
+    public void Dispose_DisposesCreatedDisposableInstances()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<DisposableService>();
+
+        var resolved = container.Resolve<DisposableService>();
+        container.Dispose();
+
+        resolved.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dispose_DoesNotDisposeRegisteredInstances()
+    {
+        // Default: caller retains ownership; scope does not dispose.
+        var container = new ScopedContainer();
+        var instance = new DisposableService();
+
+        container.RegisterInstance(instance);
+        container.Dispose();
+
+        instance.IsDisposed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesOwnedRegisteredInstances()
+    {
+        var container = new ScopedContainer();
+        var instance = new AsyncDisposableService();
+
+        container.RegisterInstance(instance, transferOwnership: true);
+        await container.DisposeAsync();
+
+        instance.IsDisposed.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(typeof(ITestService))]
+    [InlineData(typeof(IDependency))]
+    public void Resolve_ThrowsAfterDispose(Type serviceType)
+    {
+        var container = new ScopedContainer();
+        container.Dispose();
+
+        var act = () => container.Resolve(serviceType);
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void CreateScope_ThrowsAfterDispose()
+    {
+        var container = new ScopedContainer();
+        container.Dispose();
+
+        var act = () => container.CreateChildScope(_ => {});
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void RegisterType_WithTypeWithNoPublicConstructor_ThrowsOnResolve()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<PrivateConstructorService>();
+
+        var act = () => container.Resolve<PrivateConstructorService>();
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*no public constructors*");
+    }
+
+    private class PrivateConstructorService
+    {
+        private PrivateConstructorService()
+        {
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Child-scope override flow-through tests
+    //
+    // These test the new behaviour where child-scope registrations are passed as
+    // overrides into the parent's resolution chain, so that a service registered
+    // only in the parent scope can still be fully instantiated using dependencies
+    // that live in the child scope.
+    //
+    // Known bugs at time of writing (do not fix here, just note):
+    //
+    //   BUG-1: Resolve(Type, IServiceResolver? extra = null) at line ~71 calls
+    //          itself recursively — `return Resolve(serviceType, extra)` binds
+    //          back to the same 2-arg overload instead of the 3-arg one.
+    //          All tests that fall through to parent will StackOverflow.
+    //
+    //   BUG-2: The extra-resolver check at line ~83 calls IServiceResolver.Resolve
+    //          which throws InvalidOperationException for unregistered services.
+    //          The `is { }` guard is never reached for a miss; the exception
+    //          propagates instead of falling through to local registrations.
+    //
+    //   BUG-3: CreateInstance at line ~251 calls Resolve(paramType, requestingType)
+    //          without threading extraResolver through, so child-scope overrides
+    //          are invisible for transitive dependencies.
+    // -------------------------------------------------------------------------
+
+    // Test types for override flow-through scenarios
+
+    public interface IOverrideA { }
+    public interface IOverrideB { }
+    public interface IOverrideC { }
+
+    // A depends on B — one level deep
+    private class ServiceA_NeedsB(IOverrideB b) : IOverrideA
+    {
+        public IOverrideB B { get; } = b;
+    }
+
+    // A depends on B and C — two siblings
+    private class ServiceA_NeedsBC(IOverrideB b, IOverrideC c) : IOverrideA
+    {
+        public IOverrideB B { get; } = b;
+        public IOverrideC C { get; } = c;
+    }
+
+    // B depends on C — for transitive chain A→B→C
+    private class ServiceB_NeedsC(IOverrideC c) : IOverrideB
+    {
+        public IOverrideC C { get; } = c;
+    }
+
+    private class ServiceB_NoDeps : IOverrideB { }
+    private class ServiceC_NoDeps : IOverrideC { }
+
+    [Fact]
+    public void ChildScope_CanResolveParentServiceUsingChildInstanceDep()
+    {
+        // Parent knows how to build IOverrideA (needs IOverrideB).
+        // Child supplies IOverrideB.
+        // Resolving IOverrideA from the child should succeed and use the child's IOverrideB.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childB));
+
+        var result = child.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsB>();
+        ((ServiceA_NeedsB)result).B.Should().BeSameAs(childB);
+    }
+
+    [Fact]
+    public void ChildScope_CanResolveParentServiceUsingMultipleChildDeps()
+    {
+        // Parent knows how to build IOverrideA (needs IOverrideB and IOverrideC).
+        // Child supplies both.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsBC>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var childC = new Mock<IOverrideC>().Object;
+        var child = parent.CreateChildScope(r =>
+        {
+            r.RegisterInstance(childB);
+            r.RegisterInstance(childC);
+        });
+
+        var result = child.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsBC>();
+        ((ServiceA_NeedsBC)result).B.Should().BeSameAs(childB);
+        ((ServiceA_NeedsBC)result).C.Should().BeSameAs(childC);
+    }
+
+    [Fact]
+    public void ChildScope_ChildDepOverridesParentDepDuringParentInstantiation()
+    {
+        // Parent has IOverrideA → ServiceA_NeedsB, and IOverrideB → ServiceB_NoDeps.
+        // Child overrides IOverrideB with its own instance.
+        // Resolving IOverrideA from the child should use the child's IOverrideB, not
+        // the parent's ServiceB_NoDeps.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+        parent.RegisterType<IOverrideB, ServiceB_NoDeps>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childB));
+
+        var result = child.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsB>();
+        ((ServiceA_NeedsB)result).B.Should().BeSameAs(childB);
+    }
+
+    [Fact]
+    public void ChildScope_TransitiveChildDepVisibleThroughParentChain()
+    {
+        // Parent has IOverrideA → ServiceA_NeedsB, IOverrideB → ServiceB_NeedsC.
+        // Child supplies IOverrideC.
+        // Resolving IOverrideA from child: parent creates ServiceA_NeedsB,
+        // which needs IOverrideB; parent creates ServiceB_NeedsC,
+        // which needs IOverrideC — found in child.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+        parent.RegisterType<IOverrideB, ServiceB_NeedsC>();
+
+        var childC = new Mock<IOverrideC>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childC));
+
+        var result = child.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsB>();
+        var innerB = (ServiceB_NeedsC)((ServiceA_NeedsB)result).B;
+        innerB.C.Should().BeSameAs(childC);
+    }
+
+    [Fact]
+    public void ChildScope_ParentDepsNotInChildStillResolveFromParent()
+    {
+        // Child has nothing extra. Parent has everything needed.
+        // Should still work — no overrides required.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+        parent.RegisterType<IOverrideB, ServiceB_NoDeps>();
+
+        var child = parent.CreateChildScope(_ => { });
+
+        var result = child.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsB>();
+        ((ServiceA_NeedsB)result).B.Should().BeOfType<ServiceB_NoDeps>();
+    }
+
+    [Fact]
+    public void ChildScope_ServiceInChildNotParent_ResolvesDirectlyFromChild()
+    {
+        // Child registers IOverrideA directly — no parent lookup needed.
+        var parent = new ScopedContainer();
+        var childA = new Mock<IOverrideA>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childA));
+
+        var result = child.Resolve<IOverrideA>();
+
+        result.Should().BeSameAs(childA);
+    }
+
+    [Fact]
+    public void GrandchildScope_CanResolveParentServiceUsingDepsFromBothIntermediateScopeAndOwnScope()
+    {
+        // Parent knows how to build IOverrideA (needs IB and IC).
+        // Child scope supplies IB.
+        // Grandchild scope supplies IC.
+        // Resolving IOverrideA from the grandchild must use IB from child AND IC from grandchild.
+        // With extraRegistrations ?? _registrations, child's IB is lost when grandchild delegates
+        // upward (grandchild's non-null extraRegistrations replaces child's registrations entirely).
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsBC>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childB));
+
+        var childC = new Mock<IOverrideC>().Object;
+        var grandchild = child.CreateChildScope(r => r.RegisterInstance(childC));
+
+        var result = grandchild.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsBC>();
+        ((ServiceA_NeedsBC)result).B.Should().BeSameAs(childB);
+        ((ServiceA_NeedsBC)result).C.Should().BeSameAs(childC);
+    }
+
+    [Fact]
+    public void GrandchildScope_OwnRegistrationWinsOverIntermediateScopeForSameInterface()
+    {
+        // Grandchild overrides IB that the child also provides — grandchild should win.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childB));
+
+        var grandchildB = new Mock<IOverrideB>().Object;
+        var grandchild = child.CreateChildScope(r => r.RegisterInstance(grandchildB));
+
+        var result = grandchild.Resolve<IOverrideA>();
+
+        result.Should().BeOfType<ServiceA_NeedsB>();
+        ((ServiceA_NeedsB)result).B.Should().BeSameAs(grandchildB);
+    }
+
+    [Fact]
+    public void ChildScope_ResolveEnumerable_UsesChildDepsWhenInstantiatingParentRegistrations()
+    {
+        // Parent has two IOverrideA implementations, both needing IOverrideB.
+        // Child supplies IOverrideB.
+        // Asking child for IEnumerable<IOverrideA> should return both instances,
+        // each constructed with the child's IOverrideB.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var child = parent.CreateChildScope(r => r.RegisterInstance(childB));
+
+        var results = child.Resolve<IEnumerable<IOverrideA>>().ToArray();
+
+        results.Should().HaveCount(1);
+        results[0].Should().BeOfType<ServiceA_NeedsB>();
+        ((ServiceA_NeedsB)results[0]).B.Should().BeSameAs(childB);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesAsyncDisposableInstances()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<AsyncDisposableService>();
+
+        var resolved = container.Resolve<AsyncDisposableService>();
+        await container.DisposeAsync();
+
+        resolved.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesChildScopeWhenParentIsDisposed()
+    {
+        var container = new ScopedContainer();
+
+        var child = container.CreateChildScope(r => r.RegisterType<AsyncDisposableService>());
+        var childResolved = child.Resolve<AsyncDisposableService>();
+
+        await container.DisposeAsync();
+
+        childResolved!.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesInReverseCreationOrder()
+    {
+        var order = new List<string>();
+        var container = new ScopedContainer();
+
+        // Owned instances added to _disposables in creation order
+        container.RegisterInstance(new OrderedDisposable(order, "first"), transferOwnership: true);
+        container.RegisterInstance(new OrderedDisposable(order, "second"), transferOwnership: true);
+
+        // Child scope created last — appended to parent _disposables after both parent instances
+        container.CreateChildScope(r =>
+            r.RegisterInstance(new OrderedDisposable(order, "child"), transferOwnership: true));
+
+        await container.DisposeAsync();
+
+        // Reverse creation order: child (last added) disposed first
+        order.Should().Equal("child", "second", "first");
+    }
+
+    [Fact]
+    public void ChildScope_ResolveEnumerable_IncludesParentAndChildImplementations()
+    {
+        // Parent has one IOverrideA implementation; child adds another.
+        // Both require IOverrideB which the child supplies.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IOverrideA, ServiceA_NeedsB>();
+
+        var childB = new Mock<IOverrideB>().Object;
+        var child = parent.CreateChildScope(r =>
+        {
+            r.RegisterInstance(childB);
+            r.RegisterType<IOverrideA, ServiceA_NeedsBC>(); // child adds a second impl (also needs IOverrideB)
+            r.RegisterInstance(new Mock<IOverrideC>().Object); // satisfy ServiceA_NeedsBC's IOverrideC dep
+        });
+
+        var results = child.Resolve<IEnumerable<IOverrideA>>().ToArray();
+
+        results.Should().HaveCount(2);
+        results.Should().ContainSingle(x => x is ServiceA_NeedsB);
+        results.Should().ContainSingle(x => x is ServiceA_NeedsBC);
+        results.OfType<ServiceA_NeedsB>().Single().B.Should().BeSameAs(childB);
+        results.OfType<ServiceA_NeedsBC>().Single().B.Should().BeSameAs(childB);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/DependencyInjection/ScopedContainerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/DependencyInjection/ScopedContainerTests.cs
@@ -203,7 +203,8 @@ public class ScopedContainerTests
 
         act.Should()
             .Throw<InvalidOperationException>()
-            .WithMessage("*Circular dependency*");
+            .WithMessage("*Circular dependency*")
+            .WithMessage("*CircularA -> CircularB -> CircularA*");
     }
 
     [Fact]
@@ -454,22 +455,6 @@ public class ScopedContainerTests
     // overrides into the parent's resolution chain, so that a service registered
     // only in the parent scope can still be fully instantiated using dependencies
     // that live in the child scope.
-    //
-    // Known bugs at time of writing (do not fix here, just note):
-    //
-    //   BUG-1: Resolve(Type, IServiceResolver? extra = null) at line ~71 calls
-    //          itself recursively — `return Resolve(serviceType, extra)` binds
-    //          back to the same 2-arg overload instead of the 3-arg one.
-    //          All tests that fall through to parent will StackOverflow.
-    //
-    //   BUG-2: The extra-resolver check at line ~83 calls IServiceResolver.Resolve
-    //          which throws InvalidOperationException for unregistered services.
-    //          The `is { }` guard is never reached for a miss; the exception
-    //          propagates instead of falling through to local registrations.
-    //
-    //   BUG-3: CreateInstance at line ~251 calls Resolve(paramType, requestingType)
-    //          without threading extraResolver through, so child-scope overrides
-    //          are invisible for transitive dependencies.
     // -------------------------------------------------------------------------
 
     // Test types for override flow-through scenarios
@@ -745,5 +730,147 @@ public class ScopedContainerTests
         results.Should().ContainSingle(x => x is ServiceA_NeedsBC);
         results.OfType<ServiceA_NeedsB>().Single().B.Should().BeSameAs(childB);
         results.OfType<ServiceA_NeedsBC>().Single().B.Should().BeSameAs(childB);
+    }
+
+    [Fact]
+    public void RegisterType_Singleton_ReturnsSameInstanceForEveryResolve()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<ITestService, ServiceWithNoDependencies>(singleton: true);
+
+        var first = container.Resolve<ITestService>();
+        var second = container.Resolve<ITestService>();
+
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void RegisterType_NonSingleton_ReturnsNewInstanceForEveryResolve()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<ITestService, ServiceWithNoDependencies>();
+
+        var first = container.Resolve<ITestService>();
+        var second = container.Resolve<ITestService>();
+
+        first.Should().NotBeSameAs(second);
+    }
+
+    [Fact]
+    public void RegisterType_Singleton_IsSharedAcrossChildScopes()
+    {
+        // A singleton is cached on the registration it was registered against, so a
+        // parent-registered singleton is the same instance for every child scope.
+        var parent = new ScopedContainer();
+        parent.RegisterType<ITestService, ServiceWithNoDependencies>(singleton: true);
+
+        var child1 = parent.CreateChildScope(_ => { });
+        var child2 = parent.CreateChildScope(_ => { });
+
+        var fromChild1 = child1.Resolve<ITestService>();
+        var fromChild2 = child2.Resolve<ITestService>();
+
+        fromChild1.Should().BeSameAs(fromChild2);
+    }
+
+    [Fact]
+    public void ResolveEnumerable_Singleton_ReturnsSameInstanceForEveryResolve()
+    {
+        var container = new ScopedContainer();
+        container.RegisterType<IMultiImplementer, MultiImplementer1>(singleton: true);
+
+        var first = container.Resolve<IEnumerable<IMultiImplementer>>().Single();
+        var second = container.Resolve<IEnumerable<IMultiImplementer>>().Single();
+
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void ChildSingleton_ShadowsParentForSingleResolve_ButBothAppearInEnumerable()
+    {
+        // Parent and child each register their own singleton implementation of the same
+        // interface. They are independent singletons: the child's shadows the parent's for
+        // single-service resolution, while an enumerable resolve returns both — and the
+        // enumerable yields the same cached instances as the single resolves.
+        var parent = new ScopedContainer();
+        parent.RegisterType<IMultiImplementer, MultiImplementer1>(singleton: true);
+        var child = parent.CreateChildScope(r => r.RegisterType<IMultiImplementer, MultiImplementer2>(singleton: true));
+
+        var fromChild = child.Resolve<IMultiImplementer>();
+        var fromParent = parent.Resolve<IMultiImplementer>();
+        var childEnumerable = child.Resolve<IEnumerable<IMultiImplementer>>().ToArray();
+
+        fromChild.Should().BeOfType<MultiImplementer2>();
+        fromParent.Should().BeOfType<MultiImplementer1>();
+        fromChild.Should().NotBeSameAs(fromParent);
+
+        childEnumerable.Should().HaveCount(2);
+        childEnumerable.Should().Contain(x => ReferenceEquals(x, fromParent));
+        childEnumerable.Should().Contain(x => ReferenceEquals(x, fromChild));
+    }
+
+    [Fact]
+    public void RegisterType_ImplementationNotAssignableToService_Throws()
+    {
+        var container = new ScopedContainer();
+
+        var act = () => container.RegisterType(typeof(ITestService), typeof(MultiImplementer1));
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void RegisterInstance_NullInstance_ThrowsArgumentNullException()
+    {
+        var container = new ScopedContainer();
+
+        var act = () => container.RegisterInstance<ITestService>(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RegisterInterceptor_NullInterceptor_ThrowsArgumentNullException()
+    {
+        var container = new ScopedContainer();
+
+        var act = () => container.RegisterInterceptor(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RegisterInstance_AfterDispose_Throws()
+    {
+        var container = new ScopedContainer();
+        var instance = new Mock<ITestService>().Object;
+        container.Dispose();
+
+        var act = () => container.RegisterInstance(instance);
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void RegisterType_AfterDispose_Throws()
+    {
+        var container = new ScopedContainer();
+        container.Dispose();
+
+        var act = () => container.RegisterType<ITestService, ServiceWithNoDependencies>();
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void RegisterInterceptor_AfterDispose_Throws()
+    {
+        var container = new ScopedContainer();
+        var interceptor = new Mock<IResolutionInterceptor>().Object;
+        container.Dispose();
+
+        var act = () => container.RegisterInterceptor(interceptor);
+
+        act.Should().Throw<ObjectDisposedException>();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/AutoRegisterAttribute.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/AutoRegisterAttribute.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Internal.DependencyInjection;
+
+/// <summary>
+/// Marks a class to be automatically registered for all interfaces it implements when using
+/// the built-in dependency injection container.
+/// </summary>
+/// <param name="singleton">
+/// When <c>true</c>, the container creates only one instance per scope and returns it for all
+/// subsequent resolutions of any of the registered interfaces within that scope.
+/// </param>
+[AttributeUsage(AttributeTargets.Class)]
+internal class AutoRegisterAttribute(bool singleton = false) : Attribute
+{
+    public bool Singleton { get; } = singleton;
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IResolutionInterceptor.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IResolutionInterceptor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Internal.DependencyInjection;
+
+internal interface IResolutionInterceptor
+{
+    bool TryResolve(Type serviceType, Type requestingType, IServiceResolver resolver, out object service);
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IResolutionScope.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IResolutionScope.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Internal.DependencyInjection;
+
+internal interface IResolutionScope : IServiceResolver, IAsyncDisposable
+{
+    IResolutionScope CreateChildScope(Action<IServiceRegistry> registrations);
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IServiceRegistry.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IServiceRegistry.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Neo4j.Driver.Internal.DependencyInjection;
+
+internal interface IServiceRegistry
+{
+    IServiceRegistry RegisterInstance<TService>(TService instance, bool transferOwnership = false);
+    IServiceRegistry RegisterType<TService, TImplementation>(bool singleton = false) where TImplementation : TService;
+    IServiceRegistry RegisterType(Type service, Type implementation, bool singleton = false);
+    IServiceRegistry RegisterType<TService>(bool singleton = false);
+    IServiceRegistry RegisterInterceptor(IResolutionInterceptor interceptor);
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IServiceResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IServiceResolver.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+
+using System;
+
+namespace Neo4j.Driver.Internal.DependencyInjection;
+
+internal interface IServiceResolver
+{
+    TService Resolve<TService>();
+    object Resolve(Type serviceType);
+    object Resolve(Type serviceType, Type requestingType);
+    bool TryResolve<T>(out T? value);
+    bool TryResolve(Type serviceType, out object? service);
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IServiceResolver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/IServiceResolver.cs
@@ -16,6 +16,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Neo4j.Driver.Internal.DependencyInjection;
 
@@ -24,6 +25,6 @@ internal interface IServiceResolver
     TService Resolve<TService>();
     object Resolve(Type serviceType);
     object Resolve(Type serviceType, Type requestingType);
-    bool TryResolve<T>(out T? value);
-    bool TryResolve(Type serviceType, out object? service);
+    bool TryResolve<T>([NotNullWhen(true)] out T? value);
+    bool TryResolve(Type serviceType, [NotNullWhen(true)] out object? service);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/ScopedContainer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/ScopedContainer.cs
@@ -1,0 +1,448 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo4j.Driver.Internal.DependencyInjection;
+
+internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
+{
+    private readonly Stack<IAsyncDisposable> _disposables = new();
+    private readonly List<IResolutionInterceptor> _interceptors = [];
+    private readonly ScopedContainer? _parent;
+    private readonly Dictionary<Type, List<Registration>> _registrations = new();
+    private readonly ThreadLocal<HashSet<Type>> _resolutionStack = new(() => []);
+    private bool _disposed;
+
+    public ScopedContainer() : this(null)
+    {
+    }
+
+    private ScopedContainer(ScopedContainer? parent)
+    {
+        _parent = parent;
+        RegisterInstance<IResolutionScope>(this);
+    }
+
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        while (_disposables.TryPop(out var disposable))
+        {
+            await disposable.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _resolutionStack.Dispose();
+    }
+
+    public TService Resolve<TService>()
+    {
+        return (TService)ResolveCore(typeof(TService), null, null);
+    }
+
+    public object Resolve(Type serviceType)
+    {
+        return ResolveCore(serviceType, null, null);
+    }
+
+    public object Resolve(Type serviceType, Type? requestingType)
+    {
+        return ResolveCore(serviceType, requestingType, null);
+    }
+
+    public bool TryResolve<T>(out T? value)
+    {
+        var result = TryResolveCore(typeof(T), null, null);
+        if (result is null)
+        {
+            value = default;
+            return false;
+        }
+
+        value = (T)result;
+        return true;
+    }
+
+    public bool TryResolve(Type serviceType, out object? service)
+    {
+        var result = TryResolveCore(serviceType, null, null);
+        if (result is null)
+        {
+            service = null;
+            return false;
+        }
+
+        service = result;
+        return true;
+    }
+
+    public IResolutionScope CreateChildScope(Action<IServiceRegistry> registrations)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var newScope = new ScopedContainer(this);
+        registrations(newScope);
+        TrackInstanceForDisposal(newScope);
+        return newScope;
+    }
+
+    public IServiceRegistry RegisterInstance<TService>(TService instance, bool transferOwnership = false)
+    {
+        if (instance == null)
+        {
+            throw new ArgumentException("Instance cannot be null", nameof(instance));
+        }
+
+        var serviceType = typeof(TService);
+        if (!_registrations.TryGetValue(serviceType, out var registrations))
+        {
+            registrations = [];
+            _registrations[serviceType] = registrations;
+        }
+
+        registrations.Add(new Registration(instance));
+
+        if (transferOwnership)
+        {
+            TrackInstanceForDisposal(instance);
+        }
+
+        return this;
+    }
+
+    private void TrackInstanceForDisposal<TService>([DisallowNull] TService instance)
+    {
+        switch (instance)
+        {
+            case IAsyncDisposable ad: _disposables.Push(ad); break;
+            case IDisposable d: _disposables.Push(new AsyncDisposalWrapper(d)); break;
+        }
+    }
+
+    public IServiceRegistry RegisterType<TService, TImplementation>(bool singleton = false)
+        where TImplementation : TService
+    {
+        return RegisterType(typeof(TService), typeof(TImplementation), singleton);
+    }
+
+    public IServiceRegistry RegisterType(Type service, Type implementation, bool singleton = false)
+    {
+        if (!_registrations.TryGetValue(service, out var registrations))
+        {
+            registrations = [];
+            _registrations[service] = registrations;
+        }
+
+        registrations.Add(new Registration(implementation, singleton));
+        return this;
+    }
+
+    public IServiceRegistry RegisterType<TService>(bool singleton = false)
+    {
+        var serviceType = typeof(TService);
+        if (!_registrations.TryGetValue(serviceType, out var registrations))
+        {
+            registrations = [];
+            _registrations[serviceType] = registrations;
+        }
+
+        registrations.Add(new Registration(serviceType, singleton));
+        return this;
+    }
+
+    public IServiceRegistry RegisterInterceptor(IResolutionInterceptor interceptor)
+    {
+        _interceptors.Add(interceptor);
+        return this;
+    }
+
+    private object ResolveCore(
+        Type serviceType,
+        Type? requestingType,
+        Dictionary<Type, List<Registration>>? extraRegistrations,
+        ScopedContainer? childScope = null)
+    {
+        return TryResolveCore(serviceType, requestingType, extraRegistrations, childScope) ??
+            throw new InvalidOperationException(
+                $"Service of type {serviceType} required by {requestingType} is not registered. " +
+                $"Resolution chain: {GetResolutionStackString()}");
+    }
+
+    // All resolution logic lives here. Returns null only when the service is not registered.
+    // Other failure modes (disposed, circular dependency, construction failure) still throw.
+    // extraRegistrations carries the calling child scope's registrations so they take priority
+    // throughout the entire resolution chain, including transitive dependencies resolved by ancestors.
+    private object? TryResolveCore(
+        Type serviceType,
+        Type? requestingType,
+        Dictionary<Type, List<Registration>>? childRegistrations,
+        ScopedContainer? childScope = null)
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(ScopedContainer));
+        }
+
+        if (_resolutionStack.Value != null && !_resolutionStack.Value.Add(serviceType))
+        {
+            throw new InvalidOperationException(
+                $"Circular dependency detected while resolving {serviceType}. " +
+                $"Resolution chain: {GetResolutionStackString()}");
+        }
+
+        try
+        {
+            // Child-scope registrations take priority over everything in the parent chain.
+            if (childRegistrations != null &&
+                childRegistrations.TryGetValue(serviceType, out var foundInChild) &&
+                foundInChild.Count > 0)
+            {
+                var reg = foundInChild[^1];
+                if (reg.Instance != null)
+                {
+                    return reg.Instance;
+                }
+
+                if (reg.Singleton && childScope != null)
+                {
+                    // singletons should be attached to innermost scope
+                    return childScope.ResolveCore(serviceType, requestingType, null, null);
+                }
+
+                return CreateInstance(reg.ImplementationType, serviceType, childRegistrations, childScope);
+            }
+
+            // Interceptors
+            var interceptorResolver = (IServiceResolver)(childScope ?? this);
+            foreach (var interceptor in _interceptors)
+            {
+                if (interceptor.TryResolve(serviceType, requestingType, interceptorResolver, out var overrideResult))
+                {
+                    return overrideResult;
+                }
+            }
+
+            // IEnumerable<T>
+            if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                var elementType = serviceType.GetGenericArguments()[0];
+                return ResolveEnumerable(elementType, childRegistrations, childScope);
+            }
+
+            // Local registrations
+            if (_registrations.TryGetValue(serviceType, out var registrations) && registrations.Count > 0)
+            {
+                var registration = registrations[^1];
+                if (registration.Instance != null)
+                {
+                    return registration.Instance;
+                }
+
+                var instance = CreateInstance(
+                    registration.ImplementationType,
+                    serviceType,
+                    childRegistrations,
+                    childScope);
+
+                if (registration.Singleton)
+                {
+                    registrations[^1] = new Registration(instance);
+                }
+
+                return instance;
+            }
+
+            // Delegate to parent. Merge this scope's registrations with whatever the child
+            // passed down, so every ancestor scope sees registrations from the full chain.
+            // The more-derived scope's registrations win for any conflicting key.
+            if (_parent != null)
+            {
+                return _parent.TryResolveCore(
+                    serviceType,
+                    requestingType,
+                    MergeRegistrations(_registrations, childRegistrations),
+                    childScope ?? this);
+            }
+
+            return null;
+        }
+        finally
+        {
+            _resolutionStack.Value?.Remove(serviceType);
+        }
+    }
+
+    private string GetResolutionStackString()
+    {
+        return string.Join(" -> ", _resolutionStack.Value?.Select(t => t.Name) ?? []);
+    }
+
+    private Array ResolveEnumerable(
+        Type elementType,
+        Dictionary<Type, List<Registration>>? extraRegistrations,
+        ScopedContainer? childScope = null)
+    {
+        var instances = new List<object>();
+
+        // Merge this scope's registrations with any child overrides passed in.
+        // The more-derived scope's registrations win for conflicting keys.
+        var effectiveOverrides = MergeRegistrations(_registrations, extraRegistrations);
+
+        // Collect from parent first, forwarding the effective overrides so that
+        // parent-registered implementations are instantiated with child-scope deps.
+        if (_parent != null)
+        {
+            try
+            {
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(elementType);
+                var parentEnumerable = _parent.ResolveCore(enumerableType, null, effectiveOverrides, childScope);
+                if (parentEnumerable is IEnumerable enumerable)
+                {
+                    instances.AddRange(enumerable.Cast<object>());
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Parent has no registrations for this element type — continue.
+            }
+        }
+
+        // Add implementations from this scope's own registrations.
+        foreach (var (type, registrations) in _registrations)
+        {
+            if (!elementType.IsAssignableFrom(type))
+            {
+                continue;
+            }
+
+            foreach (var registration in registrations)
+            {
+                instances.Add(
+                    registration.Instance ??
+                    CreateInstance(registration.ImplementationType, type, effectiveOverrides, childScope));
+            }
+        }
+
+        var array = Array.CreateInstance(elementType, instances.Count);
+        for (var i = 0; i < instances.Count; i++)
+        {
+            array.SetValue(instances[i], i);
+        }
+
+        return array;
+    }
+
+    private object CreateInstance(
+        Type implementationType,
+        Type requestingType,
+        Dictionary<Type, List<Registration>>? extraRegistrations,
+        ScopedContainer? childScope = null)
+    {
+        var constructors = implementationType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+        if (constructors.Length == 0)
+        {
+            throw new InvalidOperationException($"Type {implementationType} has no public constructors.");
+        }
+
+        var constructor = constructors.OrderByDescending(c => c.GetParameters().Length).First();
+        var parameters = constructor.GetParameters();
+        var parameterInstances = new object[parameters.Length];
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            parameterInstances[i] = ResolveCore(
+                parameters[i].ParameterType,
+                implementationType,
+                extraRegistrations,
+                childScope);
+        }
+
+        var instance = Activator.CreateInstance(implementationType, parameterInstances);
+
+        if (instance is null)
+        {
+            throw new InvalidOperationException($"Failed to create instance of type {implementationType}.");
+        }
+
+        TrackInstanceForDisposal(instance);
+
+        return instance;
+    }
+
+    private static Dictionary<Type, List<Registration>> MergeRegistrations(
+        Dictionary<Type, List<Registration>> baseRegistrations,
+        Dictionary<Type, List<Registration>>? overrides)
+    {
+        if (overrides is not { Count: > 0 })
+        {
+            return baseRegistrations;
+        }
+
+        var merged = new Dictionary<Type, List<Registration>>(baseRegistrations);
+        foreach (var (type, registrations) in overrides)
+        {
+            merged[type] = registrations;
+        }
+
+        return merged;
+    }
+
+    private class Registration
+    {
+        public Registration(object instance)
+        {
+            Instance = instance;
+            ImplementationType = null!;
+            Singleton = false;
+        }
+
+        public Registration(Type implementationType, bool singleton = false)
+        {
+            Instance = null;
+            ImplementationType = implementationType;
+            Singleton = singleton;
+        }
+
+        public object? Instance { get; }
+        public Type ImplementationType { get; }
+        public bool Singleton { get; }
+    }
+
+    private class AsyncDisposalWrapper(IDisposable disposable) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            disposable.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/ScopedContainer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/ScopedContainer.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -28,6 +29,7 @@ namespace Neo4j.Driver.Internal.DependencyInjection;
 
 internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
 {
+    private readonly ConcurrentDictionary<Type, (ConstructorInfo Constructor, ParameterInfo[] Parameters)> _constructorCache = new();
     private readonly Stack<IAsyncDisposable> _disposables = new();
     private readonly List<IResolutionInterceptor> _interceptors = [];
     private readonly ScopedContainer? _parent;
@@ -79,30 +81,17 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
         return ResolveCore(serviceType, requestingType, null);
     }
 
-    public bool TryResolve<T>(out T? value)
+    public bool TryResolve<T>([NotNullWhen(true)] out T? value)
     {
-        var result = TryResolveCore(typeof(T), null, null);
-        if (result is null)
-        {
-            value = default;
-            return false;
-        }
-
-        value = (T)result;
-        return true;
+        var success = TryResolve(typeof(T), out var service);
+        value = (T?)service;
+        return success;
     }
 
-    public bool TryResolve(Type serviceType, out object? service)
+    public bool TryResolve(Type serviceType, [NotNullWhen(true)] out object? service)
     {
-        var result = TryResolveCore(serviceType, null, null);
-        if (result is null)
-        {
-            service = null;
-            return false;
-        }
-
-        service = result;
-        return true;
+        service = TryResolveCore(serviceType, null, null);
+        return service != null;
     }
 
     public IResolutionScope CreateChildScope(Action<IServiceRegistry> registrations)
@@ -274,7 +263,7 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
 
                 if (registration.Singleton)
                 {
-                    registrations[^1] = new Registration(instance);
+                    registration.Instance = instance;
                 }
 
                 return instance;
@@ -360,21 +349,31 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
         return array;
     }
 
+    private (ConstructorInfo Constructor, ParameterInfo[] Parameters) GetConstructorAndParams(Type implementationType)
+    {
+        return _constructorCache.GetOrAdd(
+            implementationType,
+            static type =>
+            {
+                var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+                if (constructors.Length == 0)
+                {
+                    throw new InvalidOperationException($"Type {type} has no public constructors.");
+                }
+
+                var constructor = constructors.OrderByDescending(c => c.GetParameters().Length).First();
+                return (constructor, constructor.GetParameters());
+            });
+    }
+
     private object CreateInstance(
         Type implementationType,
         Type requestingType,
         Dictionary<Type, List<Registration>>? extraRegistrations,
         ScopedContainer? childScope = null)
     {
-        var constructors = implementationType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-
-        if (constructors.Length == 0)
-        {
-            throw new InvalidOperationException($"Type {implementationType} has no public constructors.");
-        }
-
-        var constructor = constructors.OrderByDescending(c => c.GetParameters().Length).First();
-        var parameters = constructor.GetParameters();
+        var (constructor, parameters) = GetConstructorAndParams(implementationType);
         var parameterInstances = new object[parameters.Length];
 
         for (var i = 0; i < parameters.Length; i++)
@@ -432,7 +431,7 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
             Singleton = singleton;
         }
 
-        public object? Instance { get; }
+        public object? Instance { get; internal set; }
         public Type ImplementationType { get; }
         public bool Singleton { get; }
     }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/ScopedContainer.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/DependencyInjection/ScopedContainer.cs
@@ -34,7 +34,7 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
     private readonly List<IResolutionInterceptor> _interceptors = [];
     private readonly ScopedContainer? _parent;
     private readonly Dictionary<Type, List<Registration>> _registrations = new();
-    private readonly ThreadLocal<HashSet<Type>> _resolutionStack = new(() => []);
+    private readonly ThreadLocal<List<Type>> _resolutionStack = new(() => []);
     private bool _disposed;
 
     public ScopedContainer() : this(null)
@@ -105,9 +105,10 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
 
     public IServiceRegistry RegisterInstance<TService>(TService instance, bool transferOwnership = false)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         if (instance == null)
         {
-            throw new ArgumentException("Instance cannot be null", nameof(instance));
+            throw new ArgumentNullException(nameof(instance));
         }
 
         var serviceType = typeof(TService);
@@ -144,6 +145,14 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
 
     public IServiceRegistry RegisterType(Type service, Type implementation, bool singleton = false)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (!service.IsAssignableFrom(implementation))
+        {
+            throw new ArgumentException(
+                $"Type {implementation} is not assignable to service type {service}.",
+                nameof(implementation));
+        }
+
         if (!_registrations.TryGetValue(service, out var registrations))
         {
             registrations = [];
@@ -156,19 +165,17 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
 
     public IServiceRegistry RegisterType<TService>(bool singleton = false)
     {
-        var serviceType = typeof(TService);
-        if (!_registrations.TryGetValue(serviceType, out var registrations))
-        {
-            registrations = [];
-            _registrations[serviceType] = registrations;
-        }
-
-        registrations.Add(new Registration(serviceType, singleton));
-        return this;
+        return RegisterType(typeof(TService), typeof(TService), singleton);
     }
 
     public IServiceRegistry RegisterInterceptor(IResolutionInterceptor interceptor)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (interceptor == null)
+        {
+            throw new ArgumentNullException(nameof(interceptor));
+        }
+
         _interceptors.Add(interceptor);
         return this;
     }
@@ -200,13 +207,15 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
             throw new ObjectDisposedException(nameof(ScopedContainer));
         }
 
-        if (_resolutionStack.Value != null && !_resolutionStack.Value.Add(serviceType))
+        var resolutionStack = _resolutionStack.Value;
+        if (resolutionStack != null && resolutionStack.Contains(serviceType))
         {
             throw new InvalidOperationException(
                 $"Circular dependency detected while resolving {serviceType}. " +
-                $"Resolution chain: {GetResolutionStackString()}");
+                $"Resolution chain: {string.Join(" -> ", resolutionStack.Append(serviceType).Select(t => t.Name))}");
         }
 
+        resolutionStack?.Add(serviceType);
         try
         {
             // Child-scope registrations take priority over everything in the parent chain.
@@ -285,7 +294,10 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
         }
         finally
         {
-            _resolutionStack.Value?.Remove(serviceType);
+            if (resolutionStack is { Count: > 0 })
+            {
+                resolutionStack.RemoveAt(resolutionStack.Count - 1);
+            }
         }
     }
 
@@ -307,36 +319,42 @@ internal class ScopedContainer : IResolutionScope, IServiceRegistry, IDisposable
 
         // Collect from parent first, forwarding the effective overrides so that
         // parent-registered implementations are instantiated with child-scope deps.
+        // Enumerable resolution always yields an array (never "not registered"), so a
+        // failure here is a genuine construction error and must propagate.
         if (_parent != null)
         {
-            try
+            var enumerableType = typeof(IEnumerable<>).MakeGenericType(elementType);
+            var parentEnumerable = _parent.ResolveCore(enumerableType, null, effectiveOverrides, childScope);
+            if (parentEnumerable is IEnumerable enumerable)
             {
-                var enumerableType = typeof(IEnumerable<>).MakeGenericType(elementType);
-                var parentEnumerable = _parent.ResolveCore(enumerableType, null, effectiveOverrides, childScope);
-                if (parentEnumerable is IEnumerable enumerable)
-                {
-                    instances.AddRange(enumerable.Cast<object>());
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Parent has no registrations for this element type — continue.
+                instances.AddRange(enumerable.Cast<object>());
             }
         }
 
-        // Add implementations from this scope's own registrations.
-        foreach (var (type, registrations) in _registrations)
+        // Add implementations from this scope's own registrations, matching the element
+        // type exactly (as single-service resolution does).
+        if (_registrations.TryGetValue(elementType, out var registrations))
         {
-            if (!elementType.IsAssignableFrom(type))
-            {
-                continue;
-            }
-
             foreach (var registration in registrations)
             {
-                instances.Add(
-                    registration.Instance ??
-                    CreateInstance(registration.ImplementationType, type, effectiveOverrides, childScope));
+                if (registration.Instance != null)
+                {
+                    instances.Add(registration.Instance);
+                    continue;
+                }
+
+                var instance = CreateInstance(
+                    registration.ImplementationType,
+                    elementType,
+                    effectiveOverrides,
+                    childScope);
+
+                if (registration.Singleton)
+                {
+                    registration.Instance = instance;
+                }
+
+                instances.Add(instance);
             }
         }
 


### PR DESCRIPTION
## Summary

Adds `ScopedContainer`, a self-contained dependency injection container for internal driver use. The container has no dependencies outside `System.*`.

## Basic functionality

`ScopedContainer` implements two public-facing interfaces:

- `IServiceRegistry` — registration: `RegisterInstance`, `RegisterType<TService, TImplementation>`, `RegisterType<TService>` (self-registration), and `RegisterInterceptor`.
- `IResolutionScope` (extends `IServiceResolver` and `IAsyncDisposable`) — resolution: `Resolve<T>`, `Resolve(Type)`, `TryResolve<T>`, `TryResolve(Type, out object)`, plus `CreateChildScope` for nesting.

Registration and resolution are decoupled: consumers that only need to resolve services depend on `IServiceResolver`/`IResolutionScope`, while only the composition root needs `IServiceRegistry`.

Registering the same service type more than once does not replace the earlier registration; both are kept. A single-service resolve (`Resolve<T>`) returns the **most recently registered** implementation, while resolving `IEnumerable<T>` returns **all** of them. This lets the container be used both for plain one-to-one substitution and for the collection-of-implementations pattern.

Construction is via reflection: `CreateInstance` selects the public constructor with the **most parameters** (no fallback to a lesser constructor if that one can't be satisfied) and recursively resolves each parameter. There is no attribute-based selection of constructors.

Circular dependencies are detected via a thread-local resolution stack per container and reported with the full resolution chain in the exception message (`A -> B -> A`), rather than failing with a `StackOverflowException`. Resolving an unregistered type similarly throws `InvalidOperationException` with the resolution chain attached, unless `TryResolve` is used, which returns `false` instead of throwing.

`AutoRegisterAttribute` is included as a marker attribute (with a `singleton` flag) for classes intended to be auto-registered against every interface they implement. It carries no behaviour in this PR — no scanning/registration logic consumes it yet — and is included only so it exists as a stable extension point for later work.

## Resolution interceptors

`IResolutionInterceptor` is the container's plugin mechanism for services that cannot be satisfied by straightforward constructor injection:

```csharp
internal interface IResolutionInterceptor
{
    bool TryResolve(Type serviceType, Type requestingType, IServiceResolver resolver, out object service);
}
```

Interceptors are registered via `RegisterInterceptor` and consulted, in registration order, before the container's own registration table is checked at that scope. A resolution is short-circuited by the first interceptor that returns `true`.

The motivating use case is logging: an `ILogger` isn't a single shared implementation — each consuming class needs a logger instance tagged with *its own type*, which one-to-one type registration can't express. A `LoggingInterceptor` (to be introduced in a follow-up PR) implements this:

```csharp
internal class LoggingInterceptor : IResolutionInterceptor
{
    private readonly ILoggerFactory _loggerFactory;

    public bool TryResolve(Type serviceType, Type requestingType, IServiceResolver resolver, out object service)
    {
        if (serviceType == typeof(ILogger))
        {
            var tracker = resolver.Resolve<ILoggingContextTracker>();
            service = _loggerFactory.GetLoggerForType(requestingType, tracker);
            return true;
        }

        service = null;
        return false;
    }
}
```

`requestingType` gives the interceptor the consumer's type without any registration per consumer. The `resolver` passed to the interceptor is always the resolver for the *innermost* scope of the current resolution (see below), so an interceptor's own dependency resolution (here, `ILoggingContextTracker`) picks up whatever overrides exist at the leaf of the scope chain, even though the interceptor itself may be registered at an outer scope.

## Scopes

`CreateChildScope(Action<IServiceRegistry> registrations)` creates a new `ScopedContainer` linked to its parent and immediately applies the supplied registration callback to it. Scopes can be nested arbitrarily deep.

### Resolution precedence

A resolution request walks from the scope it was made on outward through ancestors until it is satisfied. At each scope visited, in order:

1. Registrations belonging to any more-derived scope already visited in this same resolution (see "reaching into inner scopes" below).
2. This scope's own interceptors, in registration order.
3. This scope's own registration table (most recently registered implementation for the requested type).
4. If none of the above resolve it, delegate to the parent scope, if any.

Consequently, a plain registration on a descendant scope outranks an ancestor's interceptor, and any scope's own interceptors outrank its own registration table.

### Outer scopes reaching into inner scopes

Resolution is not simply "check here, then check parent" — it threads the originating (innermost) scope's registrations *up* through every ancestor it visits. This matters when an outer scope owns the registration for a service, but that service's constructor needs a dependency that only an inner scope provides:

- A parent registers `IFoo -> FooImpl(IBar bar)`.
- A child scope registers an instance of `IBar`.
- Resolving `IFoo` from the *child* succeeds: the parent is asked to build `FooImpl`, but while doing so, its constructor dependency `IBar` is resolved by looking first at the child's registrations, which is where `IBar` was found.

This also applies transitively (a dependency two or more levels deep can still be satisfied from a scope closer to the root of the original request than the type that needs it), to `IEnumerable<T>` resolution (parent-registered implementations are instantiated using the child's overrides), and to chains more than one scope deep, where the most-derived scope's registration wins if two intermediate scopes both provide the same type.

A registration marked `singleton` is cached against the registration itself — i.e. on the scope it was registered on — so it is built at most once. A singleton registered on a parent scope is shared by every descendant scope that resolves it, unless a descendant registers its own implementation of that service, which shadows the ancestor's for single-service resolution (an `IEnumerable<T>` resolve still returns both).

## Disposal

`ScopedContainer` implements both `IDisposable` and `IAsyncDisposable`; `Dispose()` is a synchronous wrapper over `DisposeAsync()`. Disposal is idempotent.

- Instances the container **creates itself** (via `RegisterType` + resolution) are always tracked for disposal, regardless of interface.
- Instances registered via `RegisterInstance` are **not** disposed by the container by default — the caller retains ownership — unless `transferOwnership: true` is passed at registration time.
- Both `IDisposable` and `IAsyncDisposable` instances are tracked on the same stack; plain `IDisposable` instances are wrapped so synchronous disposal still participates in the async disposal chain.
- Disposal happens in **reverse creation order** (LIFO), so a service is always disposed before the dependency it was constructed from.
- Child scopes are themselves tracked as disposables of their parent, so disposing a parent scope recursively disposes every child scope (and everything owned by it) before the parent's own directly-owned instances.
- Once disposed, further `Resolve`/`CreateChildScope` calls throw `ObjectDisposedException`.
