### PR TITLE
Run the unit and integration tests against the CI build

### DIFF
--- a/testkit/integration.py
+++ b/testkit/integration.py
@@ -28,13 +28,13 @@ if __name__ == "__main__":
     os.environ.update({"TEAMCITY_PROJECT_NAME": "integrationtests"})
 
     failFlag = False
-    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--filter", "DisplayName~IntegrationTests.Internals"])
-    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--filter", "DisplayName~IntegrationTests.Direct"])
-    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--filter", "DisplayName~IntegrationTests.Reactive&DisplayName!~IntegrationTests.Reactive.NestedQueriesIT"])
+    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--configuration", "CI", "--filter", "DisplayName~IntegrationTests.Internals"])
+    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--configuration", "CI", "--filter", "DisplayName~IntegrationTests.Direct"])
+    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--configuration", "CI", "--filter", "DisplayName~IntegrationTests.Reactive&DisplayName!~IntegrationTests.Reactive.NestedQueriesIT"])
     # TODO: Re-enable for cluster tests if not replaced by testkit native ones.
-    # run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--filter", "DisplayName~IntegrationTests.Routing"])
-    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--filter", "DisplayName~IntegrationTests.Types"])
-    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--filter", "DisplayName~Examples"])
+    # run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--configuration", "CI", "--filter", "DisplayName~IntegrationTests.Routing"])
+    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--configuration", "CI", "--filter", "DisplayName~IntegrationTests.Types"])
+    run(["dotnet", "test", "Neo4j.Driver.Tests.Integration.csproj", "--configuration", "CI", "--filter", "DisplayName~Examples"])
 
     os.chdir(wd)
 

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -19,6 +19,6 @@ if __name__ == "__main__":
     # This generates a bit ugly output when not in TeamCity, it can be fixed by checking the TEST_IN_TEAMCITY
     # environment flag...(but needs to be passed to the container somehow)
     os.environ.update({"TEAMCITY_PROJECT_NAME":"unittests"})
-    run(["dotnet", "test", "Neo4j.Driver.Tests.csproj"])
+    run(["dotnet", "test", "Neo4j.Driver.Tests.csproj", "--configuration", "CI"])
     os.chdir(wd)
 


### PR DESCRIPTION
`build.py` builds the solution as CI, but neither `unittests.py` nor `integration.py` named a configuration, so `dotnet test` defaulted to Debug and rebuilt the test projects to get it. Every driver-owned suite has therefore been exercising a Debug build while the CI build it was handed went unused.

Confirmed from a CI log rather than inferred — the integration build's log contains 336 `bin/Debug/net10.0` paths and no `bin/CI` or `bin/Release` at all.

The convention for this driver is to build and test as CI, since Release needs a signing key that isn't in the repository, so Debug was never the intent.

Naming the configuration also removes a redundant compile. `dotnet test` still does its up-to-date check, but `build.py` has already produced the CI output, so there's nothing left to build. `integration.py` invokes `dotnet test` five times, so it was paying for that five times over — which is time currently sitting inside what CI reports as test time.

Both test projects declare `<Configurations>Debug;Release;CI</Configurations>` and both are in the solution, so `build.py`'s CI build does produce what these now ask for.

The commented-out Routing invocation is updated too, so re-enabling it later doesn't quietly reintroduce the Debug build.

Deliberately **not** addressed here: `integration.py` still can't fail the build. Its `except` handler assigns to a misspelled local (`failedFlag` rather than `failFlag`) and the guard calls `os.exit`, which doesn't exist. That's tracked separately.
