### PR TITLE
Don't clear testkit backend object store

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/BackendModuleTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/BackendModuleTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -142,18 +142,15 @@ public class BackendModuleTests
     }
 
     [Fact]
-    public async Task A_stored_logging_disposable_logs_exactly_once_when_the_store_is_cleared()
+    public async Task A_logging_disposable_logs_exactly_once_when_its_scope_is_disposed()
     {
         var loggerFactory = new CountingLoggerFactory();
         var container = BuildContainer(b => b.RegisterInstance<ILoggerFactory>(loggerFactory));
         var scope = container.BeginLifetimeScope();
 
         var creator = scope.Resolve<LoggingDisposableCreator>();
-        var endTestLogger = creator("Test closedown", "END TEST marker");
-        var store = scope.Resolve<IObjectStore>();
-        store.Store(endTestLogger);
+        _ = creator("Test closedown", "END TEST marker");
 
-        await store.ClearAsync();
         await scope.DisposeAsync();
 
         loggerFactory.MessageCount("END TEST marker").Should().Be(1);
@@ -234,22 +231,6 @@ public class BackendModuleTests
         using var scopeB = container.BeginLifetimeScope();
 
         scopeA.Resolve<IObjectStore>().Should().BeSameAs(scopeB.Resolve<IObjectStore>());
-    }
-
-    [Fact]
-    public async Task Handles_stored_before_a_clear_do_not_resolve_after_it()
-    {
-        var container = BuildContainer(b => b.RegisterInstance<ILoggerFactory>(new TestOutputLoggerFactory()));
-        using var scope = container.BeginLifetimeScope();
-
-        var store = scope.Resolve<IObjectStore>();
-        var id = store.Store(new Thing());
-        await store.ClearAsync();
-        var options = scope.Resolve<IJsonOptionsProvider>().GetOptions();
-
-        var act = () => JsonSerializer.Deserialize<Request>($$"""{"thing":"{{id}}"}""", options);
-
-        act.Should().Throw<TestKitProtocolException>();
     }
 
     [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/Connection/MessageLoopTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/Connection/MessageLoopTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -21,7 +21,6 @@ using Neo4j.Driver.TestKitBackend.Dispatch;
 using Neo4j.Driver.TestKitBackend.Errors;
 using Neo4j.Driver.TestKitBackend.Expectations;
 using Neo4j.Driver.TestKitBackend.Messages;
-using Neo4j.Driver.TestKitBackend.ObjectStorage;
 using Neo4j.Driver.TestKitBackend.Serialization;
 using Xunit;
 
@@ -458,59 +457,6 @@ public class MessageLoopTests
 
         unwound.Should().BeTrue();
         _autoMocker.GetMock<IResponseWriter>().Verify(w => w.WriteAsync(It.IsAny<IProtocolMessage>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task RunAsync_clears_the_object_store_when_the_connection_ends()
-    {
-        _autoMocker.GetMock<IConnectionInput>()
-            .Setup(i => i.ReadRequestAsync())
-            .ReturnsAsync((string?)null);
-
-        var loop = _autoMocker.CreateInstance<MessageLoop>();
-
-        await loop.RunAsync("testkit-1");
-
-        _autoMocker.GetMock<IObjectStore>().Verify(s => s.ClearAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task The_store_is_cleared_before_waiting_for_running_handlers()
-    {
-        const string json = """{"name":"Stuck","data":{}}""";
-        var message = Mock.Of<IProtocolMessage>();
-        var handlerFinished = new TaskCompletionSource();
-
-        _autoMocker.GetMock<IConnectionInput>()
-            .SetupSequence(i => i.ReadRequestAsync())
-            .ReturnsAsync(json)
-            .ReturnsAsync((string?)null);
-
-        _autoMocker.GetMock<IMessageSerializer>()
-            .Setup(s => s.Deserialize(json))
-            .Returns(message);
-
-        _autoMocker.GetMock<IMessageDispatcher>()
-            .Setup(d => d.DispatchAsync(message))
-            .Returns(handlerFinished.Task);
-
-        _autoMocker.GetMock<IObjectStore>()
-            .Setup(s => s.ClearAsync())
-            .Returns(() =>
-            {
-                handlerFinished.SetResult();
-                return Task.CompletedTask;
-            });
-
-        var loop = _autoMocker.CreateInstance<MessageLoop>();
-        loop.HandlerDrainTimeout = TimeSpan.FromHours(1);
-
-        await WithTimeoutAsync(loop.RunAsync("testkit-1"));
-
-        _autoMocker.GetMock<IObjectStore>().Verify(s => s.ClearAsync(), Times.Once);
-        handlerFinished.Task.IsCompleted.Should()
-            .BeTrue("the handler only finishes once the store has been cleared, so a clear placed after " +
-                "the drain would deadlock until the drain timeout");
     }
 
     [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/Connection/TestkitConnectionHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/Connection/TestkitConnectionHandlerTests.cs
@@ -58,6 +58,59 @@ public class TestkitConnectionHandlerTests
         return builder.Build();
     }
 
+    [Fact]
+    public async Task Waits_for_the_previous_connection_to_finish_before_running_the_next()
+    {
+        var firstStarted = new TaskCompletionSource();
+        var firstMayFinish = new TaskCompletionSource();
+        var secondStarted = new TaskCompletionSource();
+
+        _autoMocker.GetMock<IConnectionIdProvider>()
+            .SetupSequence(p => p.GetConnectionId())
+            .Returns("testkit-1")
+            .Returns("testkit-2");
+
+        _autoMocker.GetMock<IMessageLoop>()
+            .Setup(l => l.RunAsync("testkit-1"))
+            .Returns(async () =>
+            {
+                firstStarted.SetResult();
+                await firstMayFinish.Task;
+            });
+
+        _autoMocker.GetMock<IMessageLoop>()
+            .Setup(l => l.RunAsync("testkit-2"))
+            .Returns(() =>
+            {
+                secondStarted.SetResult();
+                return Task.CompletedTask;
+            });
+
+        _autoMocker.Use<Func<TextReader, IConnectionInput>>(_ => _autoMocker.Get<IConnectionInput>());
+        _autoMocker.Use<Func<TextWriter, IConnectionOutput>>(_ => _autoMocker.Get<IConnectionOutput>());
+        _autoMocker.Use(BuildRootScope());
+
+        var handler = _autoMocker.CreateInstance<TestkitConnectionHandler>();
+
+        var first = handler.OnConnectedAsync(NewConnection().Object);
+        await firstStarted.Task;
+
+        var second = handler.OnConnectedAsync(NewConnection().Object);
+        var settleWindow = Task.Delay(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
+        var settled = await Task.WhenAny(secondStarted.Task, settleWindow);
+
+        settled.Should()
+            .NotBeSameAs(
+                secondStarted.Task,
+                "the next connection must not start its message loop until the previous connection has torn down");
+
+        firstMayFinish.SetResult();
+        await first;
+        await second;
+
+        secondStarted.Task.IsCompleted.Should().BeTrue();
+    }
+
     private static Mock<ConnectionContext> NewConnection()
     {
         var transport = new Mock<IDuplexPipe>();

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/Connection/TestkitConnectionHandlerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/Connection/TestkitConnectionHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -56,59 +56,6 @@ public class TestkitConnectionHandlerTests
         builder.RegisterInstance(new LoggingContext()).As<ILoggingContext>();
         builder.RegisterInstance(_autoMocker.Get<IMessageLoop>()).As<IMessageLoop>();
         return builder.Build();
-    }
-
-    [Fact]
-    public async Task Waits_for_the_previous_connection_to_finish_before_running_the_next()
-    {
-        var firstStarted = new TaskCompletionSource();
-        var firstMayFinish = new TaskCompletionSource();
-        var secondStarted = new TaskCompletionSource();
-
-        _autoMocker.GetMock<IConnectionIdProvider>()
-            .SetupSequence(p => p.GetConnectionId())
-            .Returns("testkit-1")
-            .Returns("testkit-2");
-
-        _autoMocker.GetMock<IMessageLoop>()
-            .Setup(l => l.RunAsync("testkit-1"))
-            .Returns(async () =>
-            {
-                firstStarted.SetResult();
-                await firstMayFinish.Task;
-            });
-
-        _autoMocker.GetMock<IMessageLoop>()
-            .Setup(l => l.RunAsync("testkit-2"))
-            .Returns(() =>
-            {
-                secondStarted.SetResult();
-                return Task.CompletedTask;
-            });
-
-        _autoMocker.Use<Func<TextReader, IConnectionInput>>(_ => _autoMocker.Get<IConnectionInput>());
-        _autoMocker.Use<Func<TextWriter, IConnectionOutput>>(_ => _autoMocker.Get<IConnectionOutput>());
-        _autoMocker.Use(BuildRootScope());
-
-        var handler = _autoMocker.CreateInstance<TestkitConnectionHandler>();
-
-        var first = handler.OnConnectedAsync(NewConnection().Object);
-        await firstStarted.Task;
-
-        var second = handler.OnConnectedAsync(NewConnection().Object);
-        var settleWindow = Task.Delay(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
-        var settled = await Task.WhenAny(secondStarted.Task, settleWindow);
-
-        settled.Should()
-            .NotBeSameAs(
-                secondStarted.Task,
-                "the next connection must not start its message loop until the previous connection has torn down");
-
-        firstMayFinish.SetResult();
-        await first;
-        await second;
-
-        secondStarted.Task.IsCompleted.Should().BeTrue();
     }
 
     private static Mock<ConnectionContext> NewConnection()

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/ObjectStorage/ObjectStoreTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend.Tests/ObjectStorage/ObjectStoreTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -195,29 +195,17 @@ public class ObjectStoreTests
     }
 
     [Fact]
-    public async Task ClearAsync_disposes_in_reverse_storage_order_and_empties_the_store()
+    public async Task DisposeAsync_disposes_in_reverse_storage_order_and_empties_the_store()
     {
         var disposalOrder = new List<string>();
         _objectStore.Store(new SequencedDisposable("first", disposalOrder));
         var secondId = _objectStore.Store(new SequencedDisposable("second", disposalOrder));
 
-        await _objectStore.ClearAsync();
+        await _objectStore.DisposeAsync();
 
         disposalOrder.Should().Equal("second", "first");
         var get = () => _objectStore.Get<SequencedDisposable>(secondId);
         get.Should().Throw<TestKitProtocolException>();
-    }
-
-    [Fact]
-    public async Task ClearAsync_leaves_the_store_usable_for_the_next_test()
-    {
-        _objectStore.Store(new Stored());
-        await _objectStore.ClearAsync();
-
-        var stored = new Stored();
-        var id = _objectStore.Store(stored);
-
-        _objectStore.Get<Stored>(id).Should().BeSameAs(stored);
     }
 
     [Fact]

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/BackendModule.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/BackendModule.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 // 
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -20,7 +20,6 @@ using Autofac.Core.Registration;
 using Neo4j.Driver.TestKitBackend.Connection;
 using Neo4j.Driver.TestKitBackend.Dispatch;
 using Neo4j.Driver.TestKitBackend.Infrastructure;
-using Neo4j.Driver.TestKitBackend.Logging;
 using Module = Autofac.Module;
 
 namespace Neo4j.Driver.TestKitBackend;
@@ -38,12 +37,6 @@ internal class BackendModule : Module
             if (type.IsAssignableTo(typeof(IMessageHandler)))
             {
                 registration.Keyed<IMessageHandler>(MessageHandlingHelper.MessageTypeFor(type));
-            }
-
-            // the end-of-test logger is already disposed by the object store in the correct order
-            if (type == typeof(LoggingDisposable))
-            {
-                registration.ExternallyOwned();
             }
 
             _ = LifetimeOf(type) switch

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Connection/MessageLoop.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Connection/MessageLoop.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -18,7 +18,6 @@ using Neo4j.Driver.TestKitBackend.Dispatch;
 using Neo4j.Driver.TestKitBackend.Errors;
 using Neo4j.Driver.TestKitBackend.Expectations;
 using Neo4j.Driver.TestKitBackend.Messages;
-using Neo4j.Driver.TestKitBackend.ObjectStorage;
 using Neo4j.Driver.TestKitBackend.Serialization;
 
 namespace Neo4j.Driver.TestKitBackend.Connection;
@@ -32,7 +31,6 @@ internal class MessageLoop : IMessageLoop
     private readonly IDriverErrorMapper _driverErrorMapper;
     private readonly IExceptionOriginClassifier _originClassifier;
     private readonly IExpectationStore _expectationStore;
-    private readonly IObjectStore _objectStore;
     private readonly ILogger _logger;
 
     internal TimeSpan HandlerDrainTimeout { get; set; } = TimeSpan.FromSeconds(10);
@@ -45,7 +43,6 @@ internal class MessageLoop : IMessageLoop
         IDriverErrorMapper driverErrorMapper,
         IExceptionOriginClassifier originClassifier,
         IExpectationStore expectationStore,
-        IObjectStore objectStore,
         ILogger logger)
     {
         _input = input;
@@ -55,7 +52,6 @@ internal class MessageLoop : IMessageLoop
         _driverErrorMapper = driverErrorMapper;
         _originClassifier = originClassifier;
         _expectationStore = expectationStore;
-        _objectStore = objectStore;
         _logger = logger;
     }
 
@@ -100,7 +96,6 @@ internal class MessageLoop : IMessageLoop
         finally
         {
             _expectationStore.CancelAll();
-            await _objectStore.ClearAsync();
             try
             {
                 await Task.WhenAll(handlerTasks).WaitAsync(HandlerDrainTimeout);

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Connection/TestkitConnectionHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Connection/TestkitConnectionHandler.cs
@@ -29,6 +29,7 @@ internal class TestkitConnectionHandler : ConnectionHandler
     private readonly IConnectionIdProvider _connectionIdProvider;
     private readonly ILoggingContextAccessor _loggingContextAccessor;
     private readonly ILogger _logger;
+    private readonly SemaphoreSlim _connectionTurn = new(1, 1);
 
     public TestkitConnectionHandler(
         ILifetimeScope rootScope,
@@ -47,6 +48,19 @@ internal class TestkitConnectionHandler : ConnectionHandler
     }
 
     public override async Task OnConnectedAsync(ConnectionContext connection)
+    {
+        await _connectionTurn.WaitAsync();
+        try
+        {
+            await RunConnectionAsync(connection);
+        }
+        finally
+        {
+            _connectionTurn.Release();
+        }
+    }
+
+    private async Task RunConnectionAsync(ConnectionContext connection)
     {
         var connectionId = _connectionIdProvider.GetConnectionId();
         connection.ConnectionId = connectionId;

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Connection/TestkitConnectionHandler.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Connection/TestkitConnectionHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -29,7 +29,6 @@ internal class TestkitConnectionHandler : ConnectionHandler
     private readonly IConnectionIdProvider _connectionIdProvider;
     private readonly ILoggingContextAccessor _loggingContextAccessor;
     private readonly ILogger _logger;
-    private readonly SemaphoreSlim _connectionTurn = new(1, 1);
 
     public TestkitConnectionHandler(
         ILifetimeScope rootScope,
@@ -48,19 +47,6 @@ internal class TestkitConnectionHandler : ConnectionHandler
     }
 
     public override async Task OnConnectedAsync(ConnectionContext connection)
-    {
-        await _connectionTurn.WaitAsync();
-        try
-        {
-            await RunConnectionAsync(connection);
-        }
-        finally
-        {
-            _connectionTurn.Release();
-        }
-    }
-
-    private async Task RunConnectionAsync(ConnectionContext connection)
     {
         var connectionId = _connectionIdProvider.GetConnectionId();
         connection.ConnectionId = connectionId;

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Messages/StartTest.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/Messages/StartTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -18,7 +18,6 @@ using Microsoft.Extensions.Logging;
 using Neo4j.Driver.TestKitBackend.Connection;
 using Neo4j.Driver.TestKitBackend.Logging;
 using Neo4j.Driver.TestKitBackend.Dispatch;
-using Neo4j.Driver.TestKitBackend.ObjectStorage;
 
 namespace Neo4j.Driver.TestKitBackend.Messages;
 
@@ -40,24 +39,21 @@ internal class StartTestHandler : MessageHandler<StartTestRequest>
 {
     private readonly ILoggingContext _loggingContext;
     private readonly ISkipPolicy _skipPolicy;
-    private readonly LoggingDisposableCreator _createLoggingDisposable;
+    private readonly LoggingDisposableCreator _logAtEndOfTest;
     private readonly IResponseWriter _responseWriter;
-    private readonly IObjectStore _objectStore;
     private readonly ILogger _logger;
 
     public StartTestHandler(
         ILoggingContext loggingContext,
         ISkipPolicy skipPolicy,
-        LoggingDisposableCreator createLoggingDisposable,
+        LoggingDisposableCreator logAtEndOfTest,
         IResponseWriter responseWriter,
-        IObjectStore objectStore,
         ILogger logger)
     {
         _loggingContext = loggingContext;
         _skipPolicy = skipPolicy;
-        _createLoggingDisposable = createLoggingDisposable;
+        _logAtEndOfTest = logAtEndOfTest;
         _responseWriter = responseWriter;
-        _objectStore = objectStore;
         _logger = logger;
     }
 
@@ -77,9 +73,7 @@ internal class StartTestHandler : MessageHandler<StartTestRequest>
 
             _logger.LogDebug("START TEST {TestName}", message.TestName);
 
-            var endTestMsg = $"END TEST {message.TestName}";
-            var endTestLogger = _createLoggingDisposable("Test closedown", endTestMsg);
-            _objectStore.Store(endTestLogger);
+            _ = _logAtEndOfTest("Test closedown", $"END TEST {message.TestName}");
         }
     }
 }

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/ObjectStorage/IObjectStore.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/ObjectStorage/IObjectStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -25,5 +25,4 @@ internal interface IObjectStore
 
     void Remove(string id);
 
-    Task ClearAsync();
 }

--- a/Neo4j.Driver/Neo4j.Driver.TestKitBackend/ObjectStorage/ObjectStore.cs
+++ b/Neo4j.Driver/Neo4j.Driver.TestKitBackend/ObjectStorage/ObjectStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) "Neo4j"
+﻿// Copyright (c) "Neo4j"
 // Neo4j Sweden AB [https://neo4j.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
@@ -75,11 +75,6 @@ internal class ObjectStore : IObjectStore, IAsyncDisposable
     }
 
     public async ValueTask DisposeAsync()
-    {
-        await ClearAsync();
-    }
-
-    public async Task ClearAsync()
     {
         List<object> toDispose;
         lock (_lock)


### PR DESCRIPTION
Follow-up to #957. `ObjectStore` is a process singleton but was cleared per connection, and testkit doesn't wait for the backend's teardown — so a closing connection could delete the next test's objects (in CI, driver `18428` vanished between its own `NewDriver` response and the following `NewSession`). Fixed by never clearing the store, which makes the first commit's semaphore unnecessary — the second commit reverts it.
