### PR TITLE
Remove dependency of stress tests on integration tests

### DIFF
--- a/testkit/stress.py
+++ b/testkit/stress.py
@@ -18,7 +18,9 @@ if __name__ == "__main__":
         "dotnet",
         "test",
         "--no-restore",
-        "--no-build"
+        "--no-build",
+        "--configuration",
+        "CI"
     ]
 
     if os.environ.get("TEST_NEO4J_IS_CLUSTER"):


### PR DESCRIPTION
`stress.py` passes `--no-build` but never says which configuration, so `dotnet test` goes looking for Debug output — while `build.py` builds the solution as CI. The Debug assembly only exists because `integration.py` runs `dotnet test` *without* `--no-build` and rebuilds the integration project as a side effect.

So the stress tests have an undeclared dependency on the integration tests having already run in the same workspace. That held fine while testkit ran every category in one container, and broke as soon as the .NET pipeline started running categories as separate parallel builds — all three stress configurations failed with:

```
The argument .../bin/Debug/net10.0/Neo4j.Driver.Tests.Integration.dll is invalid.
```

Naming the configuration makes the script self-sufficient, and means the stress tests exercise the same build as everything else rather than a Debug build produced incidentally by another category.

Checked before changing it that `Neo4j.Driver.Tests.Integration` is in the solution, targets `net10.0`, and declares `<Configurations>Debug;Release;CI</Configurations>`, so `build.py`'s CI build does produce what `--no-build` now looks for.

Worth knowing but deliberately out of scope here: `unittests.py` and `integration.py` also omit `--configuration`, so every driver-owned test suite has been running against Debug rather than CI. There is a separate ticket for that, along with the fact that `integration.py` cannot fail the build at all.
