### PR TITLE
Fix hanging liveness probe consuming acquisition timeout (DRIVERS-488)

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -220,6 +220,58 @@ public class ConnectionPoolTests
         }
 
         [Fact]
+        public async Task ShouldAcquireFreshConnectionWhenIdleConnectionLivenessProbeHangs()
+        {
+            var deadConnection = new Mock<IPooledConnection>();
+            deadConnection
+                .Setup(x => x.ResetAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            deadConnection
+                .Setup(x => x.SyncAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(ct => Task.Delay(Timeout.Infinite, ct));
+
+            var freshConnection = new Mock<IPooledConnection>();
+            freshConnection
+                .Setup(x => x.InitAsync(It.IsAny<SessionConfig>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            freshConnection
+                .Setup(x => x.ResetAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            freshConnection
+                .Setup(x => x.SyncAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            freshConnection
+                .Setup(x => x.ValidateCredsAsync())
+                .Returns(ValueTask.CompletedTask);
+
+            var factoryMock = new Mock<IPooledConnectionFactory>();
+            factoryMock
+                .Setup(x => x.Create(It.IsAny<Uri>(), It.IsAny<IConnectionReleaseManager>(), It.IsAny<IAuthToken>()))
+                .Returns(freshConnection.Object);
+
+            var idleConnections = new BlockingCollection<IPooledConnection> { deadConnection.Object };
+
+            var pool = new ConnectionPool(
+                factoryMock.Object,
+                idleConnections,
+                driverContext: TestDriverContext.With(
+                    config: x => x
+                        .WithMaxConnectionPoolSize(1)
+                        .WithConnectionTimeout(TimeSpan.FromMilliseconds(500))
+                        .WithConnectionAcquisitionTimeout(TimeSpan.FromSeconds(5))),
+                validator: new LivenessProbeValidator());
+
+            var acquired = await pool.AcquireAsync(AccessMode.Read, null, null, Bookmarks.Empty);
+
+            acquired.Should().BeSameAs(freshConnection.Object);
+            deadConnection.Verify(x => x.DestroyAsync(), Times.Once);
+        }
+
+        [Fact]
         public async Task ShouldNotExceedIdleLimit()
         {
             var pool = NewConnectionPool(

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -272,6 +272,50 @@ public class ConnectionPoolTests
         }
 
         [Fact]
+        public async Task ShouldSurfaceAcquisitionTimeoutWhenItFiresBeforeLivenessProbeTimeout()
+        {
+            var deadConnection = new Mock<IPooledConnection>();
+            deadConnection
+                .Setup(x => x.ResetAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            deadConnection
+                .Setup(x => x.SyncAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(ct => Task.Delay(Timeout.Infinite, ct));
+
+            var connectionDestroyed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            deadConnection
+                .Setup(x => x.DestroyAsync())
+                .Returns(() =>
+                {
+                    connectionDestroyed.TrySetResult();
+                    return Task.CompletedTask;
+                });
+
+            var factoryMock = new Mock<IPooledConnectionFactory>();
+            var idleConnections = new BlockingCollection<IPooledConnection> { deadConnection.Object };
+
+            var pool = new ConnectionPool(
+                factoryMock.Object,
+                idleConnections,
+                driverContext: TestDriverContext.With(
+                    config: x => x
+                        .WithMaxConnectionPoolSize(1)
+                        .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+                        .WithConnectionAcquisitionTimeout(TimeSpan.FromMilliseconds(500))),
+                validator: new LivenessProbeValidator());
+
+            var act = () => pool.AcquireAsync(AccessMode.Read, null, null, Bookmarks.Empty);
+
+            await act.Should().ThrowAsync<ClientException>();
+
+            await connectionDestroyed.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            factoryMock.Verify(
+                x => x.Create(It.IsAny<Uri>(), It.IsAny<IConnectionReleaseManager>(), It.IsAny<IAuthToken>()),
+                Times.Never);
+        }
+
+        [Fact]
         public async Task ShouldNotExceedIdleLimit()
         {
             var pool = NewConnectionPool(

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -107,6 +107,7 @@ internal sealed class ConnectionPool : IConnectionPool
 
     private int MaxIdlePoolSize => DriverContext.Config.MaxIdleConnectionPoolSize;
     private TimeSpan ConnectionAcquisitionTimeout => DriverContext.Config.ConnectionAcquisitionTimeout;
+    private TimeSpan ConnectionTimeout => DriverContext.Config.ConnectionTimeout;
     private int MaxPoolSize => DriverContext.Config.MaxConnectionPoolSize;
 
     private bool IsClosed => AtomicRead(ref _poolStatus) == Closed;
@@ -511,8 +512,12 @@ internal sealed class ConnectionPool : IConnectionPool
             {
                 try
                 {
-                    await connection.ResetAsync(cancellationToken).ConfigureAwait(false);
-                    await connection.SyncAsync(cancellationToken).ConfigureAwait(false);
+                    using var probeTimeoutSource =
+                        CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                    probeTimeoutSource.CancelAfter(ConnectionTimeout);
+                    await connection.ResetAsync(probeTimeoutSource.Token).ConfigureAwait(false);
+                    await connection.SyncAsync(probeTimeoutSource.Token).ConfigureAwait(false);
                 }
                 catch
                 {


### PR DESCRIPTION
Fixes DRIVERS-488.

If a liveness check timeout is set, then the driver attempts to "ping" the server when it takes the connection from the pool, if the connection has been idle longer than the threshold. 

If in the meantime, the server has dropped the connection without the client getting a RST message, then the "ping" (actually a RESET) hangs. The only timeout guarding this is the ConnectionAcquisitionTimeout, typically set at 60s, which is "the longest I will wait to get a usable connection". Therefore because of the hung read, the entire timeout gets used up waiting for a response that never comes, so instead of trying a different connection, the whole acquire operation fails. 

The bug was reproduced as a failing test, with the fix turning it green.

The fix I've put in is to guard the liveness check by using the ConnectionTimeout, which is the timeout used when creating a new connection ("the longest I will try one connection before moving on").