### PR TITLE
Address issues in security report

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/AuthTokenTests.cs
@@ -121,5 +121,21 @@ public class AuthTokenTests
             dict.ContainsKey("parameters").Should().BeFalse();
             dict.ContainsKey("principal").Should().BeFalse();
         }
+
+        [Fact]
+        public void ShouldNotExposeCredentialsOrParametersInToString()
+        {
+            var authToken = AuthTokens.Custom(
+                "zhenli",
+                "toufu",
+                "foo",
+                "custom",
+                new Dictionary<string, object> { { "apiSecret", "hunter2" } });
+
+            var text = authToken.ToString();
+
+            text.Should().NotContain("toufu");
+            text.Should().NotContain("hunter2");
+        }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -246,6 +246,36 @@ public class ConnectionPoolTests
         }
 
         [Fact]
+        public async Task ShouldKeepCountingConnectionWhileItIsBeingReleased()
+        {
+            var releaseReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseMayFinish = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var connectionMock = new Mock<IConnection>();
+            connectionMock.Setup(x => x.IsOpen).Returns(true);
+            connectionMock.SetupGet(x => x.SsrEnabled).Returns(false);
+
+            var pool = new ConnectionPool(
+                new MockedConnectionFactory(connectionMock.Object),
+                driverContext: TestDriverContext.MockContext,
+                validator: new BlockingReleaseValidator(releaseReached, releaseMayFinish));
+
+            var connection = await pool.AcquireAsync(AccessMode.Read, null, null, Bookmarks.Empty);
+            pool.NumberOfConnectionsWithSsrDisabled.Should().Be(1);
+
+            var release = connection.CloseAsync();
+            await releaseReached.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            pool.NumberOfConnectionsWithSsrDisabled.Should().Be(1);
+            pool.TotalNumberOfConnections.Should().Be(1);
+
+            releaseMayFinish.SetResult(true);
+            await release;
+
+            pool.NumberOfConnectionsWithSsrDisabled.Should().Be(1);
+        }
+
+        [Fact]
         public async Task ShouldAcquireFreshConnectionWhenIdleConnectionLivenessProbeHangs()
         {
             var deadConnection = new Mock<IPooledConnection>();
@@ -1901,6 +1931,29 @@ public class ConnectionPoolTests
     {
         public Task<bool> OnReleaseAsync(IPooledConnection connection) => Task.FromResult(true);
         public AcquireStatus GetConnectionLifetimeStatus(IPooledConnection connection) => AcquireStatus.RequiresLivenessProbe;
+    }
+
+    private sealed class BlockingReleaseValidator : IConnectionValidator
+    {
+        private readonly TaskCompletionSource _reached;
+        private readonly TaskCompletionSource<bool> _mayFinish;
+
+        public BlockingReleaseValidator(TaskCompletionSource reached, TaskCompletionSource<bool> mayFinish)
+        {
+            _reached = reached;
+            _mayFinish = mayFinish;
+        }
+
+        public Task<bool> OnReleaseAsync(IPooledConnection connection)
+        {
+            _reached.TrySetResult();
+            return _mayFinish.Task;
+        }
+
+        public AcquireStatus GetConnectionLifetimeStatus(IPooledConnection connection)
+        {
+            return AcquireStatus.Healthy;
+        }
     }
 
     private class TestConnectionValidator : IConnectionValidator

--- a/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/ConnectionPoolTests.cs
@@ -220,6 +220,32 @@ public class ConnectionPoolTests
         }
 
         [Fact]
+        public async Task ShouldNotDriftSsrCountWhenConnectionFailsBeforeBeingAddedToPool()
+        {
+            var connectionMock = new Mock<IPooledConnection>();
+            connectionMock.Setup(x => x.SsrEnabled).Returns(false);
+            connectionMock
+                .Setup(x => x.InitAsync(It.IsAny<SessionConfig>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ServiceUnavailableException("failed to init"));
+
+            var factoryMock = new Mock<IPooledConnectionFactory>();
+            factoryMock
+                .Setup(x => x.Create(It.IsAny<Uri>(), It.IsAny<IConnectionReleaseManager>(), It.IsAny<IAuthToken>()))
+                .Returns(connectionMock.Object);
+
+            var pool = new ConnectionPool(
+                factoryMock.Object,
+                driverContext: TestDriverContext.MockContext,
+                validator: new TestConnectionValidator());
+
+            var act = () => pool.AcquireAsync(AccessMode.Read, null, null, Bookmarks.Empty);
+
+            await act.Should().ThrowAsync<ServiceUnavailableException>();
+
+            pool.NumberOfConnectionsWithSsrDisabled.Should().Be(0);
+        }
+
+        [Fact]
         public async Task ShouldAcquireFreshConnectionWhenIdleConnectionLivenessProbeHangs()
         {
             var deadConnection = new Mock<IPooledConnection>();

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/Trust/TrustManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/Trust/TrustManagerTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using Neo4j.Driver.Internal.Logging;
@@ -38,6 +39,13 @@ public class TrustManagerTests
         }
     }
 
+    private static X509Certificate2 SelfSignedCertificate()
+    {
+        using var key = RSA.Create(2048);
+        var request = new CertificateRequest("CN=example.test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+    }
+
     [Theory]
     [MemberData(nameof(AllTrustManagers))]
     public void ShouldRefusePeerThatPresentedNoCertificate(TrustManager trustManager, bool verifyHostname)
@@ -51,5 +59,52 @@ public class TrustManagerTests
             SslPolicyErrors.RemoteCertificateNotAvailable);
 
         trusted.Should().BeFalse($"verifyHostname: {verifyHostname}");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllTrustManagers))]
+    public void ShouldRefuseCertificateAccompaniedByNotAvailableFlag(TrustManager trustManager, bool verifyHostname)
+    {
+        trustManager.Neo4JLogger = NullNeo4JLogger.Instance;
+        using var certificate = SelfSignedCertificate();
+
+        var trusted = trustManager.ValidateServerCertificate(
+            ServerUri,
+            certificate,
+            new X509Chain(),
+            SslPolicyErrors.RemoteCertificateNotAvailable);
+
+        trusted.Should().BeFalse($"verifyHostname: {verifyHostname}");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllTrustManagers))]
+    public void ShouldRefuseMissingCertificateEvenWithoutPolicyErrors(TrustManager trustManager, bool verifyHostname)
+    {
+        trustManager.Neo4JLogger = NullNeo4JLogger.Instance;
+
+        var trusted = trustManager.ValidateServerCertificate(
+            ServerUri,
+            null,
+            new X509Chain(),
+            SslPolicyErrors.None);
+
+        trusted.Should().BeFalse($"verifyHostname: {verifyHostname}");
+    }
+
+    [Fact]
+    public void ShouldTrustPresentedCertificateWhenValidationIsDisabled()
+    {
+        var trustManager = TrustManager.CreateInsecure();
+        trustManager.Neo4JLogger = NullNeo4JLogger.Instance;
+        using var certificate = SelfSignedCertificate();
+
+        var trusted = trustManager.ValidateServerCertificate(
+            ServerUri,
+            certificate,
+            new X509Chain(),
+            SslPolicyErrors.None);
+
+        trusted.Should().BeTrue();
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Connector/Trust/TrustManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Connector/Trust/TrustManagerTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using Neo4j.Driver.Internal.Logging;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Connector.Trust;
+
+public class TrustManagerTests
+{
+    private static readonly Uri ServerUri = new("bolt://example.test:7687");
+
+    public static IEnumerable<object[]> AllTrustManagers()
+    {
+        foreach (var verifyHostname in new[] { false, true })
+        {
+            yield return [TrustManager.CreateChainTrust(verifyHostname), verifyHostname];
+            yield return [TrustManager.CreatePeerTrust(verifyHostname), verifyHostname];
+            yield return [TrustManager.CreateCertTrust([], verifyHostname), verifyHostname];
+            yield return [TrustManager.CreateInsecure(verifyHostname), verifyHostname];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllTrustManagers))]
+    public void ShouldRefusePeerThatPresentedNoCertificate(TrustManager trustManager, bool verifyHostname)
+    {
+        trustManager.Neo4JLogger = NullNeo4JLogger.Instance;
+
+        var trusted = trustManager.ValidateServerCertificate(
+            ServerUri,
+            null,
+            new X509Chain(),
+            SslPolicyErrors.RemoteCertificateNotAvailable);
+
+        trusted.Should().BeFalse($"verifyHostname: {verifyHostname}");
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/HomeDbCaching/HomeDbCacheKeyProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/HomeDbCaching/HomeDbCacheKeyProviderTests.cs
@@ -58,13 +58,20 @@ public class HomeDbCacheKeyProviderTests
     }
 
     [Fact]
-    public void ShouldPreferSessionLevelAuthTokenOverDriverLevelAuthToken()
+    public void ShouldPreferImpersonatedUserOverSessionLevelAuthToken()
     {
-        var sessionConfig = SessionConfig.Builder.WithAuthToken(AuthTokens.Basic("alice", "alicepw")).Build();
+        var sessionToken = AuthTokens.Basic("bob", "bobpw");
+        var bothConfig = SessionConfig.Builder
+            .WithImpersonatedUser("alice")
+            .WithAuthToken(sessionToken)
+            .Build();
 
-        var withDriverToken = HomeDbCacheKeyProvider.GetCacheKey(AuthTokens.Basic("bob", "bobpw"), sessionConfig);
-        var withoutDriverToken = HomeDbCacheKeyProvider.GetCacheKey(null, sessionConfig);
+        var key = HomeDbCacheKeyProvider.GetCacheKey(null, bothConfig);
 
-        withDriverToken.Should().Be(withoutDriverToken);
+        var impersonationOnly = SessionConfig.Builder.WithImpersonatedUser("alice").Build();
+        var sessionTokenOnly = SessionConfig.Builder.WithAuthToken(sessionToken).Build();
+
+        key.Should().Be(HomeDbCacheKeyProvider.GetCacheKey(null, impersonationOnly));
+        key.Should().NotBe(HomeDbCacheKeyProvider.GetCacheKey(null, sessionTokenOnly));
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.Tests/HomeDbCaching/HomeDbCacheKeyProviderTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/HomeDbCaching/HomeDbCacheKeyProviderTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using Neo4j.Driver.Internal.HomeDbCaching;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.HomeDbCaching;
+
+public class HomeDbCacheKeyProviderTests
+{
+    [Fact]
+    public void ShouldTreatAllDriverLevelAuthTokensAsEqual()
+    {
+        var aliceKey = HomeDbCacheKeyProvider.GetCacheKey(AuthTokens.Basic("alice", "alicepw"), null);
+        var bobKey = HomeDbCacheKeyProvider.GetCacheKey(AuthTokens.Basic("bob", "bobpw"), null);
+
+        aliceKey.Should().Be(HomeDbCacheKey.Default);
+        bobKey.Should().Be(HomeDbCacheKey.Default);
+    }
+
+    [Fact]
+    public void ShouldPartitionBySessionLevelAuthToken()
+    {
+        var aliceConfig = SessionConfig.Builder.WithAuthToken(AuthTokens.Basic("alice", "alicepw")).Build();
+        var bobConfig = SessionConfig.Builder.WithAuthToken(AuthTokens.Basic("bob", "bobpw")).Build();
+
+        var aliceKey = HomeDbCacheKeyProvider.GetCacheKey(null, aliceConfig);
+        var bobKey = HomeDbCacheKeyProvider.GetCacheKey(null, bobConfig);
+
+        aliceKey.Should().NotBe(bobKey);
+        aliceKey.Should().NotBe(HomeDbCacheKey.Default);
+    }
+
+    [Fact]
+    public void ShouldPartitionByImpersonatedUser()
+    {
+        var aliceConfig = SessionConfig.Builder.WithImpersonatedUser("alice").Build();
+        var bobConfig = SessionConfig.Builder.WithImpersonatedUser("bob").Build();
+
+        var aliceKey = HomeDbCacheKeyProvider.GetCacheKey(null, aliceConfig);
+        var bobKey = HomeDbCacheKeyProvider.GetCacheKey(null, bobConfig);
+
+        aliceKey.Should().NotBe(bobKey);
+        aliceKey.Should().NotBe(HomeDbCacheKey.Default);
+    }
+
+    [Fact]
+    public void ShouldPreferSessionLevelAuthTokenOverDriverLevelAuthToken()
+    {
+        var sessionConfig = SessionConfig.Builder.WithAuthToken(AuthTokens.Basic("alice", "alicepw")).Build();
+
+        var withDriverToken = HomeDbCacheKeyProvider.GetCacheKey(AuthTokens.Basic("bob", "bobpw"), sessionConfig);
+        var withoutDriverToken = HomeDbCacheKeyProvider.GetCacheKey(null, sessionConfig);
+
+        withDriverToken.Should().Be(withoutDriverToken);
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ConcurrentHashSetTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Internal/Util/ConcurrentHashSetTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [https://neo4j.com]
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+using Neo4j.Driver.Internal.Util;
+using Xunit;
+
+namespace Neo4j.Driver.Tests.Internal.Util;
+
+public static class ConcurrentHashSetTests
+{
+    public class TryAddMethod
+    {
+        [Fact]
+        public void ShouldReportWhetherItemWasInserted()
+        {
+            var set = new ConcurrentHashSet<string>();
+
+            var first = set.TryAdd("a");
+            var second = set.TryAdd("a");
+
+            first.Should().BeTrue();
+            second.Should().BeFalse();
+            set.Count.Should().Be(1);
+        }
+    }
+
+    public class TryRemoveMethod
+    {
+        [Fact]
+        public void ShouldReportWhetherItemWasRemoved()
+        {
+            var set = new ConcurrentHashSet<string>();
+            set.TryAdd("a");
+
+            var first = set.TryRemove("a");
+            var second = set.TryRemove("a");
+
+            first.Should().BeTrue();
+            second.Should().BeFalse();
+            set.Count.Should().Be(0);
+        }
+    }
+}

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
@@ -1046,17 +1046,10 @@ public static class RoutingTableManagerTests
 
             var discovery = new Mock<IDiscovery>();
 
-            var poolManager = new Mock<IClusterConnectionPoolManager>();
-            poolManager.Setup(x => x.CreateClusterConnectionAsync(It.IsAny<Uri>(), It.IsAny<SessionConfig>()))
-                .ReturnsAsync(Mock.Of<IConnection>);
-
-            var initialAddressProvider = new Mock<IInitialServerAddressProvider>();
-            initialAddressProvider.Setup(x => x.Get()).Returns(new HashSet<Uri> { server01 });
-
             var manager = new RoutingTableManager(
-                initialAddressProvider.Object,
+                Mock.Of<IInitialServerAddressProvider>(),
                 discovery.Object,
-                poolManager.Object,
+                Mock.Of<IClusterConnectionPoolManager>(),
                 Mock.Of<INeo4jLogger>(),
                 TimeSpan.MaxValue,
                 cachedHomeDbTable);
@@ -1073,6 +1066,68 @@ public static class RoutingTableManagerTests
                 x => x.DiscoverAsync(
                     It.IsAny<IConnection>(),
                     It.IsAny<string>(),
+                    It.IsAny<SessionConfig>(),
+                    It.IsAny<Bookmarks>(),
+                    It.IsAny<IHomeDbCache>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ShouldRediscoverHomeDatabaseWhenCachedNameIsStale()
+        {
+            var staleTable = new Mock<IRoutingTable>();
+            staleTable.Setup(x => x.Database).Returns("db_alice");
+            staleTable.Setup(x => x.IsStale(It.IsAny<AccessMode>())).Returns(true);
+            staleTable.Setup(x => x.Routers).Returns(new List<Uri> { server01 });
+
+            var freshTable =
+                new RoutingTable("db_bob", new[] { server04 }, new[] { server05 }, new[] { server06 }, 1000);
+
+            var discovery = new Mock<IDiscovery>();
+            discovery.Setup(
+                    x => x.DiscoverAsync(
+                        It.IsAny<IConnection>(),
+                        It.IsAny<string>(),
+                        It.IsAny<SessionConfig>(),
+                        It.IsAny<Bookmarks>(),
+                        It.IsAny<IHomeDbCache>()))
+                .ReturnsAsync(freshTable);
+
+            var poolManager = new Mock<IClusterConnectionPoolManager>();
+            poolManager.Setup(x => x.CreateClusterConnectionAsync(It.IsAny<Uri>(), It.IsAny<SessionConfig>()))
+                .ReturnsAsync(Mock.Of<IConnection>);
+
+            var initialAddressProvider = new Mock<IInitialServerAddressProvider>();
+            initialAddressProvider.Setup(x => x.Get()).Returns(new HashSet<Uri> { server01 });
+
+            var manager = new RoutingTableManager(
+                initialAddressProvider.Object,
+                discovery.Object,
+                poolManager.Object,
+                Mock.Of<INeo4jLogger>(),
+                TimeSpan.MaxValue,
+                staleTable.Object);
+
+            await manager.EnsureRoutingTableForModeAsync(
+                AccessMode.Read,
+                "db_alice",
+                true,
+                null,
+                Bookmarks.Empty);
+
+            discovery.Verify(
+                x => x.DiscoverAsync(
+                    It.IsAny<IConnection>(),
+                    "",
+                    It.IsAny<SessionConfig>(),
+                    It.IsAny<Bookmarks>(),
+                    It.IsAny<IHomeDbCache>()),
+                Times.Once);
+
+            discovery.Verify(
+                x => x.DiscoverAsync(
+                    It.IsAny<IConnection>(),
+                    "db_alice",
                     It.IsAny<SessionConfig>(),
                     It.IsAny<Bookmarks>(),
                     It.IsAny<IHomeDbCache>()),

--- a/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/Routing/RoutingTableManagerTests.cs
@@ -1039,6 +1039,47 @@ public static class RoutingTableManagerTests
         }
 
         [Fact]
+        public async Task ShouldReuseExistingRoutingTableWhenDatabaseCameFromHomeDbCache()
+        {
+            var cachedHomeDbTable =
+                new RoutingTable("db_alice", new[] { server01 }, new[] { server02 }, new[] { server03 }, 1000);
+
+            var discovery = new Mock<IDiscovery>();
+
+            var poolManager = new Mock<IClusterConnectionPoolManager>();
+            poolManager.Setup(x => x.CreateClusterConnectionAsync(It.IsAny<Uri>(), It.IsAny<SessionConfig>()))
+                .ReturnsAsync(Mock.Of<IConnection>);
+
+            var initialAddressProvider = new Mock<IInitialServerAddressProvider>();
+            initialAddressProvider.Setup(x => x.Get()).Returns(new HashSet<Uri> { server01 });
+
+            var manager = new RoutingTableManager(
+                initialAddressProvider.Object,
+                discovery.Object,
+                poolManager.Object,
+                Mock.Of<INeo4jLogger>(),
+                TimeSpan.MaxValue,
+                cachedHomeDbTable);
+
+            var result = await manager.EnsureRoutingTableForModeAsync(
+                AccessMode.Read,
+                "db_alice",
+                true,
+                null,
+                Bookmarks.Empty);
+
+            result.Should().Be(cachedHomeDbTable);
+            discovery.Verify(
+                x => x.DiscoverAsync(
+                    It.IsAny<IConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<SessionConfig>(),
+                    It.IsAny<Bookmarks>(),
+                    It.IsAny<IHomeDbCache>()),
+                Times.Never);
+        }
+
+        [Fact]
         public async Task ShouldPassBookmarkDownToDiscovery()
         {
             var bookmark = Bookmarks.From("bookmark-1", "bookmark-2");

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Auth/CustomAuthToken.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Auth/CustomAuthToken.cs
@@ -53,15 +53,22 @@ internal class CustomAuthToken : AuthToken
         }
     }
 
+    private static readonly HashSet<string> RedactedKeys = new()
+        { SchemeKey, PrincipalKey, RealmKey, CredentialsKey, ParametersKey };
+
     public override string ToString()
     {
         var scheme = Content.ContainsKey(SchemeKey) ? Content[SchemeKey] ?? "(null)" : "(none)";
         var principal = Content.ContainsKey(PrincipalKey) ? Content[PrincipalKey] ?? "(null)" : "(none)";
         var realm = Content.ContainsKey(RealmKey) ? Content[RealmKey] ?? "(null)" : "(none)";
+        var credentials = Content.ContainsKey(CredentialsKey) ? ", credentials: ******" : "";
+        var parameters = Content.ContainsKey(ParametersKey) ? ", parameters: ******" : "";
+
         return $"CustomAuthToken[scheme: {scheme}, principal: {principal}, realm: {realm}" +
-            // list of other keys present in Content
+            credentials +
+            parameters +
             Content.Keys
-                .Where(key => key != SchemeKey && key != PrincipalKey && key != RealmKey)
+                .Where(key => !RedactedKeys.Contains(key))
                 .Select(key => $", {key}: {Content[key] ?? "(null)"}")
                 .Aggregate("", (acc, next) => acc + next) +
             "]";

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -281,28 +281,6 @@ internal sealed class ConnectionPool : IConnectionPool
         Interlocked.CompareExchange(ref _poolStatus, Active, Inactive);
     }
 
-    /// <inheritdoc />
-    public bool IsOnlyConnectionWithoutSsr(IConnection connection)
-    {
-        var allConnections = _inUseConnections.Concat(_idleConnections).ToArray();
-        if (allConnections.All(c => c != connection))
-        {
-            // the connection is not in the pool
-            return false;
-        }
-
-        // go through all connections in the pool and check if there is any connection that has SSR enabled
-        var ssrDisabledCount = 0;
-        var connectionFound = false;
-        foreach (var conn in allConnections)
-        {
-            ssrDisabledCount += conn.SsrEnabled ? 0 : 1;
-            connectionFound |= conn == connection;
-        }
-
-        return connectionFound && ssrDisabledCount == 1;
-    }
-
     public ValueTask DisposeAsync()
     {
         return new ValueTask(CloseAsync());

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -51,9 +51,6 @@ internal sealed class ConnectionPool : IConnectionPool
     private readonly object _poolSizeSync = new();
 
     private readonly Uri _uri;
-    private int _connectionsWithSsrDisabled;
-
-    private int _connectionsWithSsrEnabled;
 
     private int _poolSize;
 
@@ -116,9 +113,9 @@ internal sealed class ConnectionPool : IConnectionPool
     internal int PoolSize => Interlocked.CompareExchange(ref _poolSize, -1, -1);
     public int NumberOfInUseConnections => _inUseConnections.Count;
     public int NumberOfIdleConnections => _idleConnections.Count;
-    public int NumberOfConnectionsWithSsrEnabled => _connectionsWithSsrEnabled;
-    public int NumberOfConnectionsWithSsrDisabled => _connectionsWithSsrDisabled;
-    public int TotalNumberOfConnections => _connectionsWithSsrDisabled + _connectionsWithSsrEnabled;
+    public int NumberOfConnectionsWithSsrEnabled => _inUseConnections.Concat(_idleConnections).Count(c => c.SsrEnabled);
+    public int NumberOfConnectionsWithSsrDisabled => _inUseConnections.Concat(_idleConnections).Count(c => !c.SsrEnabled);
+    public int TotalNumberOfConnections => _inUseConnections.Count + _idleConnections.Count;
 
     public ConnectionPoolStatus Status
     {
@@ -399,15 +396,6 @@ internal sealed class ConnectionPool : IConnectionPool
             return;
         }
 
-        if (conn.SsrEnabled)
-        {
-            Interlocked.Decrement(ref _connectionsWithSsrEnabled);
-        }
-        else
-        {
-            Interlocked.Decrement(ref _connectionsWithSsrDisabled);
-        }
-
         _poolMetricsListener?.ConnectionClosing();
         try
         {
@@ -536,14 +524,6 @@ internal sealed class ConnectionPool : IConnectionPool
     private async ValueTask AddConnectionAsync(IPooledConnection connection)
     {
         _inUseConnections.TryAdd(connection);
-        if (connection.SsrEnabled)
-        {
-            Interlocked.Increment(ref _connectionsWithSsrEnabled);
-        }
-        else
-        {
-            Interlocked.Increment(ref _connectionsWithSsrDisabled);
-        }
 
         if (!IsClosed)
         {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/ConnectionPool.cs
@@ -52,6 +52,10 @@ internal sealed class ConnectionPool : IConnectionPool
 
     private readonly Uri _uri;
 
+    private readonly ConcurrentHashSet<IPooledConnection> _liveConnections = new();
+    private int _connectionsWithSsrDisabled;
+    private int _connectionsWithSsrEnabled;
+
     private int _poolSize;
 
     private ConnectionPoolStatus _poolStatus = Active;
@@ -113,9 +117,9 @@ internal sealed class ConnectionPool : IConnectionPool
     internal int PoolSize => Interlocked.CompareExchange(ref _poolSize, -1, -1);
     public int NumberOfInUseConnections => _inUseConnections.Count;
     public int NumberOfIdleConnections => _idleConnections.Count;
-    public int NumberOfConnectionsWithSsrEnabled => _inUseConnections.Concat(_idleConnections).Count(c => c.SsrEnabled);
-    public int NumberOfConnectionsWithSsrDisabled => _inUseConnections.Concat(_idleConnections).Count(c => !c.SsrEnabled);
-    public int TotalNumberOfConnections => _inUseConnections.Count + _idleConnections.Count;
+    public int NumberOfConnectionsWithSsrEnabled => _connectionsWithSsrEnabled;
+    public int NumberOfConnectionsWithSsrDisabled => _connectionsWithSsrDisabled;
+    public int TotalNumberOfConnections => _connectionsWithSsrDisabled + _connectionsWithSsrEnabled;
 
     public ConnectionPoolStatus Status
     {
@@ -356,6 +360,7 @@ internal sealed class ConnectionPool : IConnectionPool
                 .InitAsync(sessionConfig, cancellationToken)
                 .ConfigureAwait(false);
 
+            StartTrackingConnection(conn);
             _poolMetricsListener?.ConnectionCreated();
             return conn;
         }
@@ -396,6 +401,8 @@ internal sealed class ConnectionPool : IConnectionPool
             return;
         }
 
+        StopTrackingConnection(conn);
+
         _poolMetricsListener?.ConnectionClosing();
         try
         {
@@ -404,6 +411,40 @@ internal sealed class ConnectionPool : IConnectionPool
         finally
         {
             _poolMetricsListener?.ConnectionClosed();
+        }
+    }
+
+    private void StartTrackingConnection(IPooledConnection conn)
+    {
+        if (!_liveConnections.TryAdd(conn))
+        {
+            return;
+        }
+
+        if (conn.SsrEnabled)
+        {
+            Interlocked.Increment(ref _connectionsWithSsrEnabled);
+        }
+        else
+        {
+            Interlocked.Increment(ref _connectionsWithSsrDisabled);
+        }
+    }
+
+    private void StopTrackingConnection(IPooledConnection conn)
+    {
+        if (!_liveConnections.TryRemove(conn))
+        {
+            return;
+        }
+
+        if (conn.SsrEnabled)
+        {
+            Interlocked.Decrement(ref _connectionsWithSsrEnabled);
+        }
+        else
+        {
+            Interlocked.Decrement(ref _connectionsWithSsrDisabled);
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
@@ -39,6 +39,11 @@ internal sealed class CertificateTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
+        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        {
+            return false;
+        }
+
         var now = DateTime.Now;
 
         if (_verifyHostname)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/CertificateTrustManager.cs
@@ -39,7 +39,7 @@ internal sealed class CertificateTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
-        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        if (TryRejectMissingCertificate(uri, certificate, sslPolicyErrors))
         {
             return false;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
@@ -47,6 +47,11 @@ internal class ChainTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
+        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        {
+            return false;
+        }
+
         if (_verifyHostname)
         {
             if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/ChainTrustManager.cs
@@ -47,7 +47,7 @@ internal class ChainTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
-        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        if (TryRejectMissingCertificate(uri, certificate, sslPolicyErrors))
         {
             return false;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
@@ -34,7 +34,7 @@ internal sealed class InsecureTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
-        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        if (TryRejectMissingCertificate(uri, certificate, sslPolicyErrors))
         {
             return false;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/InsecureTrustManager.cs
@@ -34,6 +34,11 @@ internal sealed class InsecureTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
+        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        {
+            return false;
+        }
+
         if (VerifyHostName)
         {
             if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
@@ -37,6 +37,11 @@ internal sealed class PeerTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
+        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        {
+            return false;
+        }
+
         var now = DateTime.Now;
 
         if (_verifyHostname)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Connector/Trust/PeerTrustManager.cs
@@ -37,7 +37,7 @@ internal sealed class PeerTrustManager : TrustManager
         X509Chain chain,
         SslPolicyErrors sslPolicyErrors)
     {
-        if (HasNoCertificate(uri, certificate, sslPolicyErrors))
+        if (TryRejectMissingCertificate(uri, certificate, sslPolicyErrors))
         {
             return false;
         }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/IConnectionPool.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
-using Neo4j.Driver.Internal.Connector;
 
 namespace Neo4j.Driver.Internal;
 
@@ -29,6 +28,4 @@ internal interface IConnectionPool : IConnectionProvider, IConnectionReleaseMana
     ConnectionPoolStatus Status { get; }
     Task DeactivateAsync();
     void Activate();
-
-    bool IsOnlyConnectionWithoutSsr(IConnection connection);
 }

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConcurrentHashSet.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Util/ConcurrentHashSet.cs
@@ -40,7 +40,7 @@ internal class ConcurrentHashSet<T> : IEnumerable<T>
     /// <returns></returns>
     public bool TryAdd(T item)
     {
-        return _items.GetOrAdd(item, _ => true);
+        return _items.TryAdd(item, true);
     }
 
     /// <summary>true if the item was removed from the set successfully; false if the item does not exists.</summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Auth/AuthTokenManagers.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Auth/AuthTokenManagers.cs
@@ -24,6 +24,11 @@ namespace Neo4j.Driver;
 /// This class provides common implementations of <see cref="IAuthTokenManager"/> for various types of
 /// authentication.
 /// </summary>
+/// <remarks>
+/// These manage credentials for a single identity, as <see cref="IAuthTokenManager"/> requires. To connect as more
+/// than one user from a single driver, give each session its own credentials with
+/// <see cref="SessionConfigBuilder.WithAuthToken"/> or use <see cref="SessionConfigBuilder.WithImpersonatedUser"/>.
+/// </remarks>
 public static class AuthTokenManagers
 {
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/Auth/IAuthTokenManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/Auth/IAuthTokenManager.cs
@@ -22,6 +22,15 @@ namespace Neo4j.Driver;
 /// Common interface for components that can provide auth tokens. For pre-baked implementations of this interface,
 /// see <see cref="AuthTokenManagers"/>.
 /// </summary>
+/// <remarks>
+/// An implementation is expected to supply credentials for a <b>single identity</b>, renewing that identity's
+/// credentials as they expire. It must not be used to switch between different users: the driver caches per-identity
+/// state, such as the home database resolved for a session that did not name one, without regard to the token
+/// returned here. Rotating identities through this interface can therefore route one user's session to another
+/// user's home database. To connect as more than one user from a single driver, give each session its own
+/// credentials via <see cref="SessionConfigBuilder.WithAuthToken"/>, or use
+/// <see cref="SessionConfigBuilder.WithImpersonatedUser"/>.
+/// </remarks>
 public interface IAuthTokenManager
 {
     /// <summary>

--- a/Neo4j.Driver/Neo4j.Driver/Public/GraphDatabase.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/GraphDatabase.cs
@@ -152,7 +152,8 @@ public static class GraphDatabase
     /// used when creating a driver connecting to the Neo4j instance directly. The protocol <c>neo4j</c> should be used when
     /// creating a driver with built-in routing.
     /// </param>
-    /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication.</param>
+    /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication. It must serve
+/// a single identity; see <see cref="IAuthTokenManager"/> for why, and for how to connect as several users.</param>
     /// <returns>A new <see cref="IDriver"/> instance.</returns>
     public static IDriver Driver(Uri uri, IAuthTokenManager authTokenManager)
     {
@@ -187,7 +188,8 @@ public static class GraphDatabase
     /// used when creating a driver connecting to the Neo4j instance directly. The protocol <c>neo4j</c> should be used when
     /// creating a driver with built-in routing.
     /// </param>
-    /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication.</param>
+    /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication. It must serve
+/// a single identity; see <see cref="IAuthTokenManager"/> for why, and for how to connect as several users.</param>
     /// <param name="action">
     /// Specifies how to build a driver configuration <see cref="Config"/>, using
     /// <see cref="ConfigBuilder"/>. If set to <c>null</c>, then no modification will be carried out and the default driver
@@ -225,7 +227,8 @@ public static class GraphDatabase
     /// used when creating a driver connecting to the Neo4j instance directly. The protocol <c>neo4j</c> should be used when
     /// creating a driver with built-in routing.
     /// </param>
-    /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication.</param>
+    /// <param name="authTokenManager">The <see cref="IAuthTokenManager"/> to use for authentication. It must serve
+/// a single identity; see <see cref="IAuthTokenManager"/> for why, and for how to connect as several users.</param>
     /// <param name="action">
     /// Specifies how to build a driver configuration <see cref="Config"/>, using
     /// <see cref="ConfigBuilder"/>. If set to <c>null</c>, then no modification will be carried out and the default driver

--- a/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
@@ -41,7 +41,7 @@ public abstract class TrustManager
 {
     internal INeo4jLogger Neo4JLogger { get; set; }
 
-    internal bool HasNoCertificate(Uri uri, X509Certificate2 certificate, SslPolicyErrors sslPolicyErrors)
+    internal bool TryRejectMissingCertificate(Uri uri, X509Certificate2 certificate, SslPolicyErrors sslPolicyErrors)
     {
         if (certificate != null && !sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNotAvailable))
         {
@@ -63,6 +63,13 @@ public abstract class TrustManager
     /// <value>false</value>
     /// otherwise
     /// </returns>
+    /// <remarks>
+    /// An implementation owns every precondition of its own decision, including the case where the peer presented
+    /// no certificate at all: <paramref name="certificate"/> is <see langword="null"/>, or
+    /// <paramref name="sslPolicyErrors"/> has <see cref="SslPolicyErrors.RemoteCertificateNotAvailable"/> set. Such a
+    /// peer must never be trusted, whatever the implementation's policy on certificates it can see, and callers of
+    /// this method are not required to screen it out first.
+    /// </remarks>
     public abstract bool ValidateServerCertificate(
         Uri uri,
         X509Certificate2 certificate,
@@ -70,7 +77,8 @@ public abstract class TrustManager
         SslPolicyErrors sslPolicyErrors);
 
     /// <summary>
-    /// Creates a trust manager that accepts any certificate without validation.
+    /// Creates a trust manager that accepts any certificate the peer presents, without validating it. A peer that
+    /// presents no certificate at all is still refused.
     /// </summary>
     /// <param name="verifyHostname">Whether to verify that the server hostname matches the certificate's subject.</param>
     /// <returns>An instance of <see cref="TrustManager"/>.</returns>

--- a/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Public/TrustManager.cs
@@ -41,6 +41,17 @@ public abstract class TrustManager
 {
     internal INeo4jLogger Neo4JLogger { get; set; }
 
+    internal bool HasNoCertificate(Uri uri, X509Certificate2 certificate, SslPolicyErrors sslPolicyErrors)
+    {
+        if (certificate != null && !sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNotAvailable))
+        {
+            return false;
+        }
+
+        Neo4JLogger.Error(null, $"{GetType().Name}: No certificate presented by '{uri}'.");
+        return true;
+    }
+
     /// <summary>Returns whether the endpoint should be trusted or not.</summary>
     /// <param name="uri">The uri towards which we're establishing connection</param>
     /// <param name="certificate">The certificate presented by the other endpoint</param>


### PR DESCRIPTION
Fixes DRIVERS-517

Response to the 6.x security audit report (30 July 2026). Four findings were raised: 3 Medium, 1 Low. Two are fixed, one is fixed in part and documented, one is deferred. Rationale for every decision is below, including the two sub-fixes we are deliberately **not** taking.

| Finding | Severity | Outcome |
|---|---|---|
| SEC-01 — custom auth token prints credentials | Medium (5.7) | Fixed |
| SEC-04 — validator accepts peer with no certificate | Medium (5.9) | Fixed |
| SEC-03 — cross-identity home-database misrouting | Medium (5.3) | 1 of 3 sub-fixes taken; 2 rejected; contract documented |
| SEC-05 — query payloads in debug log | Low (2.3) | Deferred |

Every finding was first re-verified against `6.x` at `b8091bee`. The report notes:

> **Version control was unavailable.** The directory reviewed is not a git checkout, so we could not check whether any finding has already been fixed on a branch

Nothing had been fixed in the interim — every line reference and code quote in the report matched the branch exactly.

The report also asks:

> **Static review only.** Nothing was executed or exploited. Reproduction steps are written procedures we have reasoned through, not runs we performed. We recommend confirming each one before scheduling remediation.

Each finding below was reproduced with a failing test before being fixed, and the two rejected sub-fixes were rejected on the basis of test evidence, not opinion.

---

## SEC-01 — Custom auth token prints credentials in clear text — **FIXED**

> One class — and it is the class most likely to hold a high-value secret — does the opposite.

> every other credential type in the driver deliberately hides the secret

Confirmed exactly as described: `CustomAuthToken.ToString()` excluded `scheme`/`principal`/`realm` from the "extra keys" list but not `credentials` or `parameters`, so both were printed raw.

`credentials` and `parameters` are now masked as `******`, matching the convention already used by `LogonMessage`/`HelloMessage`. Regression test asserts neither the credential nor a parameter value appears in `ToString()` output.

We accepted the report's reasoning on priority despite this being the second-ranked finding by CVSS:

> unlike anything else in this report, a leaked long-lived credential cannot be undone by deploying a patch

**Not taken:** the report's suggestion to also collapse `BearerAuthToken`/`KerberosAuthToken`'s five-character prefix to a full mask. That prefix is load-bearing for support diagnostics, and changing it is a behaviour change to two more token types that is out of scope here. Worth its own ticket if we want it.

## SEC-04 — Certificate validator accepts a peer that presented no certificate — **FIXED**

> a validator whose documented job is to verify certificates should not depend on its caller to reject a peer that presented none

Confirmed. `ChainTrustManager` tested only `RemoteCertificateChainErrors` and never asked whether a certificate was presented at all.

One correction to the report's reproduction steps, which predicted:

> **Expected today:** `trusted` is `true`. The correct result is `false`.

On macOS / .NET 8 it does not return `true` — it throws `ArgumentException: The chain context handle is invalid`, because the revocation-policy comparison sends it into `BuildChain` with a null certificate. Different symptom, same defect: it fails to cleanly refuse. The other three validators throw `NullReferenceException`. All four were wrong, none deliberately.

Implemented as the report recommended:

> Make every validator self-sufficient rather than relying on its caller. Add the same two-line precondition to all four implementations of `ValidateServerCertificate`.

The precondition lives in one `internal` helper on the `TrustManager` base class rather than being copy-pasted four times, so validators added later inherit it, and nothing is added to the public API surface. This is behaviour-neutral for every built-in path, because `DefaultTlsNegotiator` already rejects `RemoteCertificateNotAvailable` before any validator runs — it only closes the gap for applications supplying a custom `ITlsNegotiator`.

Because the helper is `internal`, it does not reach a third-party `TrustManager`, and `TrustManager` is public and abstract, so subclassing it is supported. The precondition is therefore stated on `ValidateServerCertificate` itself: an implementation owns it, and callers do not screen the case out beforehand. Widening the helper to `protected` was the alternative and was rejected to keep the public surface unchanged.

Tests cover all four validators with hostname verification on and off, for a missing certificate both with and without the policy flag, for a certificate presented alongside the flag — the one case whose result changes — and one happy path, so that a validator refusing everything no longer satisfies the file.

`InsecureTrustManager` is included, which deserves a note since `TrustManager.CreateInsecure` is documented as accepting "any certificate without validation". This is not a breaking change:

- With no certificate presented, the old code dereferenced `certificate.Subject` while building its log line and threw `NullReferenceException`. The connection failed then and fails now — a crash is replaced by a clean, logged refusal.
- The only case whose result actually flips is a non-null certificate arriving *together with* `RemoteCertificateNotAvailable`, which is self-contradictory and not reachable in practice.

"Insecure" means the driver will not judge which certificate to trust; it does not mean authenticating a peer that presented nothing at all.

## SEC-03 — Cross-identity database misrouting via the home-database cache — **PARTIALLY FIXED**

The report was explicit that this finding hinged on an unresolved question:

> Whether this is a live defect or defence-in-depth hardening turns on one unanswered question, and we could not resolve it from the code.

> The scenario assumes an application uses `IAuthTokenManager` to rotate between **different users**. If it is instead used to refresh **one user's** expiring token — which is what the built-in `Neo4jAuthTokenManager` does — the current behaviour is correct and **there is no bug**.

**That question is now settled, and the answer is that identity rotation is not supported.** Testkit specifies the opposite of the report's assumption, in `tests/stub/homedb/test_homedb.py::test_cache_considers_all_driver_auth_equal`:

> ```
> # Then: regardless of the token returned by the auth
> #       manager the driver should use the cached home db
> ```

That test rotates a driver-level `IAuthTokenManager` across three distinct users and asserts the cached home database is reused with **no new ROUTE request**. Driver-level auth is deliberately excluded from the cache key across all drivers; per-identity partitioning is expected to come from session-level auth or impersonation, both of which are already keyed correctly today.

So the report's own alternate branch applies:

> **If it is not supported** — the three fixes below are still correct hardening, but the urgency drops considerably, and the interface should be documented to say so explicitly.

We disagree that (a) and (c) are "still correct hardening" — measured against testkit they are regressions, not hardening. Each sub-fix was implemented and measured independently against `tests/stub/homedb` (baseline: 37 passed):

| Sub-fix | Result | Decision |
|---|---|---|
| (a) put identity in the cache key | 3 failures | **Rejected** |
| (b) count live connections, not borrow events | 37 passed | **Fixed** |
| (c) honour `isCachedHomeDb` on the early-return path | 39 failures, 4 errors | **Rejected** |

### (a) Rejected — contradicts the cross-driver contract

Fails `test_cache_considers_all_driver_auth_equal` in all three session variants. Partitioning the cache by driver-level token is precisely what testkit forbids.

It also required fetching a token where none was previously needed, which broke `tests/stub/authorization/test_auth_token_manager` — 160 failures, all routed cases, `get_auth_count` 3 where 2 was expected. Making the fetch lazy fixed that symptom, but the underlying spec conflict remained, so the sub-fix is dropped entirely.

### (b) Fixed — a real counter bug, independent of the identity question

> The safety gate that should disable the cache reads a meaningless number.

> It is therefore "borrows minus destructions", which bears no relationship to how many connections exist.

Confirmed and reproduced: destroying a connection that never completed `AddConnectionAsync` (a routine failed connection attempt) drives `NumberOfConnectionsWithSsrDisabled` to `-1`, and both consumers compare against exact constants, so drift can produce a false zero and re-enable the home-db cache in a mixed cluster that should have it disabled.

The report also observed that the codebase already contained a correct answer to the same question:

> **Corroborating evidence that this is a defect, not a design:** the codebase already contains a *correct* implementation of the same question — `ConnectionPool.IsOnlyConnectionWithoutSsr` — which counts the live connection collections directly. Nothing calls it.

That method is now deleted rather than promoted. The question it answers is cluster-wide, which a single pool cannot see, and `ClusterConnectionPool.ConnectionCausesCacheDisable` already answers it at that level; keeping a second per-pool implementation only invited a fix in the wrong place.

The fix is that a connection is now tracked from the end of a successful init until destruction — the same lifetime as `_poolSize` — and membership decides whether a count is owed, so the pair cannot drift the way the borrow/destroy pair did. A unit test asserts the count stays at `0` when a connection fails before entering the pool.

Deriving the counts from the `_inUseConnections`/`_idleConnections` collections, which is what this PR did first, is **not** a correct substitute, and review caught it: `ReleaseAsync` removes from in-use, awaits a RESET on the wire, then adds to idle, so for the duration of a server round trip a live connection belongs to neither collection. `CanUseHomeDbCache` would then read zero SSR-disabled connections and enable the home-db cache in a mixed cluster — failing unsafe, where the counters it replaced had only ever over-reported. The acquire side has the same gap around the liveness probe. Tracking membership over the whole lifetime avoids both windows, and keeps these reads at two `int` loads rather than a locked snapshot of every hash bucket on each connection acquisition.

### (c) Rejected — defeats the purpose of the cache it is protecting

> The re-check that should ask the server again is skipped.

The behaviour is real, but forcing a fresh discovery whenever the database name came from the home-db cache makes every cached acquisition perform the exact round trip the cache exists to avoid. It fails `assert_no_new_route_request` across the board (`3 != 2` ROUTE requests) and breaks `TestHomeDbMixedCluster` home-db fallback.

With (a) rejected, the premise for (c) is also gone: the cached name is per-spec correct for the identities the cache is keyed on, so a routing table keyed by that name is the right routing table. The report offered these as independent:

> Any *one* of these breaks the chain. We recommend all three

Taking (b) alone is sufficient for the defect that actually exists.

### Tests pinning the specified behaviour

Rather than delete the tests written while exploring (a) and (c), they are inverted to lock in the contract testkit specifies, so a future change in this area fails fast at unit level:

- `HomeDbCacheKeyProviderTests` — all driver-level auth tokens share one cache entry; session-level auth and impersonation each partition; a session carrying both keys on the impersonated user
- `RoutingTableManagerTests` — a fresh routing table reached through a cached home database is reused with no discovery, and a stale one is rediscovered with the cached name withheld, which is the only thing `isCachedHomeDb` does

### Documenting the contract

The report's remaining recommendation for this branch of the decision:

> the interface should be documented to say so explicitly

`IAuthTokenManager` now carries a `<remarks>` block stating that an implementation supplies credentials for a single identity and renews them, that it must not be used to switch users, and that the driver caches per-identity state such as the resolved home database without regard to the token it returns. It points callers who need multiple identities at `WithAuthToken` or `WithImpersonatedUser`, which are keyed correctly.

A `<remarks>` on the interface is not where the mistake gets made, though, so the constraint is cross-referenced from the two places an application author actually chooses a manager: the `AuthTokenManagers` factories and the `GraphDatabase.Driver` overloads that take one.

This is the part of SEC-03 that closes the actual exposure. The behaviour is specified and tested; what was missing was any statement of it on the public interface, which is why the report could not resolve the question from the source and why an application author could reasonably have assumed rotation was supported.

## SEC-05 — Query text, parameters and results written to the debug log — **DEFERRED**

Confirmed as described. Not addressed here, and the report itself is ambivalent:

> **This is the weakest finding in the report, and it is arguably not a defect at all.** Verbose payload logging at debug level is conventional across database drivers, and credential fields specifically *are* redacted.

> If you read it as squarely within the configuration-choice exclusion, drop it and the report stands at three findings.

The substantive part is a documentation gap rather than a code defect, and the proposed `LogQueryParameters` opt-out defaulting to redacted is a behaviour change to debug output that deserves its own discussion. Being handled separately.

---

## Testing

Unit tests, per target framework (net8.0 / net9.0 / net10.0):

- 2757 passed, 0 failed, 6 skipped (pre-existing platform-specific skips)

Testkit stub tests (testkit `6.x` at `e06789d`, Python stub server):

- `tests/stub/authorization/test_auth_token_manager` — 16 passed
- `tests/stub/homedb` — 37 passed, 7 skipped (identical to the pre-change baseline)
- `tests/stub/server_side_routing` — 2 passed

Three of the test changes here fix coverage rather than behaviour, so passing proves nothing on its own. Each was checked by mutation instead — the trust-manager happy path fails if the missing-certificate guard is made to refuse unconditionally, the routing test fails if `isCachedHomeDb` is ignored, and the cache-key precedence test fails if impersonation and session-level auth are swapped.

